### PR TITLE
chore(github): add roadmap-task issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/roadmap_task.yml
+++ b/.github/ISSUE_TEMPLATE/roadmap_task.yml
@@ -1,0 +1,85 @@
+name: 🗺️ Roadmap task
+description: Atomic task tracked under the v0.1 MVP roadmap.
+title: "[<phase>/<area>] <task-id>: <short title>"
+labels:
+  - roadmap
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to file an atomic task that belongs to the
+        published roadmap (see the `roadmap` meta tracking issue).
+
+        For one-off bug reports or feature requests, use the **Bug
+        report** or **Feature request** templates instead.
+
+  - type: input
+    id: task_id
+    attributes:
+      label: Task ID
+      description: Stable kebab-case identifier used in the roadmap and SQL plan.
+      placeholder: e.g. pty-spawn-child
+    validations:
+      required: true
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: One or two sentences describing what done looks like.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context / Background
+      description: Links to spec, related files, or prior decisions.
+      placeholder: |
+        - `src/cli/arming.rs:5`
+        - README "Triggers (locked policy)" section
+    validations:
+      required: false
+
+  - type: textarea
+    id: dod
+    attributes:
+      label: Definition of Done
+      description: Concrete checklist that an agent can use to self-verify.
+      value: |
+        - [ ] Implementation complete
+        - [ ] Unit / integration / E2E tests added or updated
+        - [ ] `cargo fmt --check` passes
+        - [ ] `cargo clippy --all-targets -- -D warnings` passes
+        - [ ] `cargo test --all-targets --all-features` passes
+        - [ ] Rubber-duck self-review pass complete (for non-trivial changes)
+    validations:
+      required: true
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: |
+        List blocking and dependent tasks. GitHub will autolink `#N`
+        references; once all blockers are closed this issue becomes
+        ready for an agent to claim.
+      value: |
+        Blocked by:
+        - (none)
+
+        Blocks:
+        - (none)
+    validations:
+      required: false
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes for AI agents
+      description: |
+        Spec lock pointers, decisions to honor, gotchas, etc. Useful
+        when multiple agents (Copilot CLI, Claude Code, Codex,
+        Gemini) may pick this up.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/roadmap_task.yml
+++ b/.github/ISSUE_TEMPLATE/roadmap_task.yml
@@ -9,9 +9,17 @@ body:
     attributes:
       value: |
         Use this template to file an atomic task that belongs to the
