### PR TITLE
feat(pty): integrate RawGuard with the wrap path entrance

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 pub mod anim;
 pub mod cli;
 pub mod error;
+pub mod pty;
 #[cfg(unix)]
 pub mod signals;
 pub mod term;
@@ -121,10 +122,7 @@ pub fn run(args: Vec<std::ffi::OsString>) -> Result<ExitCode> {
             println!("qorrection {}", env!("CARGO_PKG_VERSION"));
             Ok(ExitCode::SUCCESS)
         }
-        cli::Invocation::Wrap { .. } => {
-            eprintln!("qorrection: PTY wrap pending");
-            Ok(ExitCode::from(2))
-        }
+        cli::Invocation::Wrap { command, args } => pty::run_session(command, args),
     }
 }
 

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -12,7 +12,8 @@
 //!
 //! The wrap-path invariant `RawGuard` must enforce — "raw mode
 //! is acquired before any session work and restored on every
-//! exit path, including panics" — cannot be unit-tested through
+//! returning or unwinding exit path (normal return, `?`,
+//! panic-with-unwind)" — cannot be unit-tested through
 //! the production [`run_session`] entry because it touches the
 //! real terminal and the real `crossterm` enable / disable
 //! syscalls. [`run_session_with`] separates the policy

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -1,0 +1,215 @@
+//! PTY session entry point.
+//!
+//! [`run_session`] is the structural seat for everything the
+//! Wrap path needs to do: acquire raw mode, spawn the wrapped
+//! child on a pseudo-terminal, forward I/O, and propagate the
+//! child's exit status. PR 1 only seats the [`RawGuard`]
+//! acquisition; subsequent phase-2 PRs fill in spawn (#22),
+//! forwarders (#23 / #35 / #36), wait + exit code (#24 / #33),
+//! and replace [`default_body`] with the real pump (#26).
+//!
+//! ## Design — the `run_session_with` injection seam
+//!
+//! The wrap-path invariant `RawGuard` must enforce — "raw mode
+//! is acquired before any session work and restored on every
+//! exit path, including panics" — cannot be unit-tested through
+//! the production [`run_session`] entry because it touches the
+//! real terminal and the real `crossterm` enable / disable
+//! syscalls. [`run_session_with`] separates the policy
+//! (acquire-then-run-body, drop-on-return) from the side
+//! effects (real `acquire_raw`, real PTY pump body), so tests
+//! can substitute counter-incrementing shims and verify the
+//! ordering / lifetime invariants without touching termios.
+//!
+//! The `command` and `args` parameters are accepted but unused
+//! by [`default_body`]; PR 2 (#22) wires them into the spawn
+//! call.
+
+use std::ffi::OsString;
+use std::process::ExitCode;
+
+use crate::{
+    term::{detect, RawGuard, TerminalCaps},
+    Result,
+};
+
+/// Run a single PTY-wrapped session for `command` + `args`.
+///
+/// Snapshots the terminal capabilities, acquires raw mode for
+/// the duration of the session, and invokes the session body.
+/// Returns the exit code the wrapped child should bubble up to
+/// the binary entry point.
+pub fn run_session(command: OsString, args: Vec<OsString>) -> Result<ExitCode> {
+    let caps = detect::detect();
+    run_session_with(caps, command, args, crate::term::acquire_raw, default_body)
+}
+
+/// Lifecycle core, parameterised over the raw-mode `acquire`
+/// strategy and the session `body`. Exists so unit tests can
+/// inject shims without touching real termios. See the
+/// module-level comment for the invariants this seam protects.
+pub(crate) fn run_session_with<A, B>(
+    caps: TerminalCaps,
+    command: OsString,
+    args: Vec<OsString>,
+    acquire: A,
+    body: B,
+) -> Result<ExitCode>
+where
+    A: FnOnce(&TerminalCaps) -> Result<RawGuard>,
+    B: FnOnce(&OsString, &[OsString]) -> Result<ExitCode>,
+{
+    // Bind the guard to a named local so it lives until the end
+    // of the function. `let _ = ...` would drop it immediately
+    // and defeat the purpose.
+    let _raw = acquire(&caps)?;
+    body(&command, &args)
+}
+
+/// Placeholder body for PR 1. PR 5 (#26) replaces this with the
+/// real PTY pump and removes the diagnostic.
+fn default_body(_command: &OsString, _args: &[OsString]) -> Result<ExitCode> {
+    eprintln!("qorrection: PTY wrap pending");
+    Ok(ExitCode::from(2))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc,
+    };
+
+    fn caps() -> TerminalCaps {
+        TerminalCaps {
+            stdin_is_tty: false,
+            stdout_is_tty: false,
+            utf8: true,
+            color: false,
+            dumb: false,
+            ci: false,
+        }
+    }
+
+    /// An armed `RawGuard` whose drop hook increments `counter`.
+    /// Returned by injected `acquire` shims so tests can observe
+    /// the guard's lifetime.
+    fn observed_guard(counter: Arc<AtomicUsize>) -> RawGuard {
+        RawGuard::with_disable_hook(move || {
+            counter.fetch_add(1, Ordering::SeqCst);
+        })
+    }
+
+    #[test]
+    fn run_session_with_acquires_guard_before_body() {
+        let acquired = Arc::new(AtomicBool::new(false));
+        let acquired_for_acquire = Arc::clone(&acquired);
+        let acquired_for_body = Arc::clone(&acquired);
+
+        let _exit = run_session_with(
+            caps(),
+            OsString::from("dummy"),
+            Vec::new(),
+            move |_caps| {
+                acquired_for_acquire.store(true, Ordering::SeqCst);
+                Ok(RawGuard::noop())
+            },
+            move |_cmd, _args| {
+                assert!(
+                    acquired_for_body.load(Ordering::SeqCst),
+                    "body ran before acquire"
+                );
+                Ok(ExitCode::SUCCESS)
+            },
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn run_session_with_drops_guard_when_body_returns_ok() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let counter_for_acquire = Arc::clone(&counter);
+
+        let _exit = run_session_with(
+            caps(),
+            OsString::from("dummy"),
+            Vec::new(),
+            move |_caps| Ok(observed_guard(counter_for_acquire)),
+            |_cmd, _args| Ok(ExitCode::SUCCESS),
+        )
+        .unwrap();
+
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn run_session_with_drops_guard_on_body_early_err() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let counter_for_acquire = Arc::clone(&counter);
+
+        let result = run_session_with(
+            caps(),
+            OsString::from("dummy"),
+            Vec::new(),
+            move |_caps| Ok(observed_guard(counter_for_acquire)),
+            |_cmd, _args| {
+                Err(crate::Error::Terminal(std::io::Error::other(
+                    "synthetic body failure",
+                )))
+            },
+        );
+
+        assert!(matches!(result, Err(crate::Error::Terminal(_))));
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn run_session_with_drops_guard_on_body_panic() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let counter_for_call = Arc::clone(&counter);
+        // Build the guard inside the catch_unwind closure so
+        // only `Arc<AtomicUsize>` crosses the unwind boundary.
+        let panicked = std::panic::catch_unwind(move || {
+            let _ = run_session_with(
+                caps(),
+                OsString::from("dummy"),
+                Vec::new(),
+                move |_caps| Ok(observed_guard(counter_for_call)),
+                |_cmd, _args| -> Result<ExitCode> {
+                    panic!("body boom");
+                },
+            );
+        });
+
+        assert!(panicked.is_err());
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn run_session_with_propagates_acquire_error() {
+        let body_ran = Arc::new(AtomicBool::new(false));
+        let body_observed = Arc::clone(&body_ran);
+
+        let result = run_session_with(
+            caps(),
+            OsString::from("dummy"),
+            Vec::new(),
+            |_caps| {
+                Err(crate::Error::Terminal(std::io::Error::other(
+                    "synthetic acquire failure",
+                )))
+            },
+            move |_cmd, _args| {
+                body_observed.store(true, Ordering::SeqCst);
+                Ok(ExitCode::SUCCESS)
+            },
+        );
+
+        assert!(matches!(result, Err(crate::Error::Terminal(_))));
+        assert!(
+            !body_ran.load(Ordering::SeqCst),
+            "body ran after acquire failure"
+        );
+    }
+}

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -68,8 +68,14 @@ where
 
 /// Placeholder body for PR 1. PR 5 (#26) replaces this with the
 /// real PTY pump and removes the diagnostic.
+///
+/// Uses `\r\n` rather than `\n` because, on a real interactive
+/// TTY, the surrounding [`run_session_with`] is now holding the
+/// terminal in raw mode where output post-processing (newline
+/// translation) is disabled. A bare `\n` would leave the cursor
+/// dangling at the end of the line.
 fn default_body(_command: &OsString, _args: &[OsString]) -> Result<ExitCode> {
-    eprintln!("qorrection: PTY wrap pending");
+    eprint!("qorrection: PTY wrap pending\r\n");
     Ok(ExitCode::from(2))
 }
 
@@ -124,6 +130,30 @@ mod tests {
             },
         )
         .unwrap();
+    }
+
+    #[test]
+    fn run_session_with_calls_acquire_exactly_once() {
+        // Pin the "acquired exactly once per session" half of the
+        // invariant explicitly. Drop-counter tests cover the
+        // restore half indirectly; this asserts the entry-side
+        // contract directly so future bodies cannot regress it.
+        let acquire_calls = Arc::new(AtomicUsize::new(0));
+        let acquire_observed = Arc::clone(&acquire_calls);
+
+        let _exit = run_session_with(
+            caps(),
+            OsString::from("dummy"),
+            Vec::new(),
+            move |_caps| {
+                acquire_observed.fetch_add(1, Ordering::SeqCst);
+                Ok(RawGuard::noop())
+            },
+            |_cmd, _args| Ok(ExitCode::SUCCESS),
+        )
+        .unwrap();
+
+        assert_eq!(acquire_calls.load(Ordering::SeqCst), 1);
     }
 
     #[test]

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -75,8 +75,14 @@ where
 /// terminal in raw mode where output post-processing (newline
 /// translation) is disabled. A bare `\n` would leave the cursor
 /// dangling at the end of the line.
+///
+/// Intentionally emits no `argv[0]`-derived program-name prefix:
+/// other diagnostics route through [`crate::program_name`], but
+/// this body has no access to `argv[0]` and is throwaway code.
+/// PR 5 removes the line entirely, so plumbing the program name
+/// through the session seam just to delete it would be churn.
 fn default_body(_command: &OsString, _args: &[OsString]) -> Result<ExitCode> {
-    eprint!("qorrection: PTY wrap pending\r\n");
+    eprint!("PTY wrap pending\r\n");
     Ok(ExitCode::from(2))
 }
 

--- a/src/term/guard.rs
+++ b/src/term/guard.rs
@@ -10,9 +10,10 @@
 //! Rules (locked v0.1, see plan §6 D-RAWMODE):
 //!
 //! - Acquire only when **both** stdin and stdout are TTYs. The
-//!   non-TTY path bypasses PTY entirely (D-NONTTY) and so must
-//!   also bypass raw mode -- touching termios on a pipe is
-//!   undefined.
+//!   eventual non-TTY path will bypass PTY entirely (D-NONTTY,
+//!   tracked under #29 / #30 / #31); until that lands, raw-mode
+//!   acquisition must still be skipped when either stream is
+//!   non-TTY -- touching termios on a pipe is undefined.
 //! - Restoration runs in [`Drop`], so any panic between
 //!   acquisition and the end of the session unwinds back through
 //!   the guard and disables raw mode on the way out.
@@ -37,8 +38,11 @@ pub fn should_arm(caps: &TerminalCaps) -> bool {
 /// The disable side-effect is stored as an `FnOnce` closure so
 /// unit tests can substitute a counter-incrementing hook and
 /// assert restoration semantics without touching real termios.
-/// Production callers ([`acquire`]) supply
-/// `crossterm::terminal::disable_raw_mode`.
+/// Production callers ([`acquire`]) install a best-effort hook
+/// that calls `crossterm::terminal::disable_raw_mode` and
+/// **discards** any error -- a destructor cannot meaningfully
+/// recover from a failed restore, and the user is already in a
+/// bad state if it fails. The hook itself returns `()`.
 pub struct RawGuard {
     on_drop: Option<Box<dyn FnOnce() + Send + 'static>>,
 }

--- a/src/term/guard.rs
+++ b/src/term/guard.rs
@@ -28,37 +28,78 @@ pub fn should_arm(caps: &TerminalCaps) -> bool {
     caps.stdin_is_tty && caps.stdout_is_tty
 }
 
-/// RAII guard that disables raw mode on [`Drop`] when armed.
+/// RAII guard that runs a "disable" hook on [`Drop`] when armed.
 ///
 /// Construct via [`acquire`]. Holding the guard alive (e.g. as
 /// a local in `pty::run_session`) keeps raw mode engaged; let
 /// it drop to restore the cooked terminal.
-#[derive(Debug)]
+///
+/// The disable side-effect is stored as an `FnOnce` closure so
+/// unit tests can substitute a counter-incrementing hook and
+/// assert restoration semantics without touching real termios.
+/// Production callers ([`acquire`]) supply
+/// `crossterm::terminal::disable_raw_mode`.
 pub struct RawGuard {
-    armed: bool,
+    on_drop: Option<Box<dyn FnOnce() + Send + 'static>>,
+}
+
+impl std::fmt::Debug for RawGuard {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RawGuard")
+            .field("armed", &self.is_armed())
+            .finish()
+    }
 }
 
 impl RawGuard {
     /// Whether this guard currently owns the raw-mode state.
     pub fn is_armed(&self) -> bool {
-        self.armed
+        self.on_drop.is_some()
     }
 
     /// Construct a no-op guard for callers that have already
     /// decided not to enter raw mode (e.g. the non-TTY bypass
     /// path).
     pub fn noop() -> Self {
-        Self { armed: false }
+        Self { on_drop: None }
+    }
+
+    /// Test-only constructor that produces an armed guard whose
+    /// drop hook is the supplied closure. Lets unit tests assert
+    /// Drop semantics (normal return, panic) without enabling
+    /// real raw mode.
+    ///
+    /// # Panics in the hook
+    ///
+    /// The hook MUST NOT panic. If a `RawGuard` is dropped during
+    /// unwinding (e.g. inside a `catch_unwind` after `panic!`)
+    /// and its hook panics, the second panic aborts the process.
+    /// Test hooks should only touch `Arc<AtomicUsize>` /
+    /// `Arc<Mutex<_>>` style observers.
+    #[cfg(test)]
+    pub(crate) fn with_disable_hook<H>(hook: H) -> Self
+    where
+        H: FnOnce() + Send + 'static,
+    {
+        Self {
+            on_drop: Some(Box::new(hook)),
+        }
     }
 }
 
 impl Drop for RawGuard {
     fn drop(&mut self) {
-        if self.armed {
-            // Best-effort: if we cannot disable raw mode the
-            // terminal is already in a bad state and there is
-            // no useful recovery from a destructor.
-            let _ = crossterm::terminal::disable_raw_mode();
+        // `Option::take` is defensive — `Drop::drop` is called at
+        // most once by the language — but it also enforces that
+        // the boxed `FnOnce` is consumed exactly once.
+        //
+        // The production hook is `crossterm::disable_raw_mode`,
+        // which is best-effort: if it fails the terminal is
+        // already in a bad state and there is no useful recovery
+        // from a destructor. Hooks must not panic — see
+        // [`RawGuard::with_disable_hook`].
+        if let Some(hook) = self.on_drop.take() {
+            hook();
         }
     }
 }
@@ -68,16 +109,44 @@ impl Drop for RawGuard {
 /// Returns a [`RawGuard`] in either case; the guard is a no-op
 /// when raw mode was not entered.
 pub fn acquire(caps: &TerminalCaps) -> Result<RawGuard> {
+    acquire_with(
+        caps,
+        || crossterm::terminal::enable_raw_mode().map_err(Into::into),
+        || {
+            || {
+                let _ = crossterm::terminal::disable_raw_mode();
+            }
+        },
+    )
+}
+
+/// Decision + wiring core, parameterised over the side-effecting
+/// `enable` call and the `make_disable` factory that produces the
+/// drop hook. Lets unit tests cover every armed-path branch
+/// (non-TTY skip, enable success, enable failure) without
+/// touching real termios.
+fn acquire_with<E, MD, D>(caps: &TerminalCaps, enable: E, make_disable: MD) -> Result<RawGuard>
+where
+    E: FnOnce() -> Result<()>,
+    MD: FnOnce() -> D,
+    D: FnOnce() + Send + 'static,
+{
     if !should_arm(caps) {
         return Ok(RawGuard::noop());
     }
-    crossterm::terminal::enable_raw_mode()?;
-    Ok(RawGuard { armed: true })
+    enable()?;
+    Ok(RawGuard {
+        on_drop: Some(Box::new(make_disable())),
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
 
     fn caps(stdin_tty: bool, stdout_tty: bool) -> TerminalCaps {
         TerminalCaps {
@@ -116,5 +185,129 @@ mod tests {
         assert!(!g.is_armed());
         let g = acquire(&caps(true, false)).unwrap();
         assert!(!g.is_armed());
+    }
+
+    #[test]
+    fn noop_guard_runs_no_hook() {
+        // A noop guard has no hook to fire; nothing should be
+        // observed after it leaves scope.
+        let counter = Arc::new(AtomicUsize::new(0));
+        let observed = Arc::clone(&counter);
+        {
+            let _g = RawGuard::noop();
+            // Hold a clone so the closure-equivalent reference
+            // is alive; we simply never wire it into the guard.
+            let _ = observed;
+        }
+        assert_eq!(counter.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn armed_guard_runs_hook_on_normal_drop() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        {
+            let observed = Arc::clone(&counter);
+            let _g = RawGuard::with_disable_hook(move || {
+                observed.fetch_add(1, Ordering::SeqCst);
+            });
+        }
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn armed_guard_runs_hook_on_panic() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let observed = Arc::clone(&counter);
+        // Build the guard *inside* the catch_unwind closure so
+        // only `Arc<AtomicUsize>` crosses the unwind boundary --
+        // this avoids needing `AssertUnwindSafe` on `RawGuard`.
+        let result = std::panic::catch_unwind(move || {
+            let _g = RawGuard::with_disable_hook(move || {
+                observed.fetch_add(1, Ordering::SeqCst);
+            });
+            panic!("boom");
+        });
+        assert!(result.is_err());
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn acquire_with_non_tty_skips_enable_and_disable() {
+        let enable_calls = Arc::new(AtomicUsize::new(0));
+        let disable_calls = Arc::new(AtomicUsize::new(0));
+        let enable_observed = Arc::clone(&enable_calls);
+        let disable_observed = Arc::clone(&disable_calls);
+
+        let guard = acquire_with(
+            &caps(false, false),
+            move || {
+                enable_observed.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            },
+            move || {
+                move || {
+                    disable_observed.fetch_add(1, Ordering::SeqCst);
+                }
+            },
+        )
+        .unwrap();
+        assert!(!guard.is_armed());
+        drop(guard);
+
+        assert_eq!(enable_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(disable_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn acquire_with_tty_calls_enable_once_and_disable_on_drop() {
+        let enable_calls = Arc::new(AtomicUsize::new(0));
+        let disable_calls = Arc::new(AtomicUsize::new(0));
+        let enable_observed = Arc::clone(&enable_calls);
+        let disable_observed = Arc::clone(&disable_calls);
+
+        {
+            let guard = acquire_with(
+                &caps(true, true),
+                move || {
+                    enable_observed.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                },
+                move || {
+                    move || {
+                        disable_observed.fetch_add(1, Ordering::SeqCst);
+                    }
+                },
+            )
+            .unwrap();
+            assert!(guard.is_armed());
+            assert_eq!(enable_calls.load(Ordering::SeqCst), 1);
+            assert_eq!(disable_calls.load(Ordering::SeqCst), 0);
+        }
+
+        assert_eq!(enable_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(disable_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn acquire_with_tty_propagates_enable_error_and_skips_disable() {
+        let disable_calls = Arc::new(AtomicUsize::new(0));
+        let disable_observed = Arc::clone(&disable_calls);
+
+        let result = acquire_with(
+            &caps(true, true),
+            || {
+                Err(crate::Error::Terminal(std::io::Error::other(
+                    "synthetic enable failure",
+                )))
+            },
+            move || {
+                move || {
+                    disable_observed.fetch_add(1, Ordering::SeqCst);
+                }
+            },
+        );
+
+        assert!(matches!(result, Err(crate::Error::Terminal(_))));
+        assert_eq!(disable_calls.load(Ordering::SeqCst), 0);
     }
 }

--- a/src/term/guard.rs
+++ b/src/term/guard.rs
@@ -192,17 +192,6 @@ mod tests {
     }
 
     #[test]
-    fn noop_guard_runs_no_hook() {
-        // A noop guard has no hook to fire; the counter must stay
-        // at zero across its entire lifetime.
-        let counter = Arc::new(AtomicUsize::new(0));
-        {
-            let _g = RawGuard::noop();
-        }
-        assert_eq!(counter.load(Ordering::SeqCst), 0);
-    }
-
-    #[test]
     fn armed_guard_runs_hook_on_normal_drop() {
         let counter = Arc::new(AtomicUsize::new(0));
         {

--- a/src/term/guard.rs
+++ b/src/term/guard.rs
@@ -193,15 +193,11 @@ mod tests {
 
     #[test]
     fn noop_guard_runs_no_hook() {
-        // A noop guard has no hook to fire; nothing should be
-        // observed after it leaves scope.
+        // A noop guard has no hook to fire; the counter must stay
+        // at zero across its entire lifetime.
         let counter = Arc::new(AtomicUsize::new(0));
-        let observed = Arc::clone(&counter);
         {
             let _g = RawGuard::noop();
-            // Hold a clone so the closure-equivalent reference
-            // is alive; we simply never wire it into the guard.
-            let _ = observed;
         }
         assert_eq!(counter.load(Ordering::SeqCst), 0);
     }

--- a/src/term/guard.rs
+++ b/src/term/guard.rs
@@ -290,7 +290,12 @@ mod tests {
 
     #[test]
     fn acquire_with_tty_propagates_enable_error_and_skips_disable() {
+        // Track both the outer factory call count and the inner
+        // hook call count so the test pins down "no hook is even
+        // constructed when enable fails", not just "no hook ran".
+        let make_disable_calls = Arc::new(AtomicUsize::new(0));
         let disable_calls = Arc::new(AtomicUsize::new(0));
+        let make_disable_observed = Arc::clone(&make_disable_calls);
         let disable_observed = Arc::clone(&disable_calls);
 
         let result = acquire_with(
@@ -301,6 +306,7 @@ mod tests {
                 )))
             },
             move || {
+                make_disable_observed.fetch_add(1, Ordering::SeqCst);
                 move || {
                     disable_observed.fetch_add(1, Ordering::SeqCst);
                 }
@@ -308,6 +314,7 @@ mod tests {
         );
 
         assert!(matches!(result, Err(crate::Error::Terminal(_))));
+        assert_eq!(make_disable_calls.load(Ordering::SeqCst), 0);
         assert_eq!(disable_calls.load(Ordering::SeqCst), 0);
     }
 }


### PR DESCRIPTION
Phase 2 PR 1 of 6. Establishes the structural seat for the PTY
session lifecycle so subsequent Phase 2 PRs (#22, #23, #24, #26,
…) can plug spawn / forwarders / wait under it without revisiting
raw-mode lifecycle.

## What this PR does

- Refactors `RawGuard` so its `Drop` side-effect is a closure
  hook (`Option<Box<dyn FnOnce() + Send + 'static>>`). The
  public API (`is_armed`, `noop`, `acquire`) is unchanged; the
  factoring just makes the disable side-effect observable from
  unit tests without touching real termios.
- Adds `src/pty/mod.rs` with `run_session(command, args)` as the
  Wrap-path entry, plus a `pub(crate) run_session_with(caps,
  command, args, acquire, body)` injection seam used only by
  unit tests. The seam acquires the guard, then runs the body,
  so the guard is dropped on every exit path (normal return,
  body `?`, panic, or acquire error short-circuit).
- Wires `lib::run`'s Wrap arm to call `pty::run_session` instead
  of the previous `eprintln! + Ok(2)` stub.

## Invariant proven by tests

> Raw mode is acquired exactly once per session, before any
> session body runs, and is restored on every exit path.

Both halves are pinned directly:

- `run_session_with_calls_acquire_exactly_once` — entry-side.
- `run_session_with_drops_guard_when_body_returns_ok` /
  `_on_body_early_err` / `_on_body_panic` — restore-side.
- `run_session_with_propagates_acquire_error` — body never runs
  when acquire fails.
- `acquire_with_*` — non-TTY skip, TTY enable+disable ordering,
  enable-failure short-circuit (factory non-call + hook
  non-call both pinned).
- `armed_guard_runs_hook_on_panic` — guard built inside
  \`catch_unwind\` so only \`Arc<AtomicUsize>\` crosses the
  unwind boundary.

No real-PTY E2E tests in this PR; PR 5 (#27 / #28) owns the
\`rexpect\` coverage once the placeholder body is replaced.

## User-visible behaviour change (intentional)

If \`enable_raw_mode\` fails on the host terminal, Wrap now
returns \`Err\` (mapped via \`Error::exit_code\` to exit 2)
instead of always returning \`Ok(ExitCode::from(2))\`. A terminal
that refuses raw mode cannot be a safe wrap target.

The placeholder diagnostic \`qorrection: PTY wrap pending\`
still prints (PR 5 / #26 owns its removal), but now uses
\`\\r\\n\` because raw mode disables newline post-processing.

## Out of scope (next PRs)

- PR 2 (\`feat/pty-spawn-primitives\`): #22, #32, #34
- PR 3 (forwarders + pump): #23, #35, #36
- PR 4 (wait + lifecycle): #24, #33
- PR 5 (placeholder removal + rexpect E2E): #26, #27, #28
- PR 6 (non-TTY disarm): #29, #30, #31

Closes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wrap command now provides full pseudo-terminal session management instead of a placeholder message.

* **Tests**
  * Added comprehensive test coverage for terminal capabilities, raw mode handling, and session lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->