### PR TITLE
chore(release): bump version to 0.1.0-alpha.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "qorrection"
-version = "0.0.0"
+version = "0.1.0-alpha.0"
 dependencies = [
  "assert_cmd",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qorrection"
-version = "0.0.0"
+version = "0.1.0-alpha.0"
 edition = "2021"
 rust-version = "1.78"
 authors = ["Kuroné Kito (黒音キト) <krone@kit.black>"]

--- a/tests/snapshots/usage_layout__usage_boundary_119.snap
+++ b/tests/snapshots/usage_layout__usage_boundary_119.snap
@@ -2,7 +2,7 @@
 source: tests/usage_layout.rs
 expression: render(119)
 ---
-    _______                     qorrection 0.0.0
+    _______                     qorrection 0.1.0-alpha.0
    /  +  +  \____               qorrection: PTY wrapper that intercepts Vim-style quit commands
   /   QUEUE      \              and dispatches FI-FO-FI-FO ambulance gags.
  /________________|

--- a/tests/snapshots/usage_layout__usage_boundary_120.snap
+++ b/tests/snapshots/usage_layout__usage_boundary_120.snap
@@ -2,7 +2,7 @@
 source: tests/usage_layout.rs
 expression: render(120)
 ---
-       __________________                       qorrection 0.0.0
+       __________________                       qorrection 0.1.0-alpha.0
       /   +    +    +    \____                  qorrection: PTY wrapper that intercepts Vim-style quit commands
      /     WRITE QUEUE         \                and dispatches FI-FO-FI-FO ambulance gags.
     /    418 I'm an AI agent    \

--- a/tests/snapshots/usage_layout__usage_boundary_39.snap
+++ b/tests/snapshots/usage_layout__usage_boundary_39.snap
@@ -2,7 +2,7 @@
 source: tests/usage_layout.rs
 expression: render(39)
 ---
-qorrection 0.0.0
+qorrection 0.1.0-alpha.0
 qorrection: PTY wrapper that intercepts Vim-style quit commands
 and dispatches FI-FO-FI-FO ambulance gags.
 

--- a/tests/snapshots/usage_layout__usage_boundary_79.snap
+++ b/tests/snapshots/usage_layout__usage_boundary_79.snap
@@ -3,7 +3,7 @@ source: tests/usage_layout.rs
 expression: render(79)
 ---
 [QQ] qorrection -- :q :wq :q!
-qorrection 0.0.0
+qorrection 0.1.0-alpha.0
 qorrection: PTY wrapper that intercepts Vim-style quit commands
 and dispatches FI-FO-FI-FO ambulance gags.
 

--- a/tests/snapshots/usage_layout__usage_large_140.snap
+++ b/tests/snapshots/usage_layout__usage_large_140.snap
@@ -2,7 +2,7 @@
 source: tests/usage_layout.rs
 expression: render(140)
 ---
-       __________________                       qorrection 0.0.0
+       __________________                       qorrection 0.1.0-alpha.0
       /   +    +    +    \____                  qorrection: PTY wrapper that intercepts Vim-style quit commands
      /     WRITE QUEUE         \                and dispatches FI-FO-FI-FO ambulance gags.
     /    418 I'm an AI agent    \

--- a/tests/snapshots/usage_layout__usage_medium_100.snap
+++ b/tests/snapshots/usage_layout__usage_medium_100.snap
@@ -2,7 +2,7 @@
 source: tests/usage_layout.rs
 expression: render(100)
 ---
-    _______                     qorrection 0.0.0
+    _______                     qorrection 0.1.0-alpha.0
    /  +  +  \____               qorrection: PTY wrapper that intercepts Vim-style quit commands
   /   QUEUE      \              and dispatches FI-FO-FI-FO ambulance gags.
  /________________|

--- a/tests/snapshots/usage_layout__usage_small_60.snap
+++ b/tests/snapshots/usage_layout__usage_small_60.snap
@@ -3,7 +3,7 @@ source: tests/usage_layout.rs
 expression: render(60)
 ---
 [QQ] qorrection -- :q :wq :q!
-qorrection 0.0.0
+qorrection 0.1.0-alpha.0
 qorrection: PTY wrapper that intercepts Vim-style quit commands
 and dispatches FI-FO-FI-FO ambulance gags.
 

--- a/tests/snapshots/usage_layout__usage_tiny_30.snap
+++ b/tests/snapshots/usage_layout__usage_tiny_30.snap
@@ -2,7 +2,7 @@
 source: tests/usage_layout.rs
 expression: render(30)
 ---
-qorrection 0.0.0
+qorrection 0.1.0-alpha.0
 qorrection: PTY wrapper that intercepts Vim-style quit commands
 and dispatches FI-FO-FI-FO ambulance gags.
 


### PR DESCRIPTION
## Summary

PR B of the v0.1 MVP roadmap Phase 0. Single-purpose commit
that moves `Cargo.toml` `version` off the `0.0.0` placeholder
to `0.1.0-alpha.0`, the first version the roadmap allows for
real pre-release artifact production.

## Closed issues

Closes #15 — bump version to `0.1.0-alpha.0`

## What changes

- `Cargo.toml`: `version = "0.0.0"` → `"0.1.0-alpha.0"`.
- `Cargo.lock`: package entry for `qorrection` updated by `cargo check`.
- `tests/snapshots/usage_layout__*.snap` (×8): pure text replacement of `qorrection 0.0.0` → `qorrection 0.1.0-alpha.0`. The renderer pulls the version via `env!("CARGO_PKG_VERSION")`, so the bump propagates into all width-bucket snapshots.

No layout regression: all five width buckets (tiny 30, small 60, medium 100, large 140) plus the four boundary widths (39 / 79 / 119 / 120) still pass.

## Release-workflow interaction

`.github/workflows/release.yml` has a `verify-tag` job with an explicit guard that fails when `cargo_version == "0.0.0"`. That guard is gated on `if: startsWith(github.ref, 'refs/tags/v')`, so:

- **Tag-driven release** (`v0.1.0-alpha.0` push): `verify-tag` now permits the publish flow.
- **`workflow_dispatch`** (manual): `verify-tag` is skipped entirely, so the build matrix continues to be exercisable without a tag.

The placeholder sentinel (`0.0.0`) in `release.yml` is intentionally retained as a future safety net.

## Validation

```
cargo fmt --check                                                    ok
cargo clippy --all-targets --all-features -- -D warnings             ok
cargo test --all-targets --all-features                              ok
cargo +1.78 check --locked --all-targets --all-features              ok (MSRV gate)
```

## Self-review (rubber-duck)

1 RD pass, **CLEAN** — no P0/P1/P2 findings. Specifically checked: residual `0.0.0` pins (only the intentional `release.yml` sentinel remains), usage-layout width-threshold sensitivity to the longer version string (no breakpoint adjustment needed), and scope creep (none).

## Recommended next

- **PR C** — closes #16 (add `Pty` / `Spawn` / `Signal` variants to crate `Error`). Depends on `anyhow`, which is in **PR #81** (PR A). Will be opened against `main` once PR #81 merges, or as a stacked PR if reviewers prefer.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