-        v0.1 MVP roadmap (meta tracking issue: #11). The form mirrors
-        the canonical shape used by the bootstrapped task issues
-        (#12 – #80) so triage and AI-agent automation stay uniform.
+        v0.1 MVP roadmap (meta tracking issue: #11). The form
+        captures the **same canonical fields** as the bootstrapped
+        task issues (#12 – #80) — Task ID, Phase, Area, Kind, Goal,
+        Definition of Done, Dependencies, and Claim protocol — so
+        triage and AI-agent automation stay uniform.
+
+        > **Note on rendered shape:** GitHub issue forms render each
+        > field as its own `### Label` section, so the submitted body
+        > will look slightly different from the inline metadata
+        > header used by the bootstrapped issues. The information
+        > content is identical; only the visual layout differs.
 
         > **Before submitting:** replace the prefilled issue title
         > scaffold (`[<phase>/<area>] <task-id>: <short title>`) with

--- a/.github/ISSUE_TEMPLATE/roadmap_task.yml
+++ b/.github/ISSUE_TEMPLATE/roadmap_task.yml
@@ -132,11 +132,9 @@ body:
         references; once all blockers are closed this issue becomes
         ready for an agent to claim.
       value: |
-        Blocked by:
-        - (none)
+        **Blocked by:** _(none)_
 
-        Blocks:
-        - (none)
+        **Blocks:** _(none)_
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/roadmap_task.yml
+++ b/.github/ISSUE_TEMPLATE/roadmap_task.yml
@@ -173,7 +173,9 @@ body:
 
         1. Self-assign and add the `status/in-progress` label (remove
            `status/ready` or `status/blocked`).
-        2. Open a PR referencing this issue (`Closes #N`).
+        2. Open a PR referencing this issue using its actual
+           number, for example `Closes #123` (replace `#123` with
+           the number GitHub assigned to this issue).
         3. The PR moves the issue to `status/in-review`.
         4. Always rebase onto `main`; never merge into the feature branch.
     validations:

--- a/.github/ISSUE_TEMPLATE/roadmap_task.yml
+++ b/.github/ISSUE_TEMPLATE/roadmap_task.yml
@@ -3,12 +3,21 @@ description: Atomic task tracked under the v0.1 MVP roadmap.
 title: "[<phase>/<area>] <task-id>: <short title>"
 labels:
   - roadmap
+  - agent-claimable
 body:
   - type: markdown
     attributes:
       value: |
         Use this template to file an atomic task that belongs to the
-        published roadmap (see the `roadmap` meta tracking issue).
+        v0.1 MVP roadmap (meta tracking issue: #11). The form mirrors
+        the canonical shape used by the bootstrapped task issues
+        (#12 – #80) so triage and AI-agent automation stay uniform.
+
+        > **Before submitting:** replace the prefilled issue title
+        > scaffold (`[<phase>/<area>] <task-id>: <short title>`) with
+        > real values matching the Phase / Area / Task ID you select
+        > below. A title left as the literal scaffold will be
+        > rejected during triage.
 
         For one-off bug reports or feature requests, use the **Bug
         report** or **Feature request** templates instead.
@@ -17,8 +26,66 @@ body:
     id: task_id
     attributes:
       label: Task ID
-      description: Stable kebab-case identifier used in the roadmap and SQL plan.
+      description: Stable kebab-case identifier used in the roadmap and dependency references.
       placeholder: e.g. pty-spawn-child
+    validations:
+      required: true
+
+  - type: dropdown
+    id: phase
+    attributes:
+      label: Phase
+      description: Which roadmap phase does this task belong to?
+      options:
+        - "0 — deps & version policy"
+        - "1 — arming policy"
+        - "2 — PTY pass-through"
+        - "3 — input/output pump"
+        - "4 — animation renderer"
+        - "5 — trigger × anim wiring (MVP playable)"
+        - "6 — signals & shutdown"
+        - "7 — Windows minimal"
+        - "8 — test hardening"
+        - "9 — docs & release"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - pty
+        - anim
+        - cli
+        - trigger
+        - signals
+        - term
+        - test
+        - release
+        - docs
+        - deps
+    validations:
+      required: true
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Kind
+      options:
+        - impl
+        - test
+        - dep
+        - release-gate
+    validations:
+      required: true
+
+  - type: input
+    id: tracked_in
+    attributes:
+      label: Tracked in
+      description: Parent meta tracking issue (defaults to the v0.1 roadmap).
+      value: "#11"
     validations:
       required: true
 
@@ -81,5 +148,27 @@ body:
         Spec lock pointers, decisions to honor, gotchas, etc. Useful
         when multiple agents (Copilot CLI, Claude Code, Codex,
         Gemini) may pick this up.
+      value: |
+        - Project uses GitHub Flow + Conventional Commits + signed commits.
+        - Allowlist for arming is fixed (not configurable): copilot, codex,
+          claude, aichat, gemini, qwen, ollama.
+        - tracing env: `QORRECTION_LOG` (NOT `RUST_LOG`).
+        - See the meta tracking issue (#11) for full spec lock and approach.
+    validations:
+      required: false
+
+  - type: textarea
+    id: claim_protocol
+    attributes:
+      label: Claim protocol
+      description: Pre-filled — agents should follow these steps when claiming this issue.
+      value: |
+        When you start work on this issue:
+
+        1. Self-assign and add the `status/in-progress` label (remove
+           `status/ready` or `status/blocked`).
+        2. Open a PR referencing this issue (`Closes #N`).
+        3. The PR moves the issue to `status/in-review`.
+        4. Always rebase onto `main`; never merge into the feature branch.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/roadmap_task.yml
+++ b/.github/ISSUE_TEMPLATE/roadmap_task.yml
@@ -144,7 +144,7 @@ body:
 
         **Blocks:** _(none)_
     validations:
-      required: false
+      required: true
 
   - type: textarea
     id: notes
@@ -179,4 +179,4 @@ body:
         3. The PR moves the issue to `status/in-review`.
         4. Always rebase onto `main`; never merge into the feature branch.
     validations:
-      required: false
+      required: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,8 +15,8 @@ jobs:
           days-before-stale: 60
           close-issue-message: StaleBot closed the issue due to prolonged inactivity.
           close-pr-message: StaleBot closed the pull request due to prolonged inactivity.
-          exempt-issue-labels: bug,enhancement
-          exempt-pr-labels: bug,enhancement
+          exempt-issue-labels: bug,enhancement,roadmap,agent-claimable
+          exempt-pr-labels: bug,enhancement,roadmap,agent-claimable
           stale-issue-label: stale
           stale-issue-message: StaleBot marked the issue as stale because there has been no activity.
           stale-pr-label: stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,7 @@ jobs:
           close-issue-message: StaleBot closed the issue due to prolonged inactivity.
           close-pr-message: StaleBot closed the pull request due to prolonged inactivity.
           exempt-issue-labels: bug,enhancement,roadmap,agent-claimable
-          exempt-pr-labels: bug,enhancement,roadmap,agent-claimable
+          exempt-pr-labels: bug,enhancement,roadmap
           stale-issue-label: stale
           stale-issue-message: StaleBot marked the issue as stale because there has been no activity.
           stale-pr-label: stale


### PR DESCRIPTION
Adds a dedicated issue template for the v0.1 MVP roadmap.

The MVP rollout is being broken down into ~70 atomic tasks that will be
tracked as GitHub issues so multiple AI agents (Copilot CLI, Claude
Code, Codex, Gemini) can claim work in parallel. Each task issue
carries:

- Stable kebab-case Task ID matching the SQL plan
- Goal / Context / Definition of Done / Dependencies / Notes for AI agents

The full roadmap and dependency graph live in
`session-state/.../plan.md` (not committed) and the SQL session
database; this template is the on-repo persistence vector.

Refs: roadmap meta tracking issue (created in a follow-up)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a standardized GitHub issue template for roadmap tasks to improve project tracking and organization. The template includes structured fields for task IDs, goals, context, dependencies, and a definition of done checklist to ensure consistent roadmap management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->