### PR TITLE
feat(cli): add is_armed allowlist matcher

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -27,6 +27,12 @@ ignorePaths:
   - target/**
 ignoreRegExpList:
   - kuroné?
+  # Ignore the entire Unicode fullwidth/halfwidth forms block.
+  # Used by arming policy negative-test fixtures (e.g. ｃｌａｕｄｅ)
+  # which intentionally must not arm. The next directive
+  # silences cspell on the regex literal itself, which would
+  # otherwise flag the embedded "uffef" token. cspell directives
+  # are honoured when cspell lints this YAML file as content.
   # cspell:disable-next-line
   - '[\uff00-\uffef]+'
 language: en,ja

--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -27,7 +27,7 @@ ignorePaths:
   - target/**
 ignoreRegExpList:
   - kuroné?
-  # Fullwidth Unicode lookalike used in arming negative tests
+  # cspell:disable-next-line
   - '[\uff00-\uffef]+'
 language: en,ja
 useGitignore: true

--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -27,11 +27,16 @@ ignorePaths:
   - target/**
 ignoreRegExpList:
   - kuroné?
+  # Fullwidth Unicode lookalike used in arming negative tests
+  - '[\uff00-\uffef]+'
 language: en,ja
 useGitignore: true
 version: '0.2'
 words:
   - aichat
+  - clau
+  - claudex
+  - clauder
   - decckm
   - embark
   - greppable
@@ -47,3 +52,4 @@ words:
   - rexpect
   - swatinem
   - toctou
+  - xclaude

--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -29,10 +29,11 @@ ignoreRegExpList:
   - kuroné?
   # Ignore the entire Unicode fullwidth/halfwidth forms block.
   # Used by arming policy negative-test fixtures (e.g. ｃｌａｕｄｅ)
-  # which intentionally must not arm. The next directive
+  # which intentionally must not arm. The directive below
   # silences cspell on the regex literal itself, which would
-  # otherwise flag the embedded "uffef" token. cspell directives
-  # are honoured when cspell lints this YAML file as content.
+  # otherwise flag the embedded hex token inside the range.
+  # cspell directives are honoured when cspell lints this YAML
+  # file as content.
   # cspell:disable-next-line
   - '[\uff00-\uffef]+'
 language: en,ja

--- a/src/cli/arming.rs
+++ b/src/cli/arming.rs
@@ -154,7 +154,10 @@ mod tests {
         ("claude.exe.cmd", false), // strips .cmd, leaves "claude.exe" which is not allowlisted
         // dot-leading: stem becomes ".claude", not "claude"
         (".claude.exe", false),
-        // empty stem after strip
+        // suffix-only inputs: strip_known_suffix refuses to
+        // strip when the stem would be empty (it requires
+        // bytes.len() > suffix.len()), so the input is kept
+        // verbatim and simply fails the allowlist match.
         (".exe", false),
         (".cmd", false),
         (".bat", false),

--- a/src/cli/arming.rs
+++ b/src/cli/arming.rs
@@ -218,6 +218,24 @@ mod tests {
         }
     }
 
+    #[test]
+    fn every_allowlisted_command_accepts_strippable_suffixes() {
+        // Generic guard: each allowlist entry must arm with every
+        // strippable suffix in any ASCII case. Catches regressions
+        // where a refactor accidentally special-cases one entry.
+        for entry in [
+            "copilot", "codex", "claude", "aichat", "gemini", "qwen", "ollama",
+        ] {
+            for suffix in [".exe", ".cmd", ".bat", ".EXE", ".Cmd", ".BAT"] {
+                let command = format!("{entry}{suffix}");
+                assert!(
+                    is_armed(OsStr::new(&command)),
+                    "{command:?} should arm via suffix strip"
+                );
+            }
+        }
+    }
+
     #[cfg(unix)]
     mod unix {
         use super::is_armed;
@@ -258,6 +276,18 @@ mod tests {
             // strip + ASCII fold should still arm.
             let raw: &[u8] = b"\xff\xfe/claude.EXE";
             assert!(is_armed(OsStr::from_bytes(raw)));
+        }
+
+        #[test]
+        fn windows_backslash_path_does_not_arm_on_unix() {
+            // On Unix, backslash is an ordinary byte, not a path
+            // separator. Documented in the module: native semantics
+            // mean these strings have no separator at all so the
+            // entire string is the basename, which is not in the
+            // allowlist.
+            assert!(!is_armed(OsStr::new(r"C:\tools\claude.exe")));
+            assert!(!is_armed(OsStr::new(r"bin\claude.exe")));
+            assert!(!is_armed(OsStr::new(r"\claude")));
         }
     }
 
@@ -304,6 +334,22 @@ mod tests {
                 'c' as u16, 'l' as u16, 'a' as u16, 0, 'u' as u16, 'd' as u16, 'e' as u16,
             ];
             assert!(!is_armed(&OsString::from_wide(&raw)));
+        }
+
+        #[test]
+        fn dot_final_component_uses_previous_component_on_windows() {
+            // `Path::file_name` documented behavior also holds on
+            // Windows with backslash separators: a final `.`
+            // component is normalised away so the previous
+            // component is the basename.
+            assert!(is_armed(&wide(r"C:\tools\claude\.")));
+        }
+
+        #[test]
+        fn dot_dot_final_component_does_not_arm_on_windows() {
+            // A final `..` makes the basename `None`, so the
+            // input cannot arm.
+            assert!(!is_armed(&wide(r"C:\tools\claude\..")));
         }
     }
 }

--- a/src/cli/arming.rs
+++ b/src/cli/arming.rs
@@ -17,8 +17,12 @@
 //!   with a single `.exe` / `.cmd` / `.bat` suffix stripped if
 //!   present (case-insensitive on the suffix), then compared
 //!   ASCII case-insensitively against the allowlist.
-//! - Comparison is **byte-wise**: full-width Unicode lookalikes
-//!   (`ｃｌａｕｄｅ`) and Cyrillic homoglyphs do **not** arm.
+//!   - Comparison is **byte-wise**: full-width Unicode lookalikes
+//!     (`ｃｌａｕｄｅ`) and Cyrillic homoglyphs do **not** arm.
+//!     There is **no** Unicode normalisation, no locale-aware
+//!     case folding, and no whitespace trimming -- the input is
+//!     compared exactly as the user typed it (after basename and
+//!     extension handling described above).
 //!
 //! [meta issue #11]: https://github.com/kurone-kito/qorrection/issues/11
 //!

--- a/src/cli/arming.rs
+++ b/src/cli/arming.rs
@@ -1,10 +1,270 @@
 //! Trigger arming policy (allowlist of wrapped commands).
 //!
-//! Placeholder module -- real implementation lands in Phase B/E
-//! per the implementation plan. The locked spec requires
-//! triggers to fire only when the basename of the wrapped command
-//! (case-insensitive, with `.exe`/`.cmd`/`.bat` stripped) matches
-//! one of:
+//! Phase 1 deliverable: a single pure function, [`is_armed`],
+//! that decides whether the wrapped child command is one of the
+//! AI CLIs whose `:q`-style typings should be intercepted by the
+//! Phase 2+ pump. Everything else (the actual interception, the
+//! animation, the pump wiring) is out of scope for this module.
 //!
-//! - `copilot`, `codex`, `claude`, `aichat`, `gemini`, `qwen`,
+//! ## Spec lock
+//!
+//! From the locked v0.1 spec ([meta issue #11]):
+//!
+//! - The allowlist is **fixed** (not configurable):
+//!   `copilot`, `codex`, `claude`, `aichat`, `gemini`, `qwen`,
 //!   `ollama`.
+//! - Matching uses the **basename** of the wrapped command,
+//!   with a single `.exe` / `.cmd` / `.bat` suffix stripped if
+//!   present (case-insensitive on the suffix), then compared
+//!   ASCII case-insensitively against the allowlist.
+//! - Comparison is **byte-wise**: full-width Unicode lookalikes
+//!   (`ｃｌａｕｄｅ`) and Cyrillic homoglyphs do **not** arm.
+//!
+//! [meta issue #11]: https://github.com/kurone-kito/qorrection/issues/11
+//!
+//! ## Path semantics
+//!
+//! Basename extraction is delegated to [`std::path::Path::file_name`].
+//! That means platform-native separators apply: `/` on every
+//! target, plus `\` (and Windows-style drive prefixes like
+//! `C:`) on `cfg(windows)`. As a consequence,
+//! `C:\\tools\\claude.exe` arms on Windows and does **not** arm
+//! on Unix (where the whole string is one filename). This
+//! matches how the OS will actually resolve the command and
+//! avoids surprising false positives on Unix filenames that
+//! legitimately contain a backslash.
+//!
+//! ## NUL guard
+//!
+//! Synthetic [`std::ffi::OsStr`] inputs that contain a NUL byte
+//! cannot be passed to real `exec`/`CreateProcess` calls but
+//! could otherwise sneak past basename extraction. We reject
+//! them up front so the function's behaviour matches the
+//! "command we would actually try to spawn" intuition.
+
+use std::ffi::OsStr;
+use std::path::Path;
+
+/// Suffixes stripped (case-insensitively, one shot) before
+/// comparing against [`ALLOWLIST`].
+const STRIPPABLE_SUFFIXES: &[&[u8]] = &[b".exe", b".cmd", b".bat"];
+
+/// Fixed allowlist of AI CLIs whose Vim-style quit literals are
+/// intercepted by the wrapper. Order is irrelevant; the matcher
+/// returns on first hit.
+const ALLOWLIST: &[&[u8]] = &[
+    b"copilot", b"codex", b"claude", b"aichat", b"gemini", b"qwen", b"ollama",
+];
+
+/// Returns `true` iff `command`'s basename (after a single
+/// optional `.exe`/`.cmd`/`.bat` strip) ASCII-case-insensitively
+/// matches one of the locked allowlist entries.
+///
+/// Never panics; never allocates. See the [module-level
+/// documentation](self) for the spec lock and platform notes.
+pub fn is_armed(command: &OsStr) -> bool {
+    // NUL guard: real spawn paths reject these, and they would
+    // otherwise let synthetic OsStr inputs bypass basename rules.
+    if command.as_encoded_bytes().contains(&0) {
+        return false;
+    }
+
+    let Some(basename) = Path::new(command).file_name() else {
+        return false;
+    };
+    let bytes = basename.as_encoded_bytes();
+    let stem = strip_known_suffix(bytes).unwrap_or(bytes);
+    if stem.is_empty() {
+        return false;
+    }
+    ALLOWLIST
+        .iter()
+        .any(|entry| entry.eq_ignore_ascii_case(stem))
+}
+
+/// If `bytes` ends with one of [`STRIPPABLE_SUFFIXES`]
+/// (case-insensitive on ASCII) and the stem before that suffix
+/// is non-empty, return the stem. Otherwise return `None` so the
+/// caller keeps the original bytes.
+///
+/// Strip is single-shot: `claude.exe.bak` does not match (the
+/// `.bak` is not strippable), and `claude.exe.cmd` keeps only
+/// the trailing `.cmd` removed (leaving `claude.exe`, which is
+/// not in the allowlist).
+fn strip_known_suffix(bytes: &[u8]) -> Option<&[u8]> {
+    for suffix in STRIPPABLE_SUFFIXES {
+        if bytes.len() > suffix.len() {
+            let split_at = bytes.len() - suffix.len();
+            let (stem, tail) = bytes.split_at(split_at);
+            if tail.eq_ignore_ascii_case(suffix) {
+                return Some(stem);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_armed;
+    use std::ffi::OsStr;
+
+    /// Portable cases that work uniformly on every target.
+    /// Backslash-bearing strings are tested under
+    /// `cfg(windows)`-only blocks below to avoid baking in
+    /// platform-specific path semantics on Unix.
+    const PORTABLE_CASES: &[(&str, bool)] = &[
+        // bare allowlist entries (each one covered)
+        ("copilot", true),
+        ("codex", true),
+        ("claude", true),
+        ("aichat", true),
+        ("gemini", true),
+        ("qwen", true),
+        ("ollama", true),
+        // ASCII case folding
+        ("Claude", true),
+        ("CLAUDE", true),
+        ("CoPiLoT", true),
+        // single-shot extension strip (case-insensitive on suffix)
+        ("claude.exe", true),
+        ("CLAUDE.EXE", true),
+        ("Claude.Exe", true),
+        ("claude.cmd", true),
+        ("claude.CMD", true),
+        ("claude.bat", true),
+        ("Claude.BAT", true),
+        // path components -- basename is what counts
+        ("/usr/bin/claude", true),
+        ("/usr/local/bin/Claude.exe", true),
+        ("./claude", true),
+        ("bin/claude", true),
+        // negatives: not on allowlist
+        ("vim", false),
+        ("nano", false),
+        ("zsh", false),
+        // negatives: unknown extension is NOT stripped
+        ("claude.bak", false),
+        // single-shot strip: only the trailing suffix is removed
+        ("claude.exe.bak", false),
+        ("claude.exe.cmd", false), // strips .cmd, leaves "claude.exe" which is not allowlisted
+        // dot-leading: stem becomes ".claude", not "claude"
+        (".claude.exe", false),
+        // empty stem after strip
+        (".exe", false),
+        (".cmd", false),
+        (".bat", false),
+        // super/substrings of allowlist entries
+        ("claudex", false),
+        ("clau", false),
+        ("xclaude", false),
+        // empty / whitespace / separator-only
+        ("", false),
+        ("   ", false),
+        ("/", false),
+        ("/usr/bin/", false), // Path::file_name returns None
+        // Unicode lookalikes must NOT match (ASCII-only fold)
+        ("\u{ff43}\u{ff4c}\u{ff41}\u{ff55}\u{ff44}\u{ff45}", false), // ｃｌａｕｄｅ
+        ("\u{0441}laude", false), // Cyrillic small letter es + 'laude'
+        ("clauder", false),
+    ];
+
+    #[test]
+    fn portable_matrix() {
+        for (input, expected) in PORTABLE_CASES {
+            let actual = is_armed(OsStr::new(input));
+            assert_eq!(
+                actual, *expected,
+                "is_armed({input:?}) returned {actual}, expected {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn allowlist_is_complete() {
+        // Hard guard so an accidental allowlist edit cannot pass
+        // CI by removing both the entry and its positive case.
+        for entry in [
+            "copilot", "codex", "claude", "aichat", "gemini", "qwen", "ollama",
+        ] {
+            assert!(
+                is_armed(OsStr::new(entry)),
+                "allowlist regression: {entry:?} should arm"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    mod unix {
+        use super::is_armed;
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        #[test]
+        fn invalid_utf8_with_no_match_is_false() {
+            // Non-UTF-8 lead bytes; basename byte-content does
+            // not equal any allowlist entry.
+            let raw: &[u8] = b"\xff\xfeclaude_no";
+            assert!(!is_armed(OsStr::from_bytes(raw)));
+        }
+
+        #[test]
+        fn invalid_utf8_path_with_matching_basename_is_true() {
+            // Directory part has invalid UTF-8 but the basename
+            // bytes equal "claude" exactly -- arms.
+            let raw: &[u8] = b"\xff\xfe/claude";
+            assert!(is_armed(OsStr::from_bytes(raw)));
+        }
+
+        #[test]
+        fn embedded_nul_is_rejected() {
+            let raw: &[u8] = b"clau\0de";
+            assert!(!is_armed(OsStr::from_bytes(raw)));
+        }
+
+        #[test]
+        fn embedded_nul_in_path_part_is_rejected() {
+            let raw: &[u8] = b"junk\0/claude";
+            assert!(!is_armed(OsStr::from_bytes(raw)));
+        }
+
+        #[test]
+        fn invalid_utf8_path_with_extension_in_basename_arms() {
+            // Non-UTF-8 directory part, basename "claude.EXE" --
+            // strip + ASCII fold should still arm.
+            let raw: &[u8] = b"\xff\xfe/claude.EXE";
+            assert!(is_armed(OsStr::from_bytes(raw)));
+        }
+    }
+
+    #[cfg(windows)]
+    mod windows {
+        use super::is_armed;
+        use std::ffi::OsString;
+        use std::os::windows::ffi::OsStringExt;
+
+        fn wide(s: &str) -> OsString {
+            OsString::from_wide(&s.encode_utf16().collect::<Vec<u16>>())
+        }
+
+        #[test]
+        fn drive_letter_path_arms() {
+            assert!(is_armed(&wide(r"C:\tools\claude.exe")));
+        }
+
+        #[test]
+        fn drive_letter_trailing_separator_does_not_arm() {
+            assert!(!is_armed(&wide(r"C:\tools\")));
+        }
+
+        #[test]
+        fn forward_slash_path_arms_on_windows_too() {
+            assert!(is_armed(&wide("C:/tools/claude.exe")));
+        }
+
+        #[test]
+        fn bare_basename_arms() {
+            assert!(is_armed(&wide("claude.exe")));
+        }
+    }
+}

--- a/src/cli/arming.rs
+++ b/src/cli/arming.rs
@@ -162,7 +162,27 @@ mod tests {
         ("", false),
         ("   ", false),
         ("/", false),
-        ("/usr/bin/", false), // Path::file_name returns None
+        // `Path::file_name` strips trailing separators, so
+        // `claude/` and `bin/claude/` arm. This matches what
+        // a shell would resolve before exec, so the matcher
+        // intentionally accepts them.
+        ("claude/", true),
+        ("bin/claude/", true),
+        ("claude/.", true), // `.` final component is normalised away
+        // `Path::file_name` returns None for these.
+        (".", false),
+        ("..", false),
+        // `/usr/bin/` -> file_name "bin" -> not allowlisted.
+        ("/usr/bin/", false),
+        // No trimming of whitespace or newlines: byte-wise match
+        // against the allowlist must fail for these.
+        ("claude\n", false),
+        ("claude ", false),
+        (" claude", false),
+        // Two-dot stem: ".."+strip yields "..claude" or
+        // "..claude.exe" -> stem "..claude" -> not allowlisted.
+        ("..claude", false),
+        ("..claude.exe", false),
         // Unicode lookalikes must NOT match (ASCII-only fold)
         ("\u{ff43}\u{ff4c}\u{ff41}\u{ff55}\u{ff44}\u{ff45}", false), // ｃｌａｕｄｅ
         ("\u{0441}laude", false), // Cyrillic small letter es + 'laude'
@@ -265,6 +285,21 @@ mod tests {
         #[test]
         fn bare_basename_arms() {
             assert!(is_armed(&wide("claude.exe")));
+        }
+
+        #[test]
+        fn nul_only_wide_input_is_rejected() {
+            let raw: Vec<u16> = vec![0];
+            assert!(!is_armed(&OsString::from_wide(&raw)));
+        }
+
+        #[test]
+        fn embedded_nul_in_wide_input_is_rejected() {
+            // "claude" with a NUL spliced in the middle.
+            let raw: Vec<u16> = vec![
+                'c' as u16, 'l' as u16, 'a' as u16, 0, 'u' as u16, 'd' as u16, 'e' as u16,
+            ];
+            assert!(!is_armed(&OsString::from_wide(&raw)));
         }
     }
 }


### PR DESCRIPTION
Phase 1 of the v0.1 MVP roadmap (#11) lands the pure-logic
arming gate: a single function that decides whether the
wrapped child command is one of the AI CLIs whose
Vim-style quit literals should be intercepted by the
Phase 2+ pump.

## Scope

- Implements \`pub fn is_armed(command: &OsStr) -> bool\` in
  \`src/cli/arming.rs\`.
- Allowlist is FIXED to \`copilot, codex, claude, aichat,
  gemini, qwen, ollama\` (locked spec, issue #11).
- Basename via \`std::path::Path::file_name\` (delegates
  separator + drive-letter semantics to \`std\`).
- Single-shot \`.exe\`/\`.cmd\`/\`.bat\` strip,
  case-insensitive on the suffix.
- ASCII case-insensitive byte comparison; no Unicode
  normalisation, no locale-aware folding, no whitespace
  trimming (documented).
- NUL-byte guard on raw input; never panics; no allocation.

## Design notes

- \`Path::file_name()\` over manual byte scanning means
  \`C:\\\\tools\\\\claude.exe\` arms on Windows (drive-aware) and
  stays a single filename on Unix (no surprising backslash
  splits) — matching how the OS would actually resolve
  the command.
- Single-shot extension strip keeps \`claude.exe.bak\` and
  \`claude.exe.cmd\` non-arming, which is the conservative
  default.

## Tests (table-driven)

A portable \`&str\` matrix in \`#[cfg(test)] mod tests\`
covers:

- every allowlist entry (positive),
- ASCII case-folding (\`Claude\`, \`CoPiLoT\`),
- single-shot strip across mixed-case suffixes,
- relative / absolute path basenames,
- super/substring negatives (\`claudex\`, \`clau\`),
- trailing-separator basenames (\`claude/\`, \`bin/claude/\`,
  \`claude/.\`) and their negative siblings (\`.\`, \`..\`,
  \`/usr/bin/\`),
- whitespace/newline negatives (no trimming),
- two-dot-stem negatives (\`..claude\`, \`..claude.exe\`),
- Unicode lookalikes (full-width \`ｃｌａｕｄｅ\`, Cyrillic
  homoglyph).

\`#[cfg(unix)]\` adds non-UTF-8 / NUL byte cases via
\`OsStrExt::from_bytes\`. \`#[cfg(windows)]\` adds drive-letter
paths, trailing-separator drive paths, forward-slash drive
paths, and wide-char NUL coverage via \`OsStringExt::from_wide\`.

All checks green locally:

- \`cargo fmt --check\`
- \`cargo clippy --all-targets --all-features -- -D warnings\`
- \`cargo test --all-targets --all-features\`

Self-review pass via the rubber-duck agent ran twice; the
first round produced four accepted findings (extra
trailing-separator + boundary tests, Windows wide NUL
coverage, doc clarification on no normalisation/trimming),
each landed as its own atomic commit. The second round
returned zero findings.

Closes #20
Closes #21

## Successor

Recommended next issue: **#51 \`arming-wire-into-pump\`**
(Phase 2) — wires this matcher into the input pump so
arming actually gates trigger detection.

Property-based tests (\`#67 test-arming-property\`) are
deferred to Phase 9 (test hardening) per the roadmap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Commands are now validated against an allowlist of approved tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->