### PR TITLE
feat(pty): I/O forwarders + IoPump assembly (Phase 2 PR 3)

### DIFF
--- a/src/pty/forward.rs
+++ b/src/pty/forward.rs
@@ -1,0 +1,380 @@
+//! Direction-tagged stdio forwarder primitive.
+//!
+//! [`spawn_forwarder`] owns one half of the wrap session's
+//! U-shaped pipe: a thread that reads from `reader`, writes
+//! to `writer`, and reports completion via a typed
+//! [`ForwarderExit`]. It is deliberately decoupled from the
+//! PTY layer (works on any [`Read`] / [`Write`] pair) so that
+//! the unit tests can drive the contract in-memory without
+//! spawning a real PTY.
+//!
+//! The wait/drain supervisor that converges both forwarders
+//! with the child wait is owned by PR 4 (#33). PR 3 only
+//! ships the moving primitive plus its assembly point in
+//! [`super::pump`].
+
+use std::io::{self, Read, Write};
+use std::thread::{self, JoinHandle};
+
+const BUF_LEN: usize = 8 * 1024;
+
+/// Direction tag carried in [`ForwarderHandle`] so PR 4's
+/// supervisor can attribute join failures to the right pipe.
+#[allow(dead_code)] // wired into default_body in PR 5 / #26
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Direction {
+    HostToChild,
+    ChildToHost,
+}
+
+/// Why a forwarder thread stopped.
+///
+/// Both variants are graceful for PR 3, but the supervisor in
+/// PR 4 may want to short-circuit drain on [`Self::WriterClosed`]
+/// (the receiving side hung up — e.g. host stdout pager exit,
+/// or child closing its stdin after EOF).
+#[allow(dead_code)] // wired into default_body in PR 5 / #26
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ForwarderExit {
+    /// Reader returned `Ok(0)` — natural EOF on the source.
+    ReaderEof { bytes: u64 },
+    /// Writer raised [`io::ErrorKind::BrokenPipe`] — the
+    /// receiving side hung up.
+    WriterClosed { bytes: u64 },
+}
+
+/// A spawned forwarder thread plus its direction tag.
+///
+/// The thread keeps running until [`ForwarderExit`] is
+/// produced or an unrecoverable [`io::Error`] is returned.
+/// PR 4 owns the join policy.
+#[allow(dead_code)] // wired into default_body in PR 5 / #26
+pub(crate) struct ForwarderHandle {
+    pub(crate) direction: Direction,
+    pub(crate) join: JoinHandle<io::Result<ForwarderExit>>,
+}
+
+/// Spawn a thread that copies bytes from `reader` into
+/// `writer` until EOF or an unrecoverable error.
+///
+/// See [`ForwarderExit`] for graceful termination tagging and
+/// the module-level docs for the I/O policy summary.
+#[allow(dead_code)] // wired into default_body in PR 5 / #26
+pub(crate) fn spawn_forwarder<R, W>(
+    direction: Direction,
+    mut reader: R,
+    mut writer: W,
+) -> ForwarderHandle
+where
+    R: Read + Send + 'static,
+    W: Write + Send + 'static,
+{
+    let join = thread::spawn(move || run_forwarder(&mut reader, &mut writer));
+    ForwarderHandle { direction, join }
+}
+
+fn run_forwarder<R, W>(reader: &mut R, writer: &mut W) -> io::Result<ForwarderExit>
+where
+    R: Read,
+    W: Write,
+{
+    let mut buf = [0u8; BUF_LEN];
+    let mut bytes: u64 = 0;
+    loop {
+        let n = match reader.read(&mut buf) {
+            Ok(0) => {
+                // Final flush is best-effort: we are already
+                // terminating cleanly, so a flush error here
+                // does not change the outcome.
+                let _ = writer.flush();
+                return Ok(ForwarderExit::ReaderEof { bytes });
+            }
+            Ok(n) => n,
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(e),
+        };
+        match write_all_chunked(writer, &buf[..n]) {
+            Ok(()) => bytes += n as u64,
+            Err(WriteOutcome::WriterClosed { written }) => {
+                bytes += written as u64;
+                return Ok(ForwarderExit::WriterClosed { bytes });
+            }
+            Err(WriteOutcome::Err(e)) => return Err(e),
+        }
+        // Per-chunk flush so interactive prompts (no trailing
+        // newline) reach the consumer immediately. BrokenPipe
+        // here mirrors the writer policy.
+        match writer.flush() {
+            Ok(()) => {}
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+            Err(e) if e.kind() == io::ErrorKind::BrokenPipe => {
+                return Ok(ForwarderExit::WriterClosed { bytes });
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+enum WriteOutcome {
+    WriterClosed { written: usize },
+    Err(io::Error),
+}
+
+fn write_all_chunked<W: Write>(writer: &mut W, mut data: &[u8]) -> Result<(), WriteOutcome> {
+    let mut written = 0usize;
+    while !data.is_empty() {
+        match writer.write(data) {
+            Ok(0) => {
+                return Err(WriteOutcome::Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "forwarder writer accepted zero bytes",
+                )));
+            }
+            Ok(n) => {
+                written += n;
+                data = &data[n..];
+            }
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+            Err(e) if e.kind() == io::ErrorKind::BrokenPipe => {
+                return Err(WriteOutcome::WriterClosed { written });
+            }
+            Err(e) => return Err(WriteOutcome::Err(e)),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Cursor, Read, Write};
+    use std::sync::{Arc, Mutex};
+
+    fn forward_blocking<R, W>(reader: R, writer: W) -> io::Result<ForwarderExit>
+    where
+        R: Read + Send + 'static,
+        W: Write + Send + 'static,
+    {
+        let h = spawn_forwarder(Direction::HostToChild, reader, writer);
+        h.join.join().expect("forwarder thread panicked")
+    }
+
+    // ----- Fakes -----
+
+    /// Reader that yields `Interrupted` once before serving the
+    /// underlying `Cursor`.
+    struct InterruptOnceReader {
+        inner: Cursor<Vec<u8>>,
+        tripped: bool,
+    }
+    impl Read for InterruptOnceReader {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            if !self.tripped {
+                self.tripped = true;
+                return Err(io::Error::new(io::ErrorKind::Interrupted, "trip"));
+            }
+            self.inner.read(buf)
+        }
+    }
+
+    /// Writer that records every accepted byte and `flush` call.
+    #[derive(Default, Clone)]
+    struct RecordingWriter {
+        inner: Arc<Mutex<RecordingState>>,
+    }
+    #[derive(Default)]
+    struct RecordingState {
+        bytes: Vec<u8>,
+        flush_calls: usize,
+    }
+    impl RecordingWriter {
+        fn snapshot(&self) -> (Vec<u8>, usize) {
+            let s = self.inner.lock().unwrap();
+            (s.bytes.clone(), s.flush_calls)
+        }
+    }
+    impl Write for RecordingWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            let mut s = self.inner.lock().unwrap();
+            s.bytes.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            self.inner.lock().unwrap().flush_calls += 1;
+            Ok(())
+        }
+    }
+
+    /// Writer that raises `BrokenPipe` after `cap` bytes accepted.
+    struct BrokenPipeAfter {
+        accepted: usize,
+        cap: usize,
+    }
+    impl Write for BrokenPipeAfter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            if self.accepted >= self.cap {
+                return Err(io::Error::new(io::ErrorKind::BrokenPipe, "boom"));
+            }
+            let take = (self.cap - self.accepted).min(buf.len());
+            self.accepted += take;
+            Ok(take)
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Writer that accepts at most `chunk` bytes per call.
+    struct PartialWriter {
+        inner: Vec<u8>,
+        chunk: usize,
+    }
+    impl Write for PartialWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            let take = buf.len().min(self.chunk);
+            self.inner.extend_from_slice(&buf[..take]);
+            Ok(take)
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Writer that always returns `Ok(0)` — exercises the
+    /// `WriteZero` guard.
+    struct StallWriter;
+    impl Write for StallWriter {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Ok(0)
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Writer that returns `Interrupted` once before delegating.
+    struct InterruptOnceWriter {
+        sink: Vec<u8>,
+        tripped: bool,
+    }
+    impl Write for InterruptOnceWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            if !self.tripped {
+                self.tripped = true;
+                return Err(io::Error::new(io::ErrorKind::Interrupted, "trip"));
+            }
+            self.sink.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Writer that always returns `PermissionDenied`.
+    struct DenyWriter;
+    impl Write for DenyWriter {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::Error::new(io::ErrorKind::PermissionDenied, "nope"))
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    // ----- Tests -----
+
+    #[test]
+    fn spawn_forwarder_returns_reader_eof_with_byte_count() {
+        let payload = b"hello world".to_vec();
+        let writer = RecordingWriter::default();
+        let probe = writer.clone();
+        let exit = forward_blocking(Cursor::new(payload.clone()), writer).unwrap();
+        assert_eq!(exit, ForwarderExit::ReaderEof { bytes: 11 });
+        let (bytes, _) = probe.snapshot();
+        assert_eq!(bytes, payload);
+    }
+
+    #[test]
+    fn spawn_forwarder_returns_writer_closed_on_broken_pipe() {
+        let payload = vec![b'x'; 32];
+        let writer = BrokenPipeAfter {
+            accepted: 0,
+            cap: 5,
+        };
+        let exit = forward_blocking(Cursor::new(payload), writer).unwrap();
+        assert_eq!(exit, ForwarderExit::WriterClosed { bytes: 5 });
+    }
+
+    #[test]
+    fn spawn_forwarder_handles_partial_writes() {
+        let payload = vec![1u8; 17];
+        let writer = PartialWriter {
+            inner: Vec::new(),
+            chunk: 3,
+        };
+        // Move `writer` into the thread; we cannot probe its
+        // sink afterwards, so verify via byte count + EOF
+        // tag (writer policy guarantees no drops).
+        let exit = forward_blocking(Cursor::new(payload), writer).unwrap();
+        assert_eq!(exit, ForwarderExit::ReaderEof { bytes: 17 });
+    }
+
+    #[test]
+    fn spawn_forwarder_returns_write_zero_when_writer_stalls() {
+        let payload = vec![0u8; 4];
+        let err = forward_blocking(Cursor::new(payload), StallWriter).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::WriteZero);
+    }
+
+    #[test]
+    fn spawn_forwarder_retries_interrupted_reader() {
+        let reader = InterruptOnceReader {
+            inner: Cursor::new(b"abc".to_vec()),
+            tripped: false,
+        };
+        let writer = RecordingWriter::default();
+        let probe = writer.clone();
+        let exit = forward_blocking(reader, writer).unwrap();
+        assert_eq!(exit, ForwarderExit::ReaderEof { bytes: 3 });
+        assert_eq!(probe.snapshot().0, b"abc");
+    }
+
+    #[test]
+    fn spawn_forwarder_retries_interrupted_writer() {
+        let writer = InterruptOnceWriter {
+            sink: Vec::new(),
+            tripped: false,
+        };
+        let exit = forward_blocking(Cursor::new(b"abc".to_vec()), writer).unwrap();
+        assert_eq!(exit, ForwarderExit::ReaderEof { bytes: 3 });
+    }
+
+    #[test]
+    fn spawn_forwarder_propagates_other_writer_errors() {
+        let err = forward_blocking(Cursor::new(b"x".to_vec()), DenyWriter).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn spawn_forwarder_flushes_each_chunk() {
+        let writer = RecordingWriter::default();
+        let probe = writer.clone();
+        let _ = forward_blocking(Cursor::new(b"abc".to_vec()), writer).unwrap();
+        let (_, flushes) = probe.snapshot();
+        // At least one per-chunk flush must precede the EOF
+        // path; exact count depends on read chunking but >= 1.
+        assert!(flushes >= 1, "expected >=1 flush call, got {flushes}");
+    }
+
+    #[test]
+    fn forwarder_handle_carries_direction_tag() {
+        let h = spawn_forwarder(
+            Direction::ChildToHost,
+            Cursor::new(Vec::<u8>::new()),
+            Vec::<u8>::new(),
+        );
+        assert_eq!(h.direction, Direction::ChildToHost);
+        let _ = h.join.join().unwrap();
+    }
+}

--- a/src/pty/forward.rs
+++ b/src/pty/forward.rs
@@ -83,11 +83,19 @@ where
     loop {
         let n = match reader.read(&mut buf) {
             Ok(0) => {
-                // Final flush is best-effort: we are already
-                // terminating cleanly, so a flush error here
-                // does not change the outcome.
-                let _ = writer.flush();
-                return Ok(ForwarderExit::ReaderEof { bytes });
+                // EOF flush must NOT swallow errors: a buffered
+                // writer (e.g. line-buffered stdout wrapper)
+                // may stage bytes whose first failure point is
+                // this final flush. Classify it the same way
+                // the per-chunk flush does so callers see
+                // `WriterClosed` instead of a misleading
+                // `ReaderEof` when the consumer hung up while
+                // bytes were still pending.
+                return match flush_with_retry(writer) {
+                    FlushOutcome::Ok => Ok(ForwarderExit::ReaderEof { bytes }),
+                    FlushOutcome::WriterClosed => Ok(ForwarderExit::WriterClosed { bytes }),
+                    FlushOutcome::Err(e) => Err(e),
+                };
             }
             Ok(n) => n,
             Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
@@ -102,15 +110,34 @@ where
             Err(WriteOutcome::Err(e)) => return Err(e),
         }
         // Per-chunk flush so interactive prompts (no trailing
-        // newline) reach the consumer immediately. BrokenPipe
-        // here mirrors the writer policy.
-        match writer.flush() {
-            Ok(()) => {}
-            Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
-            Err(e) if e.kind() == io::ErrorKind::BrokenPipe => {
+        // newline) reach the consumer immediately. `Interrupted`
+        // is retried in a tight loop -- treating it as success
+        // would let EINTR from a signal indefinitely defer the
+        // flush until the next read returns, defeating the
+        // prompt-visibility guarantee.
+        match flush_with_retry(writer) {
+            FlushOutcome::Ok => {}
+            FlushOutcome::WriterClosed => {
                 return Ok(ForwarderExit::WriterClosed { bytes });
             }
-            Err(e) => return Err(e),
+            FlushOutcome::Err(e) => return Err(e),
+        }
+    }
+}
+
+enum FlushOutcome {
+    Ok,
+    WriterClosed,
+    Err(io::Error),
+}
+
+fn flush_with_retry<W: Write>(writer: &mut W) -> FlushOutcome {
+    loop {
+        match writer.flush() {
+            Ok(()) => return FlushOutcome::Ok,
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+            Err(e) if e.kind() == io::ErrorKind::BrokenPipe => return FlushOutcome::WriterClosed,
+            Err(e) => return FlushOutcome::Err(e),
         }
     }
 }
@@ -357,14 +384,102 @@ mod tests {
     }
 
     #[test]
-    fn spawn_forwarder_flushes_each_chunk() {
+    fn spawn_forwarder_flushes_at_least_once_per_chunk() {
+        // Strengthens the previous `>= 1` assertion. A
+        // single-byte cursor is read in (at most) one chunk
+        // before EOF; with per-chunk + EOF flush the count
+        // must be >= 2. A regression that drops the per-chunk
+        // flush would leave only the EOF flush and fail this.
         let writer = RecordingWriter::default();
         let probe = writer.clone();
-        let _ = forward_blocking(Cursor::new(b"abc".to_vec()), writer).unwrap();
+        let _ = forward_blocking(Cursor::new(b"a".to_vec()), writer).unwrap();
         let (_, flushes) = probe.snapshot();
-        // At least one per-chunk flush must precede the EOF
-        // path; exact count depends on read chunking but >= 1.
-        assert!(flushes >= 1, "expected >=1 flush call, got {flushes}");
+        assert!(
+            flushes >= 2,
+            "expected >=2 flush calls (per-chunk + EOF), got {flushes}"
+        );
+    }
+
+    #[test]
+    fn spawn_forwarder_retries_interrupted_flush() {
+        // Writer's flush returns Interrupted twice, then Ok.
+        // The forwarder must loop on EINTR; a regression that
+        // continues past Interrupted would lose the prompt-
+        // visibility guarantee but not surface here -- this
+        // test pins the retry by counting flush calls.
+        #[derive(Clone, Default)]
+        struct InterruptFlush {
+            inner: Arc<Mutex<InterruptFlushState>>,
+        }
+        #[derive(Default)]
+        struct InterruptFlushState {
+            sink: Vec<u8>,
+            flush_attempts: usize,
+        }
+        impl Write for InterruptFlush {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                self.inner.lock().unwrap().sink.extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                let mut s = self.inner.lock().unwrap();
+                s.flush_attempts += 1;
+                if s.flush_attempts <= 2 {
+                    Err(io::Error::new(io::ErrorKind::Interrupted, "trip"))
+                } else {
+                    Ok(())
+                }
+            }
+        }
+        let writer = InterruptFlush::default();
+        let probe = writer.inner.clone();
+        let exit = forward_blocking(Cursor::new(b"x".to_vec()), writer).unwrap();
+        assert_eq!(exit, ForwarderExit::ReaderEof { bytes: 1 });
+        // Per-chunk: 1 attempt fails (Interrupted), retried,
+        // then EOF flush succeeds. At minimum 3 attempts.
+        assert!(
+            probe.lock().unwrap().flush_attempts >= 3,
+            "expected flush retry on Interrupted, got {} attempts",
+            probe.lock().unwrap().flush_attempts
+        );
+    }
+
+    #[test]
+    fn spawn_forwarder_classifies_eof_flush_broken_pipe_as_writer_closed() {
+        // Buffered writers may stage bytes whose first error
+        // surfaces only at the final flush. Policy: EOF flush
+        // BrokenPipe -> WriterClosed (not silently ReaderEof).
+        struct BrokenPipeOnFlush;
+        impl Write for BrokenPipeOnFlush {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                Err(io::Error::new(io::ErrorKind::BrokenPipe, "boom"))
+            }
+        }
+        let exit = forward_blocking(Cursor::new(b"abc".to_vec()), BrokenPipeOnFlush).unwrap();
+        assert!(
+            matches!(exit, ForwarderExit::WriterClosed { .. }),
+            "expected WriterClosed, got {exit:?}"
+        );
+    }
+
+    #[test]
+    fn spawn_forwarder_propagates_eof_flush_other_errors() {
+        // Per-chunk flush short-circuits before EOF here
+        // (write succeeds, flush errors with PermissionDenied).
+        struct DenyOnFlush;
+        impl Write for DenyOnFlush {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                Err(io::Error::new(io::ErrorKind::PermissionDenied, "nope"))
+            }
+        }
+        let err = forward_blocking(Cursor::new(b"x".to_vec()), DenyOnFlush).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
     }
 
     #[test]

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -30,6 +30,7 @@
 //! by [`default_body`]; PR 5 (#26) wires them into the spawn
 //! call using the PR 2 spawn primitives.
 
