### PR TITLE
feat(pty): wait+drain supervisor + ExitStatus mapping

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -57,6 +57,11 @@ words:
   - qorrection
   - qwen
   - rexpect
+  - sigcld
+  - sigpoll
+  - sigpwr
+  - sigstkflt
+  - sigunused
   - swatinem
   - toctou
   - xclaude

--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -48,6 +48,7 @@ words:
   - embark
   - greppable
   - hsomething
+  - illumos
   - kito
   - jvim
   - kyuukyuu

--- a/src/pty/exit.rs
+++ b/src/pty/exit.rs
@@ -91,12 +91,17 @@ fn classify_signal_name(name: &str) -> i32 {
 ///
 /// Returns `None` on non-Unix targets (where `signal()` is
 /// always `None` anyway, so this branch is unreachable in
-/// practice) or when no signum in `1..=64` produces a matching
-/// name.
+/// practice) or when no signum in the platform's signal range
+/// produces a matching name. The upper bound is `SIGRTMAX()`
+/// on platforms that expose it (Linux, Solaris, Hurd) so RT
+/// signals are covered, and a generous static fallback (96)
+/// elsewhere — comfortably above every Unix signal table I've
+/// seen (AIX = 57; macOS / *BSD = 32).
 #[cfg(unix)]
 fn lookup_via_strsignal(name: &str) -> Option<i32> {
     use std::ffi::CStr;
-    for n in 1..=64i32 {
+    let upper = max_signum_probe();
+    for n in 1..=upper {
         // SAFETY: `libc::strsignal` returns a pointer into a
         // statically-allocated, NUL-terminated, immutable string
         // owned by libc. We borrow it for the duration of the
@@ -118,6 +123,33 @@ fn lookup_via_strsignal(name: &str) -> Option<i32> {
     None
 }
 
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "solaris",
+    target_os = "illumos",
+    target_os = "hurd",
+))]
+fn max_signum_probe() -> i32 {
+    // SIGRTMAX is exposed as a safe `extern fn` (no parameters,
+    // no preconditions) on Linux/Solaris/Hurd in `libc`.
+    libc::SIGRTMAX()
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "solaris",
+    target_os = "illumos",
+    target_os = "hurd",
+)))]
+fn max_signum_probe() -> i32 {
+    // Generous static fallback for targets without SIGRTMAX().
+    // Comfortably above every Unix signal table observed in
+    // practice (AIX = 57; macOS / *BSD = 32).
+    96
+}
+
 #[cfg(not(unix))]
 fn lookup_via_strsignal(_name: &str) -> Option<i32> {
     None
@@ -127,49 +159,81 @@ fn lookup_via_strsignal(_name: &str) -> Option<i32> {
 /// where the cached name was produced under a different locale
 /// than the current one.
 ///
-/// The mapping uses Linux `signal(7)` numbering. `SIGSTKFLT`,
-/// `SIGCLD`, `SIGPOLL`, `SIGUNUSED`, etc. are intentionally
-/// omitted — they are aliases or non-POSIX, and a downstream
-/// caller that cares can extend this table.
+/// Uses `libc::SIG*` constants rather than hardcoded Linux
+/// signal numbers, so the mapping is correct on macOS and other
+/// BSD-family targets where signal numbering diverges (e.g.
+/// SIGSYS = 12 on macOS, 31 on Linux). Signals that don't exist
+/// on every Unix target are `cfg`-gated. `SIGSTKFLT`, `SIGCLD`,
+/// `SIGPOLL`, `SIGUNUSED`, etc. are intentionally omitted —
+/// they are aliases or non-POSIX, and a downstream caller that
+/// cares can extend this table.
+#[cfg(unix)]
 fn lookup_english_posix(name: &str) -> Option<i32> {
     // strsignal often prints "Hangup", "Interrupt", "Terminated"
     // — full English words rather than the SIG* tokens — so we
     // accept both spellings and a couple of common variants.
     let lowered = name.to_ascii_lowercase();
-    let n = match lowered.as_str() {
-        "hangup" | "sighup" => 1,
-        "interrupt" | "sigint" => 2,
-        "quit" | "sigquit" => 3,
-        "illegal instruction" | "sigill" => 4,
-        "trace/breakpoint trap" | "trace trap" | "sigtrap" => 5,
-        "aborted" | "abort" | "sigabrt" => 6,
-        "bus error" | "sigbus" => 7,
-        "floating point exception" | "floating-point exception" | "sigfpe" => 8,
-        "killed" | "sigkill" => 9,
-        "user defined signal 1" | "sigusr1" => 10,
-        "segmentation fault" | "sigsegv" => 11,
-        "user defined signal 2" | "sigusr2" => 12,
-        "broken pipe" | "sigpipe" => 13,
-        "alarm clock" | "sigalrm" => 14,
-        "terminated" | "sigterm" => 15,
-        "child exited" | "sigchld" => 17,
-        "continued" | "sigcont" => 18,
-        "stopped (signal)" | "sigstop" => 19,
-        "stopped" | "sigtstp" => 20,
-        "stopped (tty input)" | "sigttin" => 21,
-        "stopped (tty output)" | "sigttou" => 22,
-        "urgent i/o condition" | "sigurg" => 23,
-        "cpu time limit exceeded" | "sigxcpu" => 24,
-        "file size limit exceeded" | "sigxfsz" => 25,
-        "virtual timer expired" | "sigvtalrm" => 26,
-        "profiling timer expired" | "sigprof" => 27,
-        "window changed" | "sigwinch" => 28,
-        "i/o possible" | "sigio" => 29,
-        "power failure" | "sigpwr" => 30,
-        "bad system call" | "sigsys" => 31,
-        _ => return None,
-    };
-    Some(n)
+    let candidates: &[(&[&str], i32)] = &[
+        (&["hangup", "sighup"], libc::SIGHUP),
+        (&["interrupt", "sigint"], libc::SIGINT),
+        (&["quit", "sigquit"], libc::SIGQUIT),
+        (&["illegal instruction", "sigill"], libc::SIGILL),
+        (
+            &["trace/breakpoint trap", "trace trap", "sigtrap"],
+            libc::SIGTRAP,
+        ),
+        (&["aborted", "abort", "sigabrt"], libc::SIGABRT),
+        (&["bus error", "sigbus"], libc::SIGBUS),
+        (
+            &[
+                "floating point exception",
+                "floating-point exception",
+                "sigfpe",
+            ],
+            libc::SIGFPE,
+        ),
+        (&["killed", "sigkill"], libc::SIGKILL),
+        (&["user defined signal 1", "sigusr1"], libc::SIGUSR1),
+        (&["segmentation fault", "sigsegv"], libc::SIGSEGV),
+        (&["user defined signal 2", "sigusr2"], libc::SIGUSR2),
+        (&["broken pipe", "sigpipe"], libc::SIGPIPE),
+        (&["alarm clock", "sigalrm"], libc::SIGALRM),
+        (&["terminated", "sigterm"], libc::SIGTERM),
+        (&["child exited", "sigchld"], libc::SIGCHLD),
+        (&["continued", "sigcont"], libc::SIGCONT),
+        (&["stopped (signal)", "sigstop"], libc::SIGSTOP),
+        (&["stopped", "sigtstp"], libc::SIGTSTP),
+        (&["stopped (tty input)", "sigttin"], libc::SIGTTIN),
+        (&["stopped (tty output)", "sigttou"], libc::SIGTTOU),
+        (&["urgent i/o condition", "sigurg"], libc::SIGURG),
+        (&["cpu time limit exceeded", "sigxcpu"], libc::SIGXCPU),
+        (&["file size limit exceeded", "sigxfsz"], libc::SIGXFSZ),
+        (&["virtual timer expired", "sigvtalrm"], libc::SIGVTALRM),
+        (&["profiling timer expired", "sigprof"], libc::SIGPROF),
+        (&["window changed", "sigwinch"], libc::SIGWINCH),
+        (&["i/o possible", "sigio"], libc::SIGIO),
+        (&["bad system call", "sigsys"], libc::SIGSYS),
+    ];
+    for (names, sig) in candidates {
+        if names.contains(&lowered.as_str()) {
+            return Some(*sig);
+        }
+    }
+    // SIGPWR is Linux/Android-specific; gate separately rather
+    // than `cfg`-attribute the table entry, which the
+    // const-context restrictions of slice literals don't allow.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        if matches!(lowered.as_str(), "power failure" | "sigpwr") {
+            return Some(libc::SIGPWR);
+        }
+    }
+    None
+}
+
+#[cfg(not(unix))]
+fn lookup_english_posix(_name: &str) -> Option<i32> {
+    None
 }
 
 /// Layer 3 — parse `"Signal N"` (the literal fallback

--- a/src/pty/exit.rs
+++ b/src/pty/exit.rs
@@ -334,6 +334,16 @@ mod tests {
         use std::ffi::CStr;
         for n in 1..=31i32 {
             let name = unsafe {
+                // SAFETY: `libc::strsignal(n)` is a thread-safe
+                // POSIX inquiry returning either a NULL pointer
+                // (handled below) or a pointer to a process- or
+                // thread-local static C string that remains
+                // valid until the next strsignal call on the
+                // same thread. We do not call strsignal again
+                // before consuming the pointer, so the returned
+                // `*const c_char` is valid for `CStr::from_ptr`,
+                // which copies the bytes into an owned String
+                // before the borrow ends.
                 let ptr = libc::strsignal(n);
                 if ptr.is_null() {
                     continue;

--- a/src/pty/exit.rs
+++ b/src/pty/exit.rs
@@ -56,7 +56,6 @@ use crate::{Error, Result};
 /// POSIX `WEXITSTATUS` macro (which discards the upper bits of
 /// the wait-status word). Values above 255 are exotic and
 /// usually a bug in the child anyway.
-#[allow(dead_code)] // wired into the supervisor in the next commit (#33)
 pub(crate) fn map_exit_status(status: ExitStatus) -> Result<ExitCode> {
     if let Some(name) = status.signal() {
         let signum = classify_signal_name(name);

--- a/src/pty/exit.rs
+++ b/src/pty/exit.rs
@@ -1,0 +1,290 @@
+//! Map [`portable_pty::ExitStatus`] to [`std::process::ExitCode`].
+//!
+//! `portable-pty` reports the wrapped child's outcome via
+//! [`portable_pty::ExitStatus`], which carries either an exit
+//! code (`u32`) or a *locale-dependent* signal name string
+//! produced by `libc::strsignal()` on Unix
+//! (or the literal `"Signal N"` fallback when `strsignal`
+//! returns null). Our public boundary type
+//! [`crate::Error::Signal`] needs the raw signal *number*, not
+//! a locale-dependent string. This module isolates that mapping
+//! so the supervisor in [`super::session`] stays a pure I/O
+//! state machine.
+//!
+//! ## Recovering the signum from the signal name
+//!
+//! Three classification layers, tried in order:
+//!
+//! 1. **`#[cfg(unix)]` dynamic same-locale reverse lookup.**
+//!    Iterate `1..=64` and compare
+//!    `unsafe { libc::strsignal(n) }` (rendered as a `String`
+//!    via `CStr`) against the reported name. Because
+//!    `portable-pty` itself produced the name with the *same*
+//!    `strsignal` in the *same* process locale, this round-trips
+//!    deterministically when the running locale is consistent
+//!    (the common case).
+//! 2. **English POSIX-name allowlist.** Some distributions or
+//!    embedded contexts may have already cached a name from a
+//!    different locale (e.g. via a thread that switched locale,
+//!    or a pre-baked test status). The static allowlist covers
+//!    every signal whose POSIX name fits in a small table
+//!    (HUP, INT, …, SYS).
+//! 3. **`"Signal N"` numeric parse.** The literal fallback
+//!    portable-pty emits when `strsignal` returns null.
+//!
+//! Only the genuinely unreachable defensive branch falls through
+//! to `signum = 0` — see [`crate::Error::exit_code`] which maps
+//! that to exit `128` (POSIX "killed by signal 0", a defined
+//! sentinel rather than wrapping or panicking).
+
+use std::process::ExitCode;
+
+use portable_pty::ExitStatus;
+
+use crate::{Error, Result};
+
+/// Map a [`portable_pty::ExitStatus`] to either an
+/// [`ExitCode`] (clean exit) or [`Error::Signal`] (signal death).
+///
+/// Pure function — no I/O, no globals beyond `libc::strsignal`
+/// (which is process-wide but not mutated here).
+///
+/// # Truncation
+///
+/// `ExitStatus::exit_code()` is `u32` but `ExitCode` is `u8`
+/// on most platforms. We truncate via `& 0xFF`, matching the
+/// POSIX `WEXITSTATUS` macro (which discards the upper bits of
+/// the wait-status word). Values above 255 are exotic and
+/// usually a bug in the child anyway.
+#[allow(dead_code)] // wired into the supervisor in the next commit (#33)
+pub(crate) fn map_exit_status(status: ExitStatus) -> Result<ExitCode> {
+    if let Some(name) = status.signal() {
+        let signum = classify_signal_name(name);
+        return Err(Error::Signal { signum });
+    }
+    if status.success() {
+        return Ok(ExitCode::SUCCESS);
+    }
+    Ok(ExitCode::from((status.exit_code() & 0xFF) as u8))
+}
+
+/// Try to recover a raw signal number from a
+/// `portable_pty::ExitStatus::signal()` string.
+///
+/// Returns `0` when no layer can classify the input — see
+/// the module-level docs for the rationale.
+fn classify_signal_name(name: &str) -> i32 {
+    if let Some(n) = lookup_via_strsignal(name) {
+        return n;
+    }
+    if let Some(n) = lookup_english_posix(name) {
+        return n;
+    }
+    if let Some(n) = parse_signal_n_literal(name) {
+        return n;
+    }
+    0
+}
+
+/// Layer 1 — `#[cfg(unix)]` round-trip through `libc::strsignal`
+/// in the current locale.
+///
+/// Returns `None` on non-Unix targets (where `signal()` is
+/// always `None` anyway, so this branch is unreachable in
+/// practice) or when no signum in `1..=64` produces a matching
+/// name.
+#[cfg(unix)]
+fn lookup_via_strsignal(name: &str) -> Option<i32> {
+    use std::ffi::CStr;
+    for n in 1..=64i32 {
+        // SAFETY: `libc::strsignal` returns a pointer into a
+        // statically-allocated, NUL-terminated, immutable string
+        // owned by libc. We borrow it for the duration of the
+        // `CStr::from_ptr` call and immediately copy via
+        // `to_string_lossy().into_owned()`, so no aliasing or
+        // lifetime issue can leak. A null return is treated as
+        // "no name available for this signum" and skipped.
+        let rendered = unsafe {
+            let ptr = libc::strsignal(n);
+            if ptr.is_null() {
+                continue;
+            }
+            CStr::from_ptr(ptr).to_string_lossy().into_owned()
+        };
+        if rendered == name {
+            return Some(n);
+        }
+    }
+    None
+}
+
+#[cfg(not(unix))]
+fn lookup_via_strsignal(_name: &str) -> Option<i32> {
+    None
+}
+
+/// Layer 2 — small POSIX English-name allowlist for the case
+/// where the cached name was produced under a different locale
+/// than the current one.
+///
+/// The mapping uses Linux `signal(7)` numbering. `SIGSTKFLT`,
+/// `SIGCLD`, `SIGPOLL`, `SIGUNUSED`, etc. are intentionally
+/// omitted — they are aliases or non-POSIX, and a downstream
+/// caller that cares can extend this table.
+fn lookup_english_posix(name: &str) -> Option<i32> {
+    // strsignal often prints "Hangup", "Interrupt", "Terminated"
+    // — full English words rather than the SIG* tokens — so we
+    // accept both spellings and a couple of common variants.
+    let lowered = name.to_ascii_lowercase();
+    let n = match lowered.as_str() {
+        "hangup" | "sighup" => 1,
+        "interrupt" | "sigint" => 2,
+        "quit" | "sigquit" => 3,
+        "illegal instruction" | "sigill" => 4,
+        "trace/breakpoint trap" | "trace trap" | "sigtrap" => 5,
+        "aborted" | "abort" | "sigabrt" => 6,
+        "bus error" | "sigbus" => 7,
+        "floating point exception" | "floating-point exception" | "sigfpe" => 8,
+        "killed" | "sigkill" => 9,
+        "user defined signal 1" | "sigusr1" => 10,
+        "segmentation fault" | "sigsegv" => 11,
+        "user defined signal 2" | "sigusr2" => 12,
+        "broken pipe" | "sigpipe" => 13,
+        "alarm clock" | "sigalrm" => 14,
+        "terminated" | "sigterm" => 15,
+        "child exited" | "sigchld" => 17,
+        "continued" | "sigcont" => 18,
+        "stopped (signal)" | "sigstop" => 19,
+        "stopped" | "sigtstp" => 20,
+        "stopped (tty input)" | "sigttin" => 21,
+        "stopped (tty output)" | "sigttou" => 22,
+        "urgent i/o condition" | "sigurg" => 23,
+        "cpu time limit exceeded" | "sigxcpu" => 24,
+        "file size limit exceeded" | "sigxfsz" => 25,
+        "virtual timer expired" | "sigvtalrm" => 26,
+        "profiling timer expired" | "sigprof" => 27,
+        "window changed" | "sigwinch" => 28,
+        "i/o possible" | "sigio" => 29,
+        "power failure" | "sigpwr" => 30,
+        "bad system call" | "sigsys" => 31,
+        _ => return None,
+    };
+    Some(n)
+}
+
+/// Layer 3 — parse `"Signal N"` (the literal fallback
+/// `portable-pty` emits when `strsignal` returns null).
+fn parse_signal_n_literal(name: &str) -> Option<i32> {
+    let suffix = name.strip_prefix("Signal ")?;
+    suffix.trim().parse::<i32>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clean_exit_zero_maps_to_success() {
+        let status = ExitStatus::with_exit_code(0);
+        let code = map_exit_status(status).expect("clean exit must be Ok");
+        // `ExitCode` has no `Eq`, so compare via debug repr.
+        assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::SUCCESS));
+    }
+
+    #[test]
+    fn nonzero_exit_passes_through_truncated() {
+        let status = ExitStatus::with_exit_code(7);
+        let code = map_exit_status(status).expect("nonzero clean exit must be Ok");
+        assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::from(7)));
+    }
+
+    #[test]
+    fn exit_255_is_boundary() {
+        let status = ExitStatus::with_exit_code(255);
+        let code = map_exit_status(status).expect("255 must be Ok");
+        assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::from(255)));
+    }
+
+    #[test]
+    fn exit_256_truncates_to_zero() {
+        // Documented behavior: WEXITSTATUS-style truncation.
+        let status = ExitStatus::with_exit_code(256);
+        let code = map_exit_status(status).expect("256 must be Ok");
+        assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::from(0)));
+    }
+
+    #[test]
+    fn english_terminated_maps_to_15() {
+        let status = ExitStatus::with_signal("Terminated");
+        let err = map_exit_status(status).expect_err("signal must be Err");
+        assert!(matches!(err, Error::Signal { signum: 15 }));
+    }
+
+    #[test]
+    fn english_killed_maps_to_9() {
+        let status = ExitStatus::with_signal("Killed");
+        let err = map_exit_status(status).expect_err("signal must be Err");
+        assert!(matches!(err, Error::Signal { signum: 9 }));
+    }
+
+    #[test]
+    fn english_hangup_maps_to_1() {
+        let status = ExitStatus::with_signal("Hangup");
+        let err = map_exit_status(status).expect_err("signal must be Err");
+        assert!(matches!(err, Error::Signal { signum: 1 }));
+    }
+
+    #[test]
+    fn english_interrupt_maps_to_2() {
+        let status = ExitStatus::with_signal("Interrupt");
+        let err = map_exit_status(status).expect_err("signal must be Err");
+        assert!(matches!(err, Error::Signal { signum: 2 }));
+    }
+
+    #[test]
+    fn signal_n_literal_parses() {
+        let status = ExitStatus::with_signal("Signal 17");
+        let err = map_exit_status(status).expect_err("signal must be Err");
+        assert!(matches!(err, Error::Signal { signum: 17 }));
+    }
+
+    #[test]
+    fn weird_locale_string_falls_through_to_zero() {
+        let status = ExitStatus::with_signal("ZZZ totally bogus name ZZZ");
+        let err = map_exit_status(status).expect_err("signal must be Err");
+        assert!(matches!(err, Error::Signal { signum: 0 }));
+    }
+
+    /// Round-trip guard for layer 1: every signum in `1..=31`
+    /// whose `strsignal` returns a non-null, non-empty name
+    /// must reverse-lookup to itself in the *current* locale.
+    /// This pins the production code path against silent
+    /// regressions in the strsignal table or future glibc
+    /// updates.
+    #[cfg(unix)]
+    #[test]
+    fn strsignal_round_trip_recovers_signum() {
+        use std::ffi::CStr;
+        for n in 1..=31i32 {
+            let name = unsafe {
+                let ptr = libc::strsignal(n);
+                if ptr.is_null() {
+                    continue;
+                }
+                CStr::from_ptr(ptr).to_string_lossy().into_owned()
+            };
+            if name.is_empty() {
+                continue;
+            }
+            let status = ExitStatus::with_signal(&name);
+            let err = map_exit_status(status).expect_err("must be Err");
+            match err {
+                Error::Signal { signum } => assert_eq!(
+                    signum, n,
+                    "signum {n} round-tripped via strsignal name {name:?} → {signum}"
+                ),
+                other => panic!("expected Signal, got {other:?}"),
+            }
+        }
+    }
+}

--- a/src/pty/exit.rs
+++ b/src/pty/exit.rs
@@ -276,6 +276,7 @@ mod tests {
         assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::from(0)));
     }
 
+    #[cfg(unix)]
     #[test]
     fn english_terminated_maps_to_15() {
         let status = ExitStatus::with_signal("Terminated");
@@ -283,6 +284,7 @@ mod tests {
         assert!(matches!(err, Error::Signal { signum: 15 }));
     }
 
+    #[cfg(unix)]
     #[test]
     fn english_killed_maps_to_9() {
         let status = ExitStatus::with_signal("Killed");
@@ -290,6 +292,7 @@ mod tests {
         assert!(matches!(err, Error::Signal { signum: 9 }));
     }
 
+    #[cfg(unix)]
     #[test]
     fn english_hangup_maps_to_1() {
         let status = ExitStatus::with_signal("Hangup");
@@ -297,6 +300,7 @@ mod tests {
         assert!(matches!(err, Error::Signal { signum: 1 }));
     }
 
+    #[cfg(unix)]
     #[test]
     fn english_interrupt_maps_to_2() {
         let status = ExitStatus::with_signal("Interrupt");

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -30,6 +30,7 @@
 //! by [`default_body`]; PR 5 (#26) wires them into the spawn
 //! call using the PR 2 spawn primitives.
 
+mod exit;
 mod forward;
 mod pump;
 mod size;

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -33,6 +33,7 @@
 mod exit;
 mod forward;
 mod pump;
+mod session;
 mod size;
 mod spawn;
 

--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -811,7 +811,18 @@ mod real_session {
         let sink = SharedSink::default();
         let pump = start_io_pump(&mut session, Cursor::new(host_stdin), sink.clone())
             .expect("start_io_pump");
-        let result = run_pump_session(session, pump);
+        let result = run_pump_session_with(
+            PtyChild {
+                child: session.child,
+            },
+            pump,
+            supervisor_deadlines(),
+        );
+        // Keep `master` alive until after the supervisor returns
+        // (mirrors the run_pump_session contract that the master
+        // must outlive the wait/drain phase) by binding it
+        // explicitly here, then dropping it at the end of scope.
+        drop(session.master);
         (result, sink.snapshot())
     }
 
@@ -853,7 +864,15 @@ mod real_session {
         // sends SIGHUP (verified in portable-pty 0.9.0
         // src/lib.rs:328), not SIGTERM, so we expect signum=1.
         term.kill().expect("send SIGHUP to child via clone_killer");
-        let res = run_pump_session(session, pump);
+        let res = run_pump_session_with(
+            PtyChild {
+                child: session.child,
+            },
+            pump,
+            supervisor_deadlines(),
+        );
+        // Keep `master` alive across the supervisor call.
+        drop(session.master);
         let err = res.expect_err("signal death must be Err");
         match err {
             Error::Signal { signum } => assert_eq!(
@@ -890,13 +909,5 @@ mod real_session {
             s.contains("hello"),
             "buffered child output truncated: captured = {s:?}"
         );
-    }
-
-    // Suppress warnings for unused supervisor_deadlines until a
-    // future test needs the custom budget shape; production
-    // entry uses Deadlines::production() under the hood.
-    #[allow(dead_code)]
-    fn _keep_deadlines_used() -> Deadlines {
-        supervisor_deadlines()
     }
 }

--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -234,10 +234,12 @@ where
                 return Err(wrap_io("forwarder failed; kill escalation failed", e));
             }
             let wait_outcome = child.wait();
-            // The wait succeeded (or definitively failed): the
-            // guard's job is done either way.
-            guard.disarm();
-            if let Err(e) = wait_outcome {
+            // Only disarm when wait() actually consumed a status;
+            // a failed wait() means the child may still be alive,
+            // in which case drop() should retry the kill.
+            if wait_outcome.is_ok() {
+                guard.disarm();
+            } else if let Err(e) = &wait_outcome {
                 tracing::warn!(error = %e, "supervisor: wait() after kill failed");
             }
             // Pull the actual io::Error out for the Pty wrapper.
@@ -457,7 +459,7 @@ mod tests {
             s.kills += 1;
             // Once killed, status becomes SIGTERM and try_wait
             // returns immediately on the next call.
-            s.scheduled = ExitStatus::with_signal("Terminated");
+            s.scheduled = ExitStatus::with_signal("Signal 15");
             s.polls_remaining = 0;
             Ok(())
         }
@@ -500,7 +502,7 @@ mod tests {
         struct ForeverReader;
         impl io::Read for ForeverReader {
             fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
-                std::thread::sleep(Duration::from_secs(60));
+                std::thread::sleep(Duration::from_millis(200));
                 Ok(0)
             }
         }
@@ -545,7 +547,7 @@ mod tests {
 
     #[test]
     fn signal_status_propagates_as_signal_error() {
-        let child = MockChild::new(ExitStatus::with_signal("Terminated"), 0);
+        let child = MockChild::new(ExitStatus::with_signal("Signal 15"), 0);
         let err = run_pump_session_with(child, quiet_pump(), fast_deadlines())
             .expect_err("signal must be Err");
         assert!(matches!(err, Error::Signal { signum: 15 }));
@@ -615,7 +617,7 @@ mod tests {
                 }
                 // Subsequent reads block forever to avoid
                 // races where the reader EOFs first.
-                std::thread::sleep(Duration::from_secs(60));
+                std::thread::sleep(Duration::from_millis(200));
                 Ok(0)
             }
         }

--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -81,6 +81,13 @@ pub(crate) struct Deadlines {
     /// supervisor from busy-looping; small enough that signal
     /// death is observed promptly.
     pub wait_poll: Duration,
+    /// After the supervisor escalates a kill, how long it polls
+    /// `try_wait()` before giving up. Bounds the failure path
+    /// when a child catches/ignores the kill signal — without
+    /// this, a blocking `child.wait()` could hang indefinitely
+    /// and defeat the coupled-state-machine convergence
+    /// guarantee.
+    pub post_kill_wait_budget: Duration,
 }
 
 impl Deadlines {
@@ -94,6 +101,7 @@ impl Deadlines {
             child_wait_deadline: None,
             forwarder_join_budget: Duration::from_secs(5),
             wait_poll: Duration::from_millis(20),
+            post_kill_wait_budget: Duration::from_secs(5),
         }
     }
 }
@@ -262,9 +270,18 @@ where
                 // still running and drop() is the last defense.
                 return Err(wrap_io("stalled supervisor; kill escalation failed", e));
             }
-            match child.wait() {
-                Ok(s) => break s,
-                Err(e) => return Err(wrap_io("child wait after kill", e)),
+            match wait_with_budget(
+                &mut child,
+                deadlines.post_kill_wait_budget,
+                deadlines.wait_poll,
+            )? {
+                Some(s) => break s,
+                None => {
+                    return Err(wrap_io(
+                        "stalled supervisor; child did not exit within post-kill budget",
+                        io::Error::new(io::ErrorKind::TimedOut, "post-kill wait budget exceeded"),
+                    ));
+                }
             }
         }
 
@@ -277,9 +294,21 @@ where
                     // still running and drop() is the last defense.
                     return Err(wrap_io("deadline reached; kill escalation failed", e));
                 }
-                match child.wait() {
-                    Ok(s) => break s,
-                    Err(e) => return Err(wrap_io("child wait after deadline kill", e)),
+                match wait_with_budget(
+                    &mut child,
+                    deadlines.post_kill_wait_budget,
+                    deadlines.wait_poll,
+                )? {
+                    Some(s) => break s,
+                    None => {
+                        return Err(wrap_io(
+                            "deadline reached; child did not exit within post-kill budget",
+                            io::Error::new(
+                                io::ErrorKind::TimedOut,
+                                "post-kill wait budget exceeded",
+                            ),
+                        ));
+                    }
                 }
             }
         }
@@ -314,6 +343,29 @@ fn escalate_kill<C: SupervisedChild>(child: &mut C) -> io::Result<()> {
         return Err(e);
     }
     Ok(())
+}
+
+/// Bounded post-kill wait: poll `try_wait()` for up to `budget`,
+/// sleeping `poll` between ticks. Returns `Ok(Some(status))` if
+/// the child exits in time, `Ok(None)` if the budget elapses
+/// (caller surfaces a timeout), or `Err` on a `try_wait` failure.
+fn wait_with_budget<C: SupervisedChild>(
+    child: &mut C,
+    budget: Duration,
+    poll: Duration,
+) -> Result<Option<ExitStatus>> {
+    let deadline = Instant::now() + budget;
+    loop {
+        match child.try_wait() {
+            Ok(Some(s)) => return Ok(Some(s)),
+            Ok(None) => {}
+            Err(e) => return Err(wrap_io("child try_wait after kill", e)),
+        }
+        if Instant::now() >= deadline {
+            return Ok(None);
+        }
+        std::thread::sleep(poll);
+    }
 }
 
 /// Non-blocking peek + extract. If the handle is finished, join
@@ -475,6 +527,7 @@ mod tests {
             child_wait_deadline: Some(Duration::from_secs(2)),
             forwarder_join_budget: Duration::from_millis(500),
             wait_poll: Duration::from_millis(2),
+            post_kill_wait_budget: Duration::from_millis(500),
         }
     }
 
@@ -582,6 +635,7 @@ mod tests {
             child_wait_deadline: Some(Duration::from_secs(2)),
             forwarder_join_budget: Duration::from_millis(50),
             wait_poll: Duration::from_millis(2),
+            post_kill_wait_budget: Duration::from_millis(500),
         };
         // Catch the "both forwarders finish" escalation by NOT
         // letting them finish — but quiet pump finishes
@@ -778,6 +832,7 @@ mod real_session {
             child_wait_deadline: Some(WAIT_BUDGET),
             forwarder_join_budget: JOIN_BUDGET,
             wait_poll: WAIT_POLL,
+            post_kill_wait_budget: WAIT_BUDGET,
         }
     }
 

--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -713,3 +713,163 @@ mod tests {
         drop(pump.child_to_host);
     }
 }
+
+// Real-PTY integration tests for the supervisor. Mirrors the
+// bounded-deadline pattern from `tests/pty_smoke.rs`,
+// `src/pty/spawn.rs::real_spawn`, and `src/pty/pump.rs::real_pump`
+// (constants duplicated locally per repo convention).
+#[cfg(all(test, unix))]
+mod real_session {
+    use super::*;
+    use crate::pty::pump::start_io_pump;
+    use crate::pty::spawn::spawn_child;
+    use portable_pty::PtySize;
+    use std::ffi::{OsStr, OsString};
+    use std::io::Cursor;
+    use std::sync::{Arc, Mutex};
+
+    const JOIN_BUDGET: Duration = Duration::from_secs(5);
+    const WAIT_BUDGET: Duration = Duration::from_secs(5);
+    const WAIT_POLL: Duration = Duration::from_millis(20);
+
+    fn pty_size_80x24() -> PtySize {
+        PtySize {
+            cols: 80,
+            rows: 24,
+            pixel_width: 0,
+            pixel_height: 0,
+        }
+    }
+
+    fn supervisor_deadlines() -> Deadlines {
+        Deadlines {
+            child_wait_deadline: Some(WAIT_BUDGET),
+            forwarder_join_budget: JOIN_BUDGET,
+            wait_poll: WAIT_POLL,
+        }
+    }
+
+    /// Shared `Write` sink so the integration test can inspect
+    /// what the `child_to_host` forwarder produced after the
+    /// supervisor returns.
+    #[derive(Clone, Default)]
+    struct SharedSink {
+        inner: Arc<Mutex<Vec<u8>>>,
+    }
+    impl SharedSink {
+        fn snapshot(&self) -> Vec<u8> {
+            self.inner.lock().unwrap().clone()
+        }
+    }
+    impl io::Write for SharedSink {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.inner.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Drive the supervisor end-to-end against a shell command
+    /// fragment. Returns the supervisor result and the captured
+    /// child->host bytes.
+    fn run_against_sh(script: &str, host_stdin: Vec<u8>) -> (Result<ExitCode>, Vec<u8>) {
+        let mut session = spawn_child(
+            OsStr::new("/bin/sh"),
+            &[OsString::from("-c"), OsString::from(script)],
+            pty_size_80x24(),
+        )
+        .expect("spawn /bin/sh");
+        let sink = SharedSink::default();
+        let pump = start_io_pump(&mut session, Cursor::new(host_stdin), sink.clone())
+            .expect("start_io_pump");
+        let result = run_pump_session(session, pump);
+        (result, sink.snapshot())
+    }
+
+    #[test]
+    fn supervisor_propagates_clean_exit() {
+        let (res, _) = run_against_sh("exit 0", Vec::new());
+        let code = res.expect("clean exit must be Ok");
+        assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::SUCCESS));
+    }
+
+    #[test]
+    fn supervisor_propagates_nonzero_exit() {
+        let (res, _) = run_against_sh("exit 7", Vec::new());
+        let code = res.expect("nonzero clean exit must be Ok");
+        assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::from(7)));
+    }
+
+    #[test]
+    fn supervisor_propagates_signal_death() {
+        // RD finding 6: `exec sleep 30` so the SIGTERM stops
+        // sleep itself (the shell exec'd into it), avoiding a
+        // shell zombie or timing race where the shell ignores
+        // SIGTERM and waits for sleep.
+        let mut session = spawn_child(
+            OsStr::new("/bin/sh"),
+            &[OsString::from("-c"), OsString::from("exec sleep 30")],
+            pty_size_80x24(),
+        )
+        .expect("spawn /bin/sh");
+
+        let mut term = session.child.clone_killer();
+        let sink = SharedSink::default();
+        let pump = start_io_pump(&mut session, Cursor::new(Vec::<u8>::new()), sink)
+            .expect("start_io_pump");
+
+        // Signal the child BEFORE handing the session to the
+        // supervisor so the very first poll sees a signal
+        // status. portable-pty's ChildKiller for unix actually
+        // sends SIGHUP (verified in portable-pty 0.9.0
+        // src/lib.rs:328), not SIGTERM, so we expect signum=1.
+        term.kill().expect("send SIGHUP to child via clone_killer");
+        let res = run_pump_session(session, pump);
+        let err = res.expect_err("signal death must be Err");
+        match err {
+            Error::Signal { signum } => assert_eq!(
+                signum, 1,
+                "portable-pty ChildKiller sends SIGHUP=1; got {signum} \
+                 (locale-dependent strsignal mapping?)"
+            ),
+            other => panic!("expected Signal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn supervisor_converges_on_host_stdin_eof() {
+        // /bin/cat stays alive until its PTY input EOFs. With a
+        // 6-byte cursor the host_to_child forwarder drains
+        // immediately, the writer is dropped, cat sees EOT,
+        // and exits cleanly. The supervisor must converge.
+        let (res, _) = run_against_sh("exec cat", b"hello\n".to_vec());
+        let code = res.expect("cat must exit cleanly on host stdin EOF");
+        assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::SUCCESS));
+    }
+
+    #[test]
+    fn supervisor_drains_buffered_child_output() {
+        // RD finding 10: a child that writes output and then
+        // exits non-zero must not have its output truncated by
+        // the supervisor's drain phase. The captured sink
+        // should contain "hello" AND the exit code must be 3.
+        let (res, captured) = run_against_sh("printf hello && exit 3", Vec::new());
+        let code = res.expect("nonzero exit must be Ok");
+        assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::from(3)));
+        let s = String::from_utf8_lossy(&captured);
+        assert!(
+            s.contains("hello"),
+            "buffered child output truncated: captured = {s:?}"
+        );
+    }
+
+    // Suppress warnings for unused supervisor_deadlines until a
+    // future test needs the custom budget shape; production
+    // entry uses Deadlines::production() under the hood.
+    #[allow(dead_code)]
+    fn _keep_deadlines_used() -> Deadlines {
+        supervisor_deadlines()
+    }
+}

--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -116,8 +116,6 @@ impl Deadlines {
 pub(crate) trait SupervisedChild {
     /// Non-blocking wait. Wraps `portable_pty::Child::try_wait`.
     fn try_wait(&mut self) -> io::Result<Option<ExitStatus>>;
-    /// Blocking wait. Wraps `portable_pty::Child::wait`.
-    fn wait(&mut self) -> io::Result<ExitStatus>;
     /// Produce a fresh killer handle. Wraps
     /// `portable_pty::Child::clone_killer`.
     fn clone_killer(&mut self) -> Box<dyn ChildKiller + Send + Sync>;
@@ -132,9 +130,6 @@ pub(crate) struct PtyChild {
 impl SupervisedChild for PtyChild {
     fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
         self.child.try_wait()
-    }
-    fn wait(&mut self) -> io::Result<ExitStatus> {
-        self.child.wait()
     }
     fn clone_killer(&mut self) -> Box<dyn ChildKiller + Send + Sync> {
         self.child.clone_killer()
@@ -241,14 +236,25 @@ where
                 // still running and drop() is the last defense.
                 return Err(wrap_io("forwarder failed; kill escalation failed", e));
             }
-            let wait_outcome = child.wait();
-            // Only disarm when wait() actually consumed a status;
-            // a failed wait() means the child may still be alive,
-            // in which case drop() should retry the kill.
-            if wait_outcome.is_ok() {
-                guard.disarm();
-            } else if let Err(e) = &wait_outcome {
-                tracing::warn!(error = %e, "supervisor: wait() after kill failed");
+            // Bounded wait: a child catching/ignoring the kill
+            // signal must not be allowed to hang the supervisor.
+            // Only disarm when an exit status was actually
+            // observed; otherwise leave drop() to retry the kill.
+            match wait_with_budget(
+                &mut child,
+                deadlines.post_kill_wait_budget,
+                deadlines.wait_poll,
+            ) {
+                Ok(Some(_status)) => guard.disarm(),
+                Ok(None) => {
+                    tracing::warn!(
+                        budget = ?deadlines.post_kill_wait_budget,
+                        "supervisor: child did not exit within post-kill wait budget after forwarder error"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "supervisor: wait_with_budget() after kill failed");
+                }
             }
             // Pull the actual io::Error out for the Pty wrapper.
             let err = h2c_result
@@ -481,12 +487,6 @@ mod tests {
                 s.polls_remaining -= 1;
                 Ok(None)
             }
-        }
-        fn wait(&mut self) -> io::Result<ExitStatus> {
-            let mut s = self.state.lock().unwrap();
-            // Block-ish wait: just return the scheduled status.
-            s.polls_remaining = 0;
-            Ok(s.scheduled.clone())
         }
         fn clone_killer(&mut self) -> Box<dyn ChildKiller + Send + Sync> {
             Box::new(MockKiller {

--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -171,13 +171,18 @@ impl Drop for KillOnDropGuard {
 /// [`run_pump_session_with`].
 #[allow(dead_code)] // wired into default_body in PR 5 / #26
 pub(crate) fn run_pump_session(session: SpawnedSession, pump: IoPump) -> Result<ExitCode> {
-    let SpawnedSession { child, master: _ } = session;
-    // Drop the master here? No — closing the master prematurely
-    // would EOF the child's PTY. The master must outlive the
-    // child wait. Stash it on the stack so it's dropped only
-    // after this function returns (after the wait).
-    let mut child = PtyChild { child };
-    let _ = &mut child; // explicit lifetime anchor for clarity
+    // Bind the master to a named local so it stays alive for
+    // the entire supervised session. A wildcard (`master: _`)
+    // pattern would drop it immediately at the destructuring
+    // point, EOF'ing the slave side and racing the child / the
+    // forwarder threads. The named binding extends its lifetime
+    // to the end of the function, so the master is dropped only
+    // after `run_pump_session_with` returns.
+    let SpawnedSession {
+        child,
+        master: _master,
+    } = session;
+    let child = PtyChild { child };
     run_pump_session_with(child, pump, Deadlines::production())
 }
 

--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -225,10 +225,21 @@ where
         let c2h_errored = matches!(c2h_result, Some(Err(_)));
         if h2c_errored || c2h_errored {
             // RD finding 8: forwarder I/O error before the child
-            // exits is unrecoverable. Kill, wait, surface.
-            escalate_kill(&mut child);
-            let _ = child.wait(); // reap, ignore status
-                                  // Pull the actual io::Error out for the Pty wrapper.
+            // exits is unrecoverable. Escalate, wait, surface.
+            // Surface kill failure rather than blocking on
+            // wait() when the child may be unreachable.
+            if let Err(e) = escalate_kill(&mut child) {
+                guard.disarm();
+                return Err(wrap_io("forwarder failed; kill escalation failed", e));
+            }
+            let wait_outcome = child.wait();
+            // The wait succeeded (or definitively failed): the
+            // guard's job is done either way.
+            guard.disarm();
+            if let Err(e) = wait_outcome {
+                tracing::warn!(error = %e, "supervisor: wait() after kill failed");
+            }
+            // Pull the actual io::Error out for the Pty wrapper.
             let err = h2c_result
                 .take()
                 .and_then(|r| r.err())
@@ -239,9 +250,14 @@ where
 
         if h2c_result.is_some() && c2h_result.is_some() {
             // Both forwarders converged while the child is still
-            // alive → no producer, no consumer. Escalate kill
-            // and block on `wait()`.
-            escalate_kill(&mut child);
+            // alive → no producer, no consumer. Escalate and
+            // block on `wait()`. If the kill itself failed, the
+            // child may be unreachable; surface the error rather
+            // than blocking forever.
+            if let Err(e) = escalate_kill(&mut child) {
+                guard.disarm();
+                return Err(wrap_io("stalled supervisor; kill escalation failed", e));
+            }
             match child.wait() {
                 Ok(s) => break s,
                 Err(e) => return Err(wrap_io("child wait after kill", e)),
@@ -252,7 +268,10 @@ where
             if start.elapsed() >= d {
                 // Test-only convergence path: bail by killing
                 // and waiting. Production passes None.
-                escalate_kill(&mut child);
+                if let Err(e) = escalate_kill(&mut child) {
+                    guard.disarm();
+                    return Err(wrap_io("deadline reached; kill escalation failed", e));
+                }
                 match child.wait() {
                     Ok(s) => break s,
                     Err(e) => return Err(wrap_io("child wait after deadline kill", e)),
@@ -283,11 +302,13 @@ fn wrap_io(context: &'static str, e: io::Error) -> Error {
     Error::Pty(anyhow::Error::new(e).context(context))
 }
 
-fn escalate_kill<C: SupervisedChild>(child: &mut C) {
+fn escalate_kill<C: SupervisedChild>(child: &mut C) -> io::Result<()> {
     let mut k = child.clone_killer();
     if let Err(e) = k.kill() {
         tracing::warn!(error = %e, "supervisor: best-effort kill failed");
+        return Err(e);
     }
+    Ok(())
 }
 
 /// Non-blocking peek + extract. If the handle is finished, join

--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -548,15 +548,17 @@ mod tests {
         }
     }
 
-    /// Build a pump whose forwarders never finish (block on a
-    /// channel that's never closed). Used for "join exceeds
-    /// budget" tests.
+    /// Build a pump whose forwarders never finish (block forever
+    /// in `read()`). Used for "join exceeds budget" tests; the
+    /// surrounding test must rely on the supervisor's bounded
+    /// budgets (kill + join detach) for termination.
     fn hung_pump() -> IoPump {
         struct ForeverReader;
         impl io::Read for ForeverReader {
             fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
-                std::thread::sleep(Duration::from_millis(200));
-                Ok(0)
+                loop {
+                    std::thread::park_timeout(Duration::from_secs(60));
+                }
             }
         }
         struct DiscardWriter;

--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -44,7 +44,8 @@
 //! `tracing::warn!`, drop the join handle (detaching the OS
 //! thread), and let the parent process termination clean it up.
 //! A first-class cancellation API for forwarders is tracked as a
-//! follow-up — see the issue linked from this PR's description.
+//! follow-up — see issue #89 (`pty: cancellable forwarders for
+//! non-EOF host stdin`).
 
 use std::io;
 use std::process::ExitCode;

--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -1,0 +1,715 @@
+//! Wait + drain supervisor for an [`IoPump`] over a
+//! [`SpawnedSession`].
+//!
+//! ## What this owns
+//!
+//! [`run_pump_session`] is the convergence point for the wrapped
+//! child and the two forwarder threads spun up by
+//! [`super::pump::start_io_pump`]. It blocks until the child
+//! exits, drains the forwarders, and returns the ExitCode the
+//! Wrap path should bubble up to the binary entry point.
+//!
+//! ## Drain ordering — why a coupled state machine
+//!
+//! A naive "wait-first, then join forwarders" ordering deadlocks
+//! when the child stalls writing to a stalled host stdout: the
+//! child cannot exit, the supervisor cannot advance, and both
+//! forwarders are blocked. Instead this module runs a coupled
+//! poll loop: every tick checks `child.try_wait()` AND probes
+//! the two `JoinHandle::is_finished()` flags. If both forwarders
+//! converge while the child is still alive (no producer / no
+//! consumer) the supervisor escalates [`ChildKiller::kill`] and
+//! resumes the wait poll. If one forwarder returns an `io::Error`
+//! before the child exits, the supervisor likewise kills the
+//! child and surfaces the error as [`Error::Pty`]. After a clean
+//! wait, forwarder I/O errors are logged via `tracing::warn!`
+//! and *not* propagated — the child's status is authoritative.
+//!
+//! ## Kill-on-drop guard
+//!
+//! `portable-pty`'s `Drop for Box<dyn Child>` does NOT wait for
+//! or signal the child (verified in
+//! [`super::spawn::SpawnedSession`] doc comment). [`KillOnDropGuard`]
+//! arms on entry, holds a cloned [`portable_pty::ChildKiller`],
+//! and best-effort `kill()`s the child on every unwind path
+//! (panic, early `?`, …) until it's disarmed by a successful
+//! wait. The guard is unit-tested via `catch_unwind`.
+//!
+//! ## Detached-thread degraded mode
+//!
+//! `host_to_child` is the only forwarder that may stay blocked
+//! after the child exits — it can be sitting in `read()` on real
+//! host stdin with no graceful cancellation primitive. If the
+//! join exceeds [`Deadlines::forwarder_join_budget`] we emit a
+//! `tracing::warn!`, drop the join handle (detaching the OS
+//! thread), and let the parent process termination clean it up.
+//! A first-class cancellation API for forwarders is tracked as a
+//! follow-up — see the issue linked from this PR's description.
+
+use std::io;
+use std::process::ExitCode;
+use std::time::{Duration, Instant};
+
+use portable_pty::{ChildKiller, ExitStatus};
+
+use crate::pty::exit::map_exit_status;
+use crate::pty::forward::{Direction, ForwarderExit, ForwarderHandle};
+use crate::pty::pump::IoPump;
+use crate::pty::spawn::SpawnedSession;
+use crate::{Error, Result};
+
+/// Polling and join time budgets the supervisor honors.
+///
+/// `child_wait_deadline = None` is the production setting — the
+/// loop polls forever, with convergence guaranteed by either
+/// (a) the child exits naturally or (b) both forwarders converge
+/// and the supervisor escalates `kill()`. A finite deadline is
+/// only meaningful in tests that need bounded run time.
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)] // wired into default_body in PR 5 / #26
+pub(crate) struct Deadlines {
+    /// Optional wall-clock deadline on Phase 1 (waiting for the
+    /// child). `None` in production (poll forever). Tests pass
+    /// a tight value (e.g. 50ms) for bounded runtime.
+    pub child_wait_deadline: Option<Duration>,
+    /// Maximum time spent joining each forwarder thread after
+    /// the child has exited. On timeout the join handle is
+    /// dropped and a `warn!` is emitted (detached-thread mode).
+    pub forwarder_join_budget: Duration,
+    /// Sleep between successive `try_wait` ticks. Keeps the
+    /// supervisor from busy-looping; small enough that signal
+    /// death is observed promptly.
+    pub wait_poll: Duration,
+}
+
+impl Deadlines {
+    /// Production defaults: poll forever, 5s join budget, 20ms
+    /// poll cadence. These match the rest of the PTY layer's
+    /// per-file constants (see `pty/spawn.rs::real_spawn`,
+    /// `pty/pump.rs::real_pump`).
+    #[allow(dead_code)] // wired into default_body in PR 5 / #26
+    pub(crate) const fn production() -> Self {
+        Self {
+            child_wait_deadline: None,
+            forwarder_join_budget: Duration::from_secs(5),
+            wait_poll: Duration::from_millis(20),
+        }
+    }
+}
+
+/// Trait-level seam for the wrapped child.
+///
+/// Production binds [`PtyChild`] (a thin wrapper over a
+/// `Box<dyn portable_pty::Child + Send + Sync>` + a cloned
+/// `Box<dyn ChildKiller + Send + Sync>`). Tests bind in-memory
+/// mocks driving the supervisor through every branch without a
+/// real PTY.
+pub(crate) trait SupervisedChild {
+    /// Non-blocking wait. Wraps `portable_pty::Child::try_wait`.
+    fn try_wait(&mut self) -> io::Result<Option<ExitStatus>>;
+    /// Blocking wait. Wraps `portable_pty::Child::wait`.
+    fn wait(&mut self) -> io::Result<ExitStatus>;
+    /// Produce a fresh killer handle. Wraps
+    /// `portable_pty::Child::clone_killer`.
+    fn clone_killer(&mut self) -> Box<dyn ChildKiller + Send + Sync>;
+}
+
+/// Production [`SupervisedChild`] over a `portable-pty` child.
+#[allow(dead_code)] // wired into default_body in PR 5 / #26
+pub(crate) struct PtyChild {
+    child: Box<dyn portable_pty::Child + Send + Sync>,
+}
+
+impl SupervisedChild for PtyChild {
+    fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
+        self.child.try_wait()
+    }
+    fn wait(&mut self) -> io::Result<ExitStatus> {
+        self.child.wait()
+    }
+    fn clone_killer(&mut self) -> Box<dyn ChildKiller + Send + Sync> {
+        self.child.clone_killer()
+    }
+}
+
+/// RAII guard that best-effort `kill()`s the child unless
+/// disarmed. Documented invariant: armed until a successful
+/// wait returns and consumes a status. See module-level docs.
+struct KillOnDropGuard {
+    killer: Option<Box<dyn ChildKiller + Send + Sync>>,
+}
+
+impl KillOnDropGuard {
+    fn armed(killer: Box<dyn ChildKiller + Send + Sync>) -> Self {
+        Self {
+            killer: Some(killer),
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.killer = None;
+    }
+}
+
+impl Drop for KillOnDropGuard {
+    fn drop(&mut self) {
+        if let Some(mut k) = self.killer.take() {
+            // Best-effort. Errors here can only be diagnostic —
+            // we cannot recover from a failed kill in a destructor
+            // path. Log via `tracing::warn!` so observability
+            // sees it.
+            if let Err(e) = k.kill() {
+                tracing::warn!(error = %e, "KillOnDropGuard: best-effort kill failed");
+            }
+        }
+    }
+}
+
+/// Production entry point. Wraps [`SpawnedSession`] +
+/// [`IoPump`] into the trait-seam form and delegates to
+/// [`run_pump_session_with`].
+#[allow(dead_code)] // wired into default_body in PR 5 / #26
+pub(crate) fn run_pump_session(session: SpawnedSession, pump: IoPump) -> Result<ExitCode> {
+    let SpawnedSession { child, master: _ } = session;
+    // Drop the master here? No — closing the master prematurely
+    // would EOF the child's PTY. The master must outlive the
+    // child wait. Stash it on the stack so it's dropped only
+    // after this function returns (after the wait).
+    let mut child = PtyChild { child };
+    let _ = &mut child; // explicit lifetime anchor for clarity
+    run_pump_session_with(child, pump, Deadlines::production())
+}
+
+/// Lifecycle core, parameterised over the [`SupervisedChild`]
+/// implementation and the time [`Deadlines`]. Exists so unit
+/// tests can drive every branch of the state machine without a
+/// real PTY.
+#[allow(dead_code)] // wired into default_body in PR 5 / #26
+pub(crate) fn run_pump_session_with<C>(
+    mut child: C,
+    pump: IoPump,
+    deadlines: Deadlines,
+) -> Result<ExitCode>
+where
+    C: SupervisedChild,
+{
+    let mut guard = KillOnDropGuard::armed(child.clone_killer());
+
+    let mut h2c = Some(pump.host_to_child);
+    let mut c2h = Some(pump.child_to_host);
+    let mut h2c_result: Option<io::Result<ForwarderExit>> = None;
+    let mut c2h_result: Option<io::Result<ForwarderExit>> = None;
+
+    let start = Instant::now();
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(s)) => break s,
+            Ok(None) => {}
+            Err(e) => return Err(wrap_io("child try_wait", e)),
+        }
+
+        // Harvest finished forwarders so we can inspect their
+        // results in subsequent ticks. This is a non-blocking
+        // peek: `is_finished()` says the join would not block,
+        // and `join()` then returns immediately.
+        harvest(&mut h2c, &mut h2c_result);
+        harvest(&mut c2h, &mut c2h_result);
+
+        let h2c_errored = matches!(h2c_result, Some(Err(_)));
+        let c2h_errored = matches!(c2h_result, Some(Err(_)));
+        if h2c_errored || c2h_errored {
+            // RD finding 8: forwarder I/O error before the child
+            // exits is unrecoverable. Kill, wait, surface.
+            escalate_kill(&mut child);
+            let _ = child.wait(); // reap, ignore status
+                                  // Pull the actual io::Error out for the Pty wrapper.
+            let err = h2c_result
+                .take()
+                .and_then(|r| r.err())
+                .or_else(|| c2h_result.take().and_then(|r| r.err()))
+                .unwrap_or_else(|| io::Error::other("forwarder failed (no io::Error captured)"));
+            return Err(wrap_io("forwarder failed", err));
+        }
+
+        if h2c_result.is_some() && c2h_result.is_some() {
+            // Both forwarders converged while the child is still
+            // alive → no producer, no consumer. Escalate kill
+            // and block on `wait()`.
+            escalate_kill(&mut child);
+            match child.wait() {
+                Ok(s) => break s,
+                Err(e) => return Err(wrap_io("child wait after kill", e)),
+            }
+        }
+
+        if let Some(d) = deadlines.child_wait_deadline {
+            if start.elapsed() >= d {
+                // Test-only convergence path: bail by killing
+                // and waiting. Production passes None.
+                escalate_kill(&mut child);
+                match child.wait() {
+                    Ok(s) => break s,
+                    Err(e) => return Err(wrap_io("child wait after deadline kill", e)),
+                }
+            }
+        }
+
+        std::thread::sleep(deadlines.wait_poll);
+    };
+
+    // Wait consumed a status → guard's job is done.
+    guard.disarm();
+
+    // Phase 2: drain remaining forwarders within budget.
+    if let Some(h) = h2c.take() {
+        h2c_result = Some(join_with_budget(h, deadlines.forwarder_join_budget));
+    }
+    if let Some(h) = c2h.take() {
+        c2h_result = Some(join_with_budget(h, deadlines.forwarder_join_budget));
+    }
+    log_forwarder_outcome(Direction::HostToChild, h2c_result);
+    log_forwarder_outcome(Direction::ChildToHost, c2h_result);
+
+    map_exit_status(status)
+}
+
+fn wrap_io(context: &'static str, e: io::Error) -> Error {
+    Error::Pty(anyhow::Error::new(e).context(context))
+}
+
+fn escalate_kill<C: SupervisedChild>(child: &mut C) {
+    let mut k = child.clone_killer();
+    if let Err(e) = k.kill() {
+        tracing::warn!(error = %e, "supervisor: best-effort kill failed");
+    }
+}
+
+/// Non-blocking peek + extract. If the handle is finished, join
+/// it (returns instantly) and stash the result. Otherwise leave
+/// the handle in place for the next tick.
+fn harvest(slot: &mut Option<ForwarderHandle>, result: &mut Option<io::Result<ForwarderExit>>) {
+    let take_now = slot.as_ref().is_some_and(|h| h.join.is_finished());
+    if !take_now {
+        return;
+    }
+    let handle = slot.take().expect("checked above");
+    *result = Some(extract_join(handle));
+}
+
+/// Join a finished (or about-to-finish) forwarder, flattening
+/// the panic case to an `io::Error` for uniform handling.
+fn extract_join(handle: ForwarderHandle) -> io::Result<ForwarderExit> {
+    match handle.join.join() {
+        Ok(r) => r,
+        Err(_) => Err(io::Error::other("forwarder thread panicked")),
+    }
+}
+
+/// Join with a wall-clock budget. On timeout drop the handle
+/// (detaching the underlying OS thread) and synthesize a
+/// `TimedOut` error so the caller can log it.
+fn join_with_budget(handle: ForwarderHandle, budget: Duration) -> io::Result<ForwarderExit> {
+    let deadline = Instant::now() + budget;
+    let direction = handle.direction;
+    // Poll-based wait so we never block past the deadline.
+    while Instant::now() < deadline {
+        if handle.join.is_finished() {
+            return extract_join(handle);
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    tracing::warn!(
+        ?direction,
+        budget_ms = budget.as_millis() as u64,
+        "supervisor: forwarder join exceeded budget; detaching thread"
+    );
+    drop(handle); // detach the underlying OS thread
+    Err(io::Error::new(
+        io::ErrorKind::TimedOut,
+        "forwarder join exceeded budget",
+    ))
+}
+
+fn log_forwarder_outcome(direction: Direction, result: Option<io::Result<ForwarderExit>>) {
+    match result {
+        None => {}
+        Some(Ok(exit)) => {
+            tracing::debug!(?direction, ?exit, "supervisor: forwarder exited cleanly")
+        }
+        Some(Err(e)) => {
+            tracing::warn!(?direction, error = %e, "supervisor: forwarder error after child exit")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pty::forward::{spawn_forwarder, Direction};
+    use std::io::{self, Cursor};
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex,
+    };
+    use std::thread;
+    use std::time::Duration;
+
+    /// In-memory mock of a `portable_pty::Child` for unit tests.
+    /// State machine: `try_wait` returns `None` `pending_polls`
+    /// times, then returns `Some(status)`. `kill` flips the
+    /// status to a synthetic SIGTERM (signum 15) and finishes
+    /// pending polls immediately.
+    struct MockChild {
+        state: Arc<Mutex<MockState>>,
+    }
+
+    struct MockState {
+        polls_remaining: usize,
+        scheduled: ExitStatus,
+        kills: usize,
+        try_waits: usize,
+    }
+
+    impl MockChild {
+        fn new(scheduled: ExitStatus, polls_until_exit: usize) -> Self {
+            Self {
+                state: Arc::new(Mutex::new(MockState {
+                    polls_remaining: polls_until_exit,
+                    scheduled,
+                    kills: 0,
+                    try_waits: 0,
+                })),
+            }
+        }
+
+        fn handle(&self) -> Arc<Mutex<MockState>> {
+            Arc::clone(&self.state)
+        }
+    }
+
+    impl SupervisedChild for MockChild {
+        fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
+            let mut s = self.state.lock().unwrap();
+            s.try_waits += 1;
+            if s.polls_remaining == 0 {
+                Ok(Some(s.scheduled.clone()))
+            } else {
+                s.polls_remaining -= 1;
+                Ok(None)
+            }
+        }
+        fn wait(&mut self) -> io::Result<ExitStatus> {
+            let mut s = self.state.lock().unwrap();
+            // Block-ish wait: just return the scheduled status.
+            s.polls_remaining = 0;
+            Ok(s.scheduled.clone())
+        }
+        fn clone_killer(&mut self) -> Box<dyn ChildKiller + Send + Sync> {
+            Box::new(MockKiller {
+                state: Arc::clone(&self.state),
+            })
+        }
+    }
+
+    struct MockKiller {
+        state: Arc<Mutex<MockState>>,
+    }
+
+    impl std::fmt::Debug for MockKiller {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("MockKiller").finish_non_exhaustive()
+        }
+    }
+
+    impl ChildKiller for MockKiller {
+        fn kill(&mut self) -> io::Result<()> {
+            let mut s = self.state.lock().unwrap();
+            s.kills += 1;
+            // Once killed, status becomes SIGTERM and try_wait
+            // returns immediately on the next call.
+            s.scheduled = ExitStatus::with_signal("Terminated");
+            s.polls_remaining = 0;
+            Ok(())
+        }
+        fn clone_killer(&self) -> Box<dyn ChildKiller + Send + Sync> {
+            Box::new(MockKiller {
+                state: Arc::clone(&self.state),
+            })
+        }
+    }
+
+    fn fast_deadlines() -> Deadlines {
+        Deadlines {
+            child_wait_deadline: Some(Duration::from_secs(2)),
+            forwarder_join_budget: Duration::from_millis(500),
+            wait_poll: Duration::from_millis(2),
+        }
+    }
+
+    /// Build an `IoPump` whose forwarders both terminate
+    /// instantly (empty source, sink discards everything).
+    fn quiet_pump() -> IoPump {
+        let h2c_in: Cursor<Vec<u8>> = Cursor::new(Vec::new());
+        let h2c_out: Vec<u8> = Vec::new();
+        let host_to_child = spawn_forwarder(Direction::HostToChild, h2c_in, h2c_out);
+
+        let c2h_in: Cursor<Vec<u8>> = Cursor::new(Vec::new());
+        let c2h_out: Vec<u8> = Vec::new();
+        let child_to_host = spawn_forwarder(Direction::ChildToHost, c2h_in, c2h_out);
+
+        IoPump {
+            host_to_child,
+            child_to_host,
+        }
+    }
+
+    /// Build a pump whose forwarders never finish (block on a
+    /// channel that's never closed). Used for "join exceeds
+    /// budget" tests.
+    fn hung_pump() -> IoPump {
+        struct ForeverReader;
+        impl io::Read for ForeverReader {
+            fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+                std::thread::sleep(Duration::from_secs(60));
+                Ok(0)
+            }
+        }
+        struct DiscardWriter;
+        impl io::Write for DiscardWriter {
+            fn write(&mut self, b: &[u8]) -> io::Result<usize> {
+                Ok(b.len())
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+        let host_to_child = spawn_forwarder(Direction::HostToChild, ForeverReader, DiscardWriter);
+        let child_to_host = spawn_forwarder(Direction::ChildToHost, ForeverReader, DiscardWriter);
+        IoPump {
+            host_to_child,
+            child_to_host,
+        }
+    }
+
+    #[test]
+    fn clean_exit_returns_success_and_disarms_guard() {
+        let child = MockChild::new(ExitStatus::with_exit_code(0), 0);
+        let handle = child.handle();
+        let code = run_pump_session_with(child, quiet_pump(), fast_deadlines())
+            .expect("clean exit must be Ok");
+        assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::SUCCESS));
+        assert_eq!(
+            handle.lock().unwrap().kills,
+            0,
+            "must not kill on clean exit"
+        );
+    }
+
+    #[test]
+    fn nonzero_exit_passes_through() {
+        let child = MockChild::new(ExitStatus::with_exit_code(7), 0);
+        let code = run_pump_session_with(child, quiet_pump(), fast_deadlines())
+            .expect("nonzero exit must be Ok");
+        assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::from(7)));
+    }
+
+    #[test]
+    fn signal_status_propagates_as_signal_error() {
+        let child = MockChild::new(ExitStatus::with_signal("Terminated"), 0);
+        let err = run_pump_session_with(child, quiet_pump(), fast_deadlines())
+            .expect_err("signal must be Err");
+        assert!(matches!(err, Error::Signal { signum: 15 }));
+    }
+
+    #[test]
+    fn both_forwarders_converging_while_child_alive_escalates_kill() {
+        // RD finding 1 regression guard: with quiet (instantly-
+        // finishing) forwarders, the child takes many polls to
+        // exit, so the supervisor must observe both forwarders
+        // finished and escalate kill.
+        let child = MockChild::new(ExitStatus::with_exit_code(99), 1_000_000);
+        let handle = child.handle();
+        let _err = run_pump_session_with(child, quiet_pump(), fast_deadlines())
+            .expect_err("kill rewrites status to SIGTERM (signal 15)");
+        let s = handle.lock().unwrap();
+        assert!(
+            s.kills >= 1,
+            "supervisor must escalate kill (got {} kills)",
+            s.kills
+        );
+    }
+
+    #[test]
+    fn forwarder_join_timeout_does_not_break_supervisor() {
+        // Exit immediately, so we reach Phase 2 with hung
+        // forwarders. The supervisor must still return the
+        // ExitCode (logging warn rather than blocking forever).
+        let child = MockChild::new(ExitStatus::with_exit_code(0), 0);
+        let pump = hung_pump();
+        let deadlines = Deadlines {
+            child_wait_deadline: Some(Duration::from_secs(2)),
+            forwarder_join_budget: Duration::from_millis(50),
+            wait_poll: Duration::from_millis(2),
+        };
+        // Catch the "both forwarders finish" escalation by NOT
+        // letting them finish — but quiet pump finishes
+        // instantly, so we use hung. With hung pump and
+        // immediate child exit, escalation never triggers
+        // because forwarders never converge. We reach Phase 2
+        // and time out the joins.
+        let start = Instant::now();
+        let code = run_pump_session_with(child, pump, deadlines)
+            .expect("clean exit must be Ok even with hung forwarders");
+        let elapsed = start.elapsed();
+        assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::SUCCESS));
+        // Two forwarders × 50ms budget + a bit of slack.
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "supervisor stalled on hung forwarders: {elapsed:?}"
+        );
+    }
+
+    /// Forwarder produces an `io::Error` (writer that always
+    /// errors) before the child exits → supervisor must kill
+    /// the child and surface the error as `Error::Pty`.
+    #[test]
+    fn forwarder_error_before_child_exit_kills_and_propagates() {
+        struct Once {
+            done: Arc<AtomicUsize>,
+        }
+        impl io::Read for Once {
+            fn read(&mut self, b: &mut [u8]) -> io::Result<usize> {
+                if self.done.fetch_add(1, Ordering::SeqCst) == 0 && !b.is_empty() {
+                    b[0] = b'x';
+                    return Ok(1);
+                }
+                // Subsequent reads block forever to avoid
+                // races where the reader EOFs first.
+                std::thread::sleep(Duration::from_secs(60));
+                Ok(0)
+            }
+        }
+        struct Failing;
+        impl io::Write for Failing {
+            fn write(&mut self, _b: &[u8]) -> io::Result<usize> {
+                Err(io::Error::other("synthetic failure"))
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+        let h2c = spawn_forwarder(
+            Direction::HostToChild,
+            Once {
+                done: Arc::new(AtomicUsize::new(0)),
+            },
+            Failing,
+        );
+        // c2h: never finishes so it doesn't trigger the
+        // "both converged" path on its own.
+        let c2h = spawn_forwarder(
+            Direction::ChildToHost,
+            Once {
+                done: Arc::new(AtomicUsize::new(usize::MAX / 2)),
+            },
+            Vec::<u8>::new(),
+        );
+        let pump = IoPump {
+            host_to_child: h2c,
+            child_to_host: c2h,
+        };
+
+        // Child takes many polls so the forwarder error
+        // observably precedes child exit.
+        let child = MockChild::new(ExitStatus::with_exit_code(0), 1_000_000);
+        let handle = child.handle();
+        let err = run_pump_session_with(child, pump, fast_deadlines())
+            .expect_err("forwarder error must surface");
+        assert!(matches!(err, Error::Pty(_)), "got {err:?}");
+        assert!(handle.lock().unwrap().kills >= 1);
+    }
+
+    #[test]
+    fn kill_on_drop_guard_kills_when_armed() {
+        let child = MockChild::new(ExitStatus::with_exit_code(0), 0);
+        let killer = child.clone_killer_for_test();
+        let handle = child.handle();
+        {
+            let _g = KillOnDropGuard::armed(killer);
+            // armed; will fire on drop
+        }
+        assert_eq!(handle.lock().unwrap().kills, 1);
+    }
+
+    #[test]
+    fn kill_on_drop_guard_skips_kill_when_disarmed() {
+        let child = MockChild::new(ExitStatus::with_exit_code(0), 0);
+        let killer = child.clone_killer_for_test();
+        let handle = child.handle();
+        {
+            let mut g = KillOnDropGuard::armed(killer);
+            g.disarm();
+        }
+        assert_eq!(handle.lock().unwrap().kills, 0);
+    }
+
+    #[test]
+    fn kill_on_drop_guard_kills_on_panic_unwind() {
+        // RD finding 4: panic-path semantics pinned via
+        // catch_unwind. A panic between arm and disarm must
+        // still kill the child.
+        let kills = Arc::new(AtomicUsize::new(0));
+        let kills_for_panic = Arc::clone(&kills);
+        let r = std::panic::catch_unwind(move || {
+            #[derive(Debug)]
+            struct CountingKiller {
+                kills: Arc<AtomicUsize>,
+            }
+            impl ChildKiller for CountingKiller {
+                fn kill(&mut self) -> io::Result<()> {
+                    self.kills.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }
+                fn clone_killer(&self) -> Box<dyn ChildKiller + Send + Sync> {
+                    Box::new(CountingKiller {
+                        kills: Arc::clone(&self.kills),
+                    })
+                }
+            }
+            let killer: Box<dyn ChildKiller + Send + Sync> = Box::new(CountingKiller {
+                kills: kills_for_panic,
+            });
+            let _g = KillOnDropGuard::armed(killer);
+            panic!("synthetic panic between arm and disarm");
+        });
+        assert!(r.is_err(), "panic must propagate");
+        assert_eq!(kills.load(Ordering::SeqCst), 1, "guard must fire on panic");
+    }
+
+    impl MockChild {
+        fn clone_killer_for_test(&self) -> Box<dyn ChildKiller + Send + Sync> {
+            Box::new(MockKiller {
+                state: Arc::clone(&self.state),
+            })
+        }
+    }
+
+    /// Sanity check: harvest is non-blocking when the forwarder
+    /// has not finished yet.
+    #[test]
+    fn harvest_leaves_unfinished_handle_in_place() {
+        let pump = hung_pump();
+        let mut h2c = Some(pump.host_to_child);
+        let mut result: Option<io::Result<ForwarderExit>> = None;
+        // Brief sleep to let the forwarder enter its blocking
+        // read; even after that, is_finished() is false.
+        thread::sleep(Duration::from_millis(20));
+        harvest(&mut h2c, &mut result);
+        assert!(h2c.is_some(), "handle must remain when not finished");
+        assert!(result.is_none());
+        // Detach to clean up the test thread.
+        drop(h2c);
+        // Drop pump.child_to_host too.
+        drop(pump.child_to_host);
+    }
+}

--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -229,7 +229,8 @@ where
             // Surface kill failure rather than blocking on
             // wait() when the child may be unreachable.
             if let Err(e) = escalate_kill(&mut child) {
-                guard.disarm();
+                // Leave the guard armed: the child is likely
+                // still running and drop() is the last defense.
                 return Err(wrap_io("forwarder failed; kill escalation failed", e));
             }
             let wait_outcome = child.wait();
@@ -255,7 +256,8 @@ where
             // child may be unreachable; surface the error rather
             // than blocking forever.
             if let Err(e) = escalate_kill(&mut child) {
-                guard.disarm();
+                // Leave the guard armed: the child is likely
+                // still running and drop() is the last defense.
                 return Err(wrap_io("stalled supervisor; kill escalation failed", e));
             }
             match child.wait() {
@@ -269,7 +271,8 @@ where
                 // Test-only convergence path: bail by killing
                 // and waiting. Production passes None.
                 if let Err(e) = escalate_kill(&mut child) {
-                    guard.disarm();
+                    // Leave the guard armed: the child is likely
+                    // still running and drop() is the last defense.
                     return Err(wrap_io("deadline reached; kill escalation failed", e));
                 }
                 match child.wait() {


### PR DESCRIPTION
## Scope

Closes #33 (`pty-session-lifecycle`) and #24
(`pty-child-exit-code`).

This PR lands the **wait+drain supervisor** that converges the
`IoPump` forwarders from PR 3 with the child wait, plus the
**`portable_pty::ExitStatus -> std::process::ExitCode`** mapping
needed to propagate the child's exit status faithfully.

`default_body` is **not** modified -- that is PR 5 (#26).

## Commits

1. `2aa44c2` -- `feat(pty): map portable-pty ExitStatus to ExitCode`
   - New `src/pty/exit.rs` with `map_exit_status`.
   - Three-layer signum recovery: same-locale `strsignal` reverse
     lookup (Unix), POSIX English allowlist, `"Signal N"` parse.
   - 11 unit tests including a Unix round-trip guard.

2. `6bbb1e1` -- `feat(pty): add wait+drain supervisor for IoPump`
   - New `src/pty/session.rs` with `run_pump_session` +
     `run_pump_session_with` (injection seam) +
     `KillOnDropGuard` RAII.
   - **Coupled state machine**: per-tick polls `try_wait()` AND
     forwarder `is_finished()`. If both forwarders converge
     before the child exits (stalled-PTY deadlock), the
     supervisor escalates `clone_killer().kill()`.
   - 10 unit tests via `MockChild` / `MockKiller` /
     `quiet_pump` / `hung_pump`, including `catch_unwind`
     coverage for the kill-on-drop guard's panic semantics.

3. `3bba2da` -- `test(pty): real-PTY supervisor integration tests`
   - 5 `#[cfg(unix)]` tests under `pty/session.rs::real_session`:
     clean exit, nonzero exit, signal death (via
     `exec sleep 30` + cloned killer), stdin-EOF convergence,
     and buffered-output drain (rubber-duck regression guard).
   - portable-pty's unix `ChildKiller` sends SIGHUP (=1), not
     SIGTERM -- verified at portable-pty 0.9.0 src/lib.rs:328 --
     so the signal-death test asserts signum=1.

4. `9fd10cc` -- `docs(pty): link cancellable-forwarders follow-up`
   - Wires the supervisor doc comment to issue #89.

## Rubber-duck pre-impl pass

Adopted in this PR:

- #1 coupled state machine (replaces "wait then join" sequencing).
- #4 `catch_unwind` tests for `KillOnDropGuard`.
- #5 dynamic same-locale `strsignal` reverse lookup.
- #6 `exec sleep 30` to avoid shell zombie / SIGTERM-ignore race.
- #8 child status is authoritative over forwarder errors after
  the child exits.
- #9 split `Deadlines` (child wait vs forwarder join budget).
- #10 buffered child output drain regression test.

Deferred to **issue #89** (`pty: cancellable forwarders for
non-EOF host stdin`):

- #2, #3 (partial) -- cancellable forwarders for host stdin
  blocked in `read()`. PR 4 ships with the documented
  detached-thread degraded mode and a `tracing::warn!`
  diagnostic when the join budget is exceeded.

## Validation

All five gates pass on this branch:

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features` (239 pass)
- `cargo +1.78 check --locked --all-targets --all-features` (MSRV)
- `cargo deny check`

## Out of scope

- Wiring into `default_body` -> PR 5 (#26).
- Signal forwarding (SIGWINCH, SIGTERM) -> Phase 6 (#59, #60).
- Animation hook -> Phase 5 (#52).
- `q9` E2E -> #28 lands when PR 5 wires everything.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved PTY session supervision with coordinated timeouts, safer child-kill behavior, and more robust I/O forwarding to reduce hangs and races.
  * Enhanced exit-status handling so process terminations (including signal cases) are classified and normalized more consistently.
* **Tests**
  * Added comprehensive unit and integration tests covering session supervision and exit-code behaviors.
* **Chores**
  * Updated spell/config word list for signal names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->