+mod forward;
 mod size;
 mod spawn;
 

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -31,6 +31,7 @@
 //! call using the PR 2 spawn primitives.
 
 mod forward;
+mod pump;
 mod size;
 mod spawn;
 

--- a/src/pty/pump.rs
+++ b/src/pty/pump.rs
@@ -1,0 +1,62 @@
+//! Assemble the host↔child I/O pump over a [`SpawnedSession`].
+//!
+//! [`start_io_pump`] consumes the master writer and clones the
+//! master reader from a live PTY spawn, then hands them to
+//! [`super::forward::spawn_forwarder`] in both directions. The
+//! returned [`IoPump`] is a passive bundle of two
+//! [`super::forward::ForwarderHandle`]s; the wait/drain
+//! supervisor that converges them with the child wait is owned
+//! by PR 4 (#33).
+
+use std::io::{Read, Write};
+
+use crate::pty::forward::{spawn_forwarder, Direction, ForwarderHandle};
+use crate::pty::spawn::SpawnedSession;
+use crate::{Error, Result};
+
+/// Owning bundle of the host↔child forwarder threads.
+///
+/// Direction tags are preserved so PR 4's supervisor can
+/// attribute join failures (and decide drain ordering) without
+/// relying on field position.
+#[allow(dead_code)] // wired into default_body in PR 5 / #26
+pub(crate) struct IoPump {
+    pub(crate) host_to_child: ForwarderHandle,
+    pub(crate) child_to_host: ForwarderHandle,
+}
+
+/// Wire host stdio onto a live `SpawnedSession` and spawn both
+/// forwarder threads.
+///
+/// **Acquisition order matters**: the master reader is cloned
+/// FIRST, then the one-shot writer is taken. If we took the
+/// writer first and the subsequent `try_clone_reader()` failed,
+/// dropping that writer on the error path would prematurely
+/// signal EOF to the child — leaking a half-shutdown to the
+/// caller. Cloning first keeps `take_writer()` the single
+/// committing step.
+///
+/// Errors from portable-pty (handle acquisition, fd dup) flow
+/// through [`Error::Pty`], preserving the existing exit-code
+/// classification from `src/error.rs`.
+#[allow(dead_code)] // wired into default_body in PR 5 / #26
+pub(crate) fn start_io_pump<HIn, HOut>(
+    session: &mut SpawnedSession,
+    host_stdin: HIn,
+    host_stdout: HOut,
+) -> Result<IoPump>
+where
+    HIn: Read + Send + 'static,
+    HOut: Write + Send + 'static,
+{
+    let pty_reader = session.master.try_clone_reader().map_err(Error::Pty)?;
+    let pty_writer = session.master.take_writer().map_err(Error::Pty)?;
+
+    let host_to_child = spawn_forwarder(Direction::HostToChild, host_stdin, pty_writer);
+    let child_to_host = spawn_forwarder(Direction::ChildToHost, pty_reader, host_stdout);
+
+    Ok(IoPump {
+        host_to_child,
+        child_to_host,
+    })
+}

--- a/src/pty/pump.rs
+++ b/src/pty/pump.rs
@@ -206,4 +206,79 @@ mod real_pump {
             "expected 'hi' in captured output, got: {captured:?}"
         );
     }
+
+    // Issue #35 specifies that host stdin EOF must close the
+    // child's PTY so the wrapped command can exit. /bin/echo
+    // doesn't read stdin and therefore can't validate that
+    // semantics; /bin/cat does -- it stays alive until its
+    // PTY input EOFs. This test pins the host->child EOF
+    // propagation path end-to-end. We deliberately do NOT
+    // assert on captured bytes (PTY line discipline echoes
+    // input, making byte-level comparisons fragile); the
+    // contract under test is "host stdin Cursor drains ->
+    // host_to_child returns ReaderEof -> writer drops ->
+    // child observes EOF -> child exits cleanly within
+    // budget".
+    #[test]
+    fn pump_host_to_child_eof_makes_cat_exit() {
+        let mut session =
+            spawn_child(OsStr::new("/bin/cat"), &[], pty_size_80x24()).expect("spawn /bin/cat");
+
+        let mut killer = session.child.clone_killer();
+        let sink = SharedSink::default();
+        // Finite payload: cursor drains -> host_to_child EOFs
+        // -> writer drops -> cat sees EOT on slave -> exits.
+        let host_stdin = Cursor::new(b"hello\n".to_vec());
+
+        let pump = start_io_pump(&mut session, host_stdin, sink.clone()).expect("start_io_pump");
+
+        let wait_deadline = Instant::now() + WAIT_BUDGET;
+        let status = loop {
+            match session.child.try_wait() {
+                Ok(Some(s)) => break s,
+                Ok(None) => {
+                    if Instant::now() >= wait_deadline {
+                        let _ = killer.kill();
+                        panic!(
+                            "cat did not exit on host stdin EOF within {WAIT_BUDGET:?}; \
+                             host->child EOF propagation likely regressed"
+                        );
+                    }
+                    thread::sleep(WAIT_POLL);
+                }
+                Err(e) => {
+                    let _ = killer.kill();
+                    panic!("child wait failed: {e}");
+                }
+            }
+        };
+        drop(session);
+
+        let h2c = join_within(pump.host_to_child.join, JOIN_BUDGET, "host_to_child")
+            .expect("host_to_child returned io::Error");
+        let c2h = join_within(pump.child_to_host.join, JOIN_BUDGET, "child_to_host")
+            .expect("child_to_host returned io::Error");
+
+        assert!(status.success(), "cat exited non-zero: {status:?}");
+        assert_eq!(
+            h2c,
+            ForwarderExit::ReaderEof { bytes: 6 },
+            "host_to_child should drain the 6-byte cursor"
+        );
+        assert!(
+            matches!(
+                c2h,
+                ForwarderExit::ReaderEof { .. } | ForwarderExit::WriterClosed { .. }
+            ),
+            "unexpected child_to_host exit: {c2h:?}"
+        );
+        // Sanity: cat must have produced *some* bytes (echoed
+        // input under PTY line discipline). Don't pin the
+        // exact content -- termios cooked-mode echo is host-
+        // dependent.
+        assert!(
+            !sink.snapshot().is_empty(),
+            "cat produced no PTY output -- pump didn't forward anything"
+        );
+    }
 }

--- a/src/pty/pump.rs
+++ b/src/pty/pump.rs
@@ -60,3 +60,150 @@ where
         child_to_host,
     })
 }
+
+// Unix-only real-spawn integration smoke. Exercises
+// `start_io_pump` against a real `/bin/echo` child: empty
+// host stdin drains the host->child forwarder via ReaderEof,
+// while the child->host forwarder captures "hi" into a
+// shared sink and converges on the master reader's EOF when
+// `echo` exits.
+//
+// Mirrors the bounded-deadline pattern from
+// `tests/pty_smoke.rs` and `src/pty/spawn.rs::real_spawn`
+// (constants duplicated locally per repo convention --
+// rubber-duck-filtered finding #6 from PR 2).
+#[cfg(all(test, unix))]
+mod real_pump {
+    use super::*;
+    use crate::pty::spawn::spawn_child;
+    use portable_pty::PtySize;
+    use std::ffi::{OsStr, OsString};
+    use std::io::{self, Cursor};
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    use crate::pty::forward::ForwarderExit;
+
+    const JOIN_BUDGET: Duration = Duration::from_secs(5);
+    const WAIT_BUDGET: Duration = Duration::from_secs(5);
+    const WAIT_POLL: Duration = Duration::from_millis(20);
+
+    fn pty_size_80x24() -> PtySize {
+        PtySize {
+            cols: 80,
+            rows: 24,
+            pixel_width: 0,
+            pixel_height: 0,
+        }
+    }
+
+    /// Shared `Write` sink so the integration test can inspect
+    /// what the `child_to_host` forwarder produced after the
+    /// thread joins.
+    #[derive(Clone, Default)]
+    struct SharedSink {
+        inner: Arc<Mutex<Vec<u8>>>,
+    }
+    impl SharedSink {
+        fn snapshot(&self) -> Vec<u8> {
+            self.inner.lock().unwrap().clone()
+        }
+    }
+    impl io::Write for SharedSink {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.inner.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn join_within<T: Send + 'static>(
+        handle: std::thread::JoinHandle<T>,
+        budget: Duration,
+        label: &str,
+    ) -> T {
+        let deadline = Instant::now() + budget;
+        loop {
+            if handle.is_finished() {
+                return handle.join().unwrap_or_else(|_| panic!("{label} panicked"));
+            }
+            if Instant::now() >= deadline {
+                panic!("{label} did not finish within {budget:?}");
+            }
+            thread::sleep(WAIT_POLL);
+        }
+    }
+
+    #[test]
+    fn pump_round_trips_echo_output_with_empty_stdin() {
+        let mut session = spawn_child(
+            OsStr::new("/bin/echo"),
+            &[OsString::from("hi")],
+            pty_size_80x24(),
+        )
+        .expect("spawn /bin/echo");
+
+        let mut killer = session.child.clone_killer();
+        let sink = SharedSink::default();
+        let host_stdin = Cursor::new(Vec::<u8>::new()); // immediate EOF
+
+        let pump = start_io_pump(&mut session, host_stdin, sink.clone()).expect("start_io_pump");
+
+        // Bounded child wait: if echo regresses, kill it so
+        // the master reader unblocks and the child_to_host
+        // forwarder can return.
+        let wait_deadline = Instant::now() + WAIT_BUDGET;
+        let status = loop {
+            match session.child.try_wait() {
+                Ok(Some(s)) => break s,
+                Ok(None) => {
+                    if Instant::now() >= wait_deadline {
+                        let _ = killer.kill();
+                        panic!("child did not exit within {WAIT_BUDGET:?}");
+                    }
+                    thread::sleep(WAIT_POLL);
+                }
+                Err(e) => {
+                    let _ = killer.kill();
+                    panic!("child wait failed: {e}");
+                }
+            }
+        };
+        // Drop the master so any lingering reader sees EOF.
+        // `start_io_pump` consumed the writer; the cloned
+        // reader inside `child_to_host` releases when the
+        // master half is dropped.
+        drop(session);
+
+        let host_to_child_exit = join_within(pump.host_to_child.join, JOIN_BUDGET, "host_to_child");
+        let child_to_host_exit = join_within(pump.child_to_host.join, JOIN_BUDGET, "child_to_host");
+
+        assert!(status.success(), "child exited non-zero: {status:?}");
+
+        // Empty cursor -> immediate ReaderEof with zero bytes.
+        let h2c = host_to_child_exit.expect("host_to_child returned io::Error");
+        assert_eq!(h2c, ForwarderExit::ReaderEof { bytes: 0 });
+
+        // child_to_host can converge as either ReaderEof
+        // (clean cat exit -> master EOF) or WriterClosed
+        // (sink dropped its handle first); either is correct
+        // for a passive PR-3 forwarder.
+        let c2h = child_to_host_exit.expect("child_to_host returned io::Error");
+        assert!(
+            matches!(
+                c2h,
+                ForwarderExit::ReaderEof { .. } | ForwarderExit::WriterClosed { .. }
+            ),
+            "unexpected child_to_host exit: {c2h:?}"
+        );
+
+        let captured = String::from_utf8_lossy(&sink.snapshot()).into_owned();
+        assert!(
+            captured.contains("hi"),
+            "expected 'hi' in captured output, got: {captured:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 PR 3 of 6. Ships the I/O moving primitives that PR 4's wait/drain supervisor will wrap.

- `src/pty/forward.rs` — direction-tagged `spawn_forwarder` returning `ForwarderExit { ReaderEof | WriterClosed }`. 8 KiB stack buffer (matches `std::io::copy`), EINTR retry on both reader and writer, `write_all`-style partial-write loop with `Ok(0)` → `WriteZero`, per-chunk `flush()` so interactive prompts (no trailing newline) reach the consumer immediately, BrokenPipe classified as graceful `WriterClosed`.
- `src/pty/pump.rs` — `IoPump` assembly via `start_io_pump`. Acquires the master reader **before** taking the one-shot writer so a reader-clone failure cannot leak a half-shutdown by dropping an already-consumed writer. portable-pty handle errors flow through `Error::Pty`.
- Unix-only `real-echo` integration smoke pins the assembly end-to-end with the bounded-deadline / `clone_killer` pattern from `tests/pty_smoke.rs`.

`default_body` is unchanged — PR 5 (#26) wires the spawn + pump into the wrap session body.

Closes #35
Closes #36
Closes #23

## Why a `ForwarderExit` enum (not `u64` or `()`)

The supervisor in PR 4 needs to distinguish a natural reader EOF from a writer hang-up so it can decide whether to short-circuit drain on the *other* direction. Returning bare `Ok(bytes)` discards that information; `Err` for `BrokenPipe` mis-classifies a normal pipe-plumbing termination as a failure.

## Why a project-side preflight order on acquisition

`MasterPty::take_writer()` is one-shot. Cloning the reader first means a reader-clone failure leaves the writer untouched and the `SpawnedSession` retryable; cloning second would have us drop a consumed writer on the error path, prematurely signalling EOF to the child.

## Out of scope (handled in follow-up PRs)

- PR 4 (#33 + #24): session supervisor (wait/join/EOF/drain policy) and child exit-code mapping.
- PR 5 (#26): replace `default_body` stub with the real spawn + pump + supervisor wiring.
- PR 6 (#29-#31): non-TTY disarm.
- Windows ConPTY equivalent of the Unix integration smoke: inherits issue #84.

## Validation

All gates run locally (Rust stable + 1.78 MSRV):

- `cargo fmt --check` ✔
- `cargo clippy --all-targets --all-features -- -D warnings` ✔
- `cargo test --all-targets --all-features` ✔ (235 tests pass: 209 lib + 26 integration)
- `cargo +1.78 check --locked --all-targets --all-features` ✔
- `cargo deny check` ✔ (advisories ok, bans ok, licenses ok, sources ok)

## Rubber-duck pre-implementation pass

Adopted findings: prompt flush per chunk (1), partial-write/`Ok(0)` handling (2), reader-before-writer acquisition order (3), corrected `master` field name (4), deadline-bounded join with `clone_killer` watchdog (5), per-item `#[allow(dead_code)]` annotations to keep clippy `-D warnings` green until PR 5 wiring (6), `ForwarderExit` enum so PR 4 keeps termination-reason information (7). Over-scoped fake-trait test seam dropped (9).

## Recommended next

PR 4 — `feat/pty-session-lifecycle` (#33 + #24): wire `IoPump` into a wait/drain supervisor and map `Child::wait` into `ExitCode`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Introduced internal PTY I/O forwarding infrastructure to support bidirectional communication between host and child processes with improved reliability and error detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->