### PR TITLE
feat(pty): wire real PTY pump into Wrap branch (closes #29, #26)

### DIFF
--- a/src/pty/forward.rs
+++ b/src/pty/forward.rs
@@ -20,7 +20,6 @@ const BUF_LEN: usize = 8 * 1024;
 
 /// Direction tag carried in [`ForwarderHandle`] so PR 4's
 /// supervisor can attribute join failures to the right pipe.
-#[allow(dead_code)] // wired into default_body in PR 5 / #26
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Direction {
     HostToChild,
@@ -33,7 +32,6 @@ pub(crate) enum Direction {
 /// PR 4 may want to short-circuit drain on [`Self::WriterClosed`]
 /// (the receiving side hung up — e.g. host stdout pager exit,
 /// or child closing its stdin after EOF).
-#[allow(dead_code)] // wired into default_body in PR 5 / #26
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ForwarderExit {
     /// Reader returned `Ok(0)` — natural EOF on the source.
@@ -48,7 +46,6 @@ pub(crate) enum ForwarderExit {
 /// The thread keeps running until [`ForwarderExit`] is
 /// produced or an unrecoverable [`io::Error`] is returned.
 /// PR 4 owns the join policy.
-#[allow(dead_code)] // wired into default_body in PR 5 / #26
 pub(crate) struct ForwarderHandle {
     pub(crate) direction: Direction,
     pub(crate) join: JoinHandle<io::Result<ForwarderExit>>,
@@ -59,7 +56,6 @@ pub(crate) struct ForwarderHandle {
 ///
 /// See [`ForwarderExit`] for graceful termination tagging and
 /// the module-level docs for the I/O policy summary.
-#[allow(dead_code)] // wired into default_body in PR 5 / #26
 pub(crate) fn spawn_forwarder<R, W>(
     direction: Direction,
     mut reader: R,

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -438,6 +438,20 @@ mod tests {
         assert!(result.is_ok(), "expected ok, got {result:?}");
     }
 
+    /// And it must propagate a non-zero exit code through the
+    /// shared `exit::map_exit_status` mapping rather than
+    /// silently coercing every spawn into success. Pins the
+    /// "transparent passthrough" contract that rubber-duck
+    /// finding #5 (PR #91) called out as untested.
+    #[cfg(unix)]
+    #[test]
+    fn non_tty_passthrough_propagates_nonzero_exit() {
+        let args = [OsString::from("-c"), OsString::from("exit 7")];
+        let result = non_tty_passthrough(&OsString::from("sh"), &args)
+            .expect("sh -c 'exit 7' must complete");
+        assert_eq!(format!("{result:?}"), format!("{:?}", ExitCode::from(7)));
+    }
+
     /// And a missing command surfaces as `Error::Spawn` so the
     /// top-level mapping (`NotFound → 127`) applies.
     #[test]

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -48,7 +48,7 @@ mod session;
 mod size;
 mod spawn;
 
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsString;
 use std::process::{Command, ExitCode};
 
 use crate::{
@@ -120,11 +120,7 @@ where
 /// applies here too.
 fn non_tty_passthrough(command: &OsString, args: &[OsString]) -> Result<ExitCode> {
     let status = Command::new(command.as_os_str())
-        .args(
-            args.iter()
-                .map(OsString::as_os_str)
-                .collect::<Vec<&OsStr>>(),
-        )
+        .args(args)
         .status()
         .map_err(Error::Spawn)?;
     exit::map_exit_status(portable_pty::ExitStatus::from(status))

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -147,7 +147,16 @@ fn default_body(command: &OsString, args: &[OsString]) -> Result<ExitCode> {
         "wrap session: spawning child on PTY"
     );
     let mut session = spawn::spawn_child(command, args, size)?;
+    // Cover the spawn -> pump handoff: if `start_io_pump` fails
+    // (e.g. `try_clone_reader` / `take_writer` returns an error)
+    // we'd otherwise drop `SpawnedSession` without killing the
+    // child — `Box<dyn portable_pty::Child>`'s Drop is documented
+    // not to kill or wait. The guard kills on early-return and is
+    // disarmed once `run_pump_session` takes over (it installs
+    // its own internal `KillOnDropGuard`).
+    let mut kill_guard = session::KillOnDropGuard::armed(session.child.clone_killer());
     let pump = pump::start_io_pump(&mut session, std::io::stdin(), std::io::stdout())?;
+    kill_guard.disarm();
     session::run_pump_session(session, pump)
 }
 

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -1,34 +1,45 @@
 //! PTY session entry point.
 //!
 //! [`run_session`] is the structural seat for everything the
-//! Wrap path needs to do: acquire raw mode, spawn the wrapped
-//! child on a pseudo-terminal, forward I/O, and propagate the
-//! child's exit status. PR 1 only seats the [`RawGuard`]
-//! acquisition; PR 2 lands the spawn building blocks under
-//! the [`size`] and [`spawn`] modules ([`size::initial_size`],
-//! [`spawn::spawn_child`], [`spawn::SpawnedSession`]) so PR 5
-//! (#26) can wire them into [`default_body`]. Subsequent
-//! phase-2 PRs fill in forwarders (#23 / #35 / #36), wait +
-//! exit code (#24 / #33), and replace [`default_body`] with
-//! the real pump (#26).
+//! Wrap path needs to do: detect the controlling terminal,
+//! acquire raw mode (TTY case only), spawn the wrapped child
+//! on a pseudo-terminal, forward I/O, and propagate the
+//! child's exit status.
 //!
 //! ## Design — the `run_session_with` injection seam
 //!
 //! The wrap-path invariant `RawGuard` must enforce — "raw mode
 //! is acquired before any session work and restored on every
 //! returning or unwinding exit path (normal return, `?`,
-//! panic-with-unwind)" — cannot be unit-tested through
-//! the production [`run_session`] entry because it touches the
-//! real terminal and the real `crossterm` enable / disable
-//! syscalls. [`run_session_with`] separates the policy
-//! (acquire-then-run-body, drop-on-return) from the side
-//! effects (real `acquire_raw`, real PTY pump body), so tests
-//! can substitute counter-incrementing shims and verify the
-//! ordering / lifetime invariants without touching termios.
+//! panic-with-unwind)" — cannot be unit-tested through the
+//! production [`run_session`] entry because it touches the
+//! real terminal, the real `crossterm` enable/disable syscalls,
+//! and a real PTY. [`run_session_with`] separates the policy
+//! (route by TTY-ness, then either passthrough OR
+//! acquire-then-run-body, drop-on-return) from the side
+//! effects (real `acquire_raw`, real PTY pump body, real child
+//! spawn), so tests can substitute counter-incrementing shims
+//! and verify the ordering, lifetime, and routing invariants
+//! without touching termios or spawning processes.
 //!
-//! The `command` and `args` parameters are accepted but unused
-//! by [`default_body`]; PR 5 (#26) wires them into the spawn
-//! call using the PR 2 spawn primitives.
+//! ## Non-TTY bypass (issue #29)
+//!
+//! When either stdin or stdout is not a TTY, [`run_session`]
+//! must NOT acquire raw mode and must NOT route the child
+//! through the PTY pump:
+//!
+//! - Acquiring raw mode would mutate parent termios state for
+//!   no benefit (no interactive user is reading).
+//! - The PTY pump would synthesize a fake controlling terminal
+//!   that the wrapped child would mistake for an interactive
+//!   session, and would also splice ANSI animation bytes into
+//!   redirected stdout — breaking pipelines like
+//!   `q9 some-cmd > out.log`.
+//!
+//! Instead the bypass branch spawns the child via
+//! [`std::process::Command`] with stdio inherited from the
+//! parent and propagates its exit status through the same
+//! [`exit::map_exit_status`] used by the PTY path.
 
 mod exit;
 mod forward;
@@ -37,45 +48,86 @@ mod session;
 mod size;
 mod spawn;
 
-use std::ffi::OsString;
-use std::process::ExitCode;
+use std::ffi::{OsStr, OsString};
+use std::process::{Command, ExitCode};
 
 use crate::{
     term::{detect, RawGuard, TerminalCaps},
-    Result,
+    Error, Result,
 };
 
 /// Run a single PTY-wrapped session for `command` + `args`.
 ///
-/// Snapshots the terminal capabilities, acquires raw mode for
-/// the duration of the session, and invokes the session body.
-/// Returns the exit code the wrapped child should bubble up to
-/// the binary entry point.
+/// Snapshots the terminal capabilities, routes through the
+/// non-TTY bypass when either stdin or stdout is not a TTY,
+/// otherwise acquires raw mode for the duration of the session
+/// and invokes the PTY session body. Returns the exit code the
+/// wrapped child should bubble up to the binary entry point.
 pub fn run_session(command: OsString, args: Vec<OsString>) -> Result<ExitCode> {
     let caps = detect::detect();
-    run_session_with(caps, command, args, crate::term::acquire_raw, default_body)
+    run_session_with(
+        caps,
+        command,
+        args,
+        crate::term::acquire_raw,
+        default_body,
+        non_tty_passthrough,
+    )
 }
 
 /// Lifecycle core, parameterised over the raw-mode `acquire`
-/// strategy and the session `body`. Exists so unit tests can
-/// inject shims without touching real termios. See the
-/// module-level comment for the invariants this seam protects.
-pub(crate) fn run_session_with<A, B>(
+/// strategy, the PTY session `body`, and the non-TTY
+/// `passthrough` strategy. Exists so unit tests can inject
+/// shims without touching real termios or spawning processes.
+/// See the module-level comment for the invariants this seam
+/// protects.
+///
+/// Routing rule: if either stdin or stdout is non-TTY, run
+/// `passthrough` and return its result without acquiring raw
+/// mode. Otherwise acquire raw mode, run `body`, and let the
+/// returned [`RawGuard`] restore the terminal on drop (normal
+/// return, `?` propagation, or panic unwind).
+pub(crate) fn run_session_with<A, B, P>(
     caps: TerminalCaps,
     command: OsString,
     args: Vec<OsString>,
     acquire: A,
     body: B,
+    passthrough: P,
 ) -> Result<ExitCode>
 where
     A: FnOnce(&TerminalCaps) -> Result<RawGuard>,
     B: FnOnce(&OsString, &[OsString]) -> Result<ExitCode>,
+    P: FnOnce(&OsString, &[OsString]) -> Result<ExitCode>,
 {
+    if !(caps.stdin_is_tty && caps.stdout_is_tty) {
+        // Non-TTY bypass: no raw mode, no PTY pump. The child
+        // inherits the parent's stdio so pipes/redirects work
+        // verbatim. Documented at module level.
+        return passthrough(&command, &args);
+    }
     // Bind the guard to a named local so it lives until the end
     // of the function. `let _ = ...` would drop it immediately
     // and defeat the purpose.
     let _raw = acquire(&caps)?;
     body(&command, &args)
+}
+
+/// Non-TTY bypass body. Spawns `command` + `args` with stdio
+/// inherited from the parent process and propagates the child's
+/// exit status through [`exit::map_exit_status`] so the same
+/// signal-death encoding (128 + sig) used by the PTY path
+/// applies here too.
+fn non_tty_passthrough(command: &OsString, args: &[OsString]) -> Result<ExitCode> {
+    let status = Command::new(command.as_os_str())
+        .args(
+            args.iter()
+                .map(OsString::as_os_str)
+                .collect::<Vec<&OsStr>>(),
+        )
+        .status()
+        .map_err(Error::Spawn)?;
+    exit::map_exit_status(portable_pty::ExitStatus::from(status))
 }
 
 /// Placeholder body for PR 1. PR 5 (#26) replaces this with the
@@ -105,15 +157,34 @@ mod tests {
         Arc,
     };
 
+    /// Default test caps simulating an interactive TTY on both
+    /// stdio sides so the raw-mode + body branch fires. Tests
+    /// that exercise the non-TTY bypass override these fields.
     fn caps() -> TerminalCaps {
         TerminalCaps {
-            stdin_is_tty: false,
-            stdout_is_tty: false,
+            stdin_is_tty: true,
+            stdout_is_tty: true,
             utf8: true,
             color: false,
             dumb: false,
             ci: false,
         }
+    }
+
+    /// Sentinel passthrough for tests that exercise the
+    /// raw-mode + body branch — the seam must never call it,
+    /// so this panics if the routing rule regresses.
+    fn no_passthrough(_cmd: &OsString, _args: &[OsString]) -> Result<ExitCode> {
+        panic!("passthrough must not be called when both stdio are TTY");
+    }
+
+    /// Sentinel acquire/body for tests that exercise the
+    /// non-TTY bypass — neither must run, so both panic.
+    fn no_acquire(_caps: &TerminalCaps) -> Result<RawGuard> {
+        panic!("acquire must not run on the non-TTY bypass path");
+    }
+    fn no_body(_cmd: &OsString, _args: &[OsString]) -> Result<ExitCode> {
+        panic!("body must not run on the non-TTY bypass path");
     }
 
     /// An armed `RawGuard` whose drop hook increments `counter`.
@@ -146,6 +217,7 @@ mod tests {
                 );
                 Ok(ExitCode::SUCCESS)
             },
+            no_passthrough,
         )
         .unwrap();
     }
@@ -168,6 +240,7 @@ mod tests {
                 Ok(RawGuard::noop())
             },
             |_cmd, _args| Ok(ExitCode::SUCCESS),
+            no_passthrough,
         )
         .unwrap();
 
@@ -185,6 +258,7 @@ mod tests {
             Vec::new(),
             move |_caps| Ok(observed_guard(counter_for_acquire)),
             |_cmd, _args| Ok(ExitCode::SUCCESS),
+            no_passthrough,
         )
         .unwrap();
 
@@ -206,6 +280,7 @@ mod tests {
                     "synthetic body failure",
                 )))
             },
+            no_passthrough,
         );
 
         assert!(matches!(result, Err(crate::Error::Terminal(_))));
@@ -227,6 +302,7 @@ mod tests {
                 |_cmd, _args| -> Result<ExitCode> {
                     panic!("body boom");
                 },
+                no_passthrough,
             );
         });
 
@@ -252,6 +328,7 @@ mod tests {
                 body_observed.store(true, Ordering::SeqCst);
                 Ok(ExitCode::SUCCESS)
             },
+            no_passthrough,
         );
 
         assert!(matches!(result, Err(crate::Error::Terminal(_))));
@@ -259,5 +336,107 @@ mod tests {
             !body_ran.load(Ordering::SeqCst),
             "body ran after acquire failure"
         );
+    }
+
+    /// Non-TTY bypass routing — when stdin is not a TTY, the
+    /// seam must invoke `passthrough` and must NOT call
+    /// `acquire` or `body`.
+    #[test]
+    fn run_session_with_routes_to_passthrough_when_stdin_not_tty() {
+        let mut c = caps();
+        c.stdin_is_tty = false;
+
+        let passthrough_calls = Arc::new(AtomicUsize::new(0));
+        let observed = Arc::clone(&passthrough_calls);
+
+        let exit = run_session_with(
+            c,
+            OsString::from("dummy"),
+            Vec::new(),
+            no_acquire,
+            no_body,
+            move |_cmd, _args| {
+                observed.fetch_add(1, Ordering::SeqCst);
+                Ok(ExitCode::SUCCESS)
+            },
+        )
+        .unwrap();
+
+        assert_eq!(passthrough_calls.load(Ordering::SeqCst), 1);
+        // ExitCode lacks Eq/Debug; round-trip through Termination
+        // is overkill for a routing test, so just exercise the
+        // happy-path return value by dropping it.
+        let _ = exit;
+    }
+
+    /// Same as above but the non-TTY side is stdout. The
+    /// routing rule is "either side non-TTY → bypass" and
+    /// stdout-only redirection (`q9 cmd > out`) is the
+    /// motivating real-world case.
+    #[test]
+    fn run_session_with_routes_to_passthrough_when_stdout_not_tty() {
+        let mut c = caps();
+        c.stdout_is_tty = false;
+
+        let passthrough_calls = Arc::new(AtomicUsize::new(0));
+        let observed = Arc::clone(&passthrough_calls);
+
+        let _exit = run_session_with(
+            c,
+            OsString::from("dummy"),
+            Vec::new(),
+            no_acquire,
+            no_body,
+            move |_cmd, _args| {
+                observed.fetch_add(1, Ordering::SeqCst);
+                Ok(ExitCode::SUCCESS)
+            },
+        )
+        .unwrap();
+
+        assert_eq!(passthrough_calls.load(Ordering::SeqCst), 1);
+    }
+
+    /// Passthrough errors propagate verbatim — the bypass body
+    /// is the sole authority over the exit-code shape on the
+    /// non-TTY path, so the seam must not swallow or remap.
+    #[test]
+    fn run_session_with_propagates_passthrough_error() {
+        let mut c = caps();
+        c.stdin_is_tty = false;
+
+        let result = run_session_with(
+            c,
+            OsString::from("dummy"),
+            Vec::new(),
+            no_acquire,
+            no_body,
+            |_cmd, _args| {
+                Err(crate::Error::Spawn(std::io::Error::other(
+                    "synthetic passthrough failure",
+                )))
+            },
+        );
+
+        assert!(matches!(result, Err(crate::Error::Spawn(_))));
+    }
+
+    /// `non_tty_passthrough` is the production bypass body and
+    /// runs a real subprocess; this verifies it propagates a
+    /// success exit code from a trivially-available command.
+    #[cfg(unix)]
+    #[test]
+    fn non_tty_passthrough_runs_true_command() {
+        let result = non_tty_passthrough(&OsString::from("true"), &[]);
+        assert!(result.is_ok(), "expected ok, got {result:?}");
+    }
+
+    /// And a missing command surfaces as `Error::Spawn` so the
+    /// top-level mapping (`NotFound → 127`) applies.
+    #[test]
+    fn non_tty_passthrough_missing_command_is_spawn_error() {
+        let result =
+            non_tty_passthrough(&OsString::from("definitely-not-a-real-command-xyzzy"), &[]);
+        assert!(matches!(result, Err(crate::Error::Spawn(_))));
     }
 }

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -442,8 +442,7 @@ mod tests {
     /// top-level mapping (`NotFound → 127`) applies.
     #[test]
     fn non_tty_passthrough_missing_command_is_spawn_error() {
-        let result =
-            non_tty_passthrough(&OsString::from("definitely-not-a-real-command-xyzzy"), &[]);
+        let result = non_tty_passthrough(&OsString::from("definitely-not-a-real-command-zz9"), &[]);
         assert!(matches!(result, Err(crate::Error::Spawn(_))));
     }
 }

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -130,23 +130,25 @@ fn non_tty_passthrough(command: &OsString, args: &[OsString]) -> Result<ExitCode
     exit::map_exit_status(portable_pty::ExitStatus::from(status))
 }
 
-/// Placeholder body for PR 1. PR 5 (#26) replaces this with the
-/// real PTY pump and removes the diagnostic.
+/// Production wrap body. Spawns the child on a fresh PTY,
+/// wires the host↔child I/O pump, and supervises the session
+/// to a child exit + bounded forwarder drain.
 ///
-/// Uses `\r\n` rather than `\n` because, on a real interactive
-/// TTY, the surrounding [`run_session_with`] is now holding the
-/// terminal in raw mode where output post-processing (newline
-/// translation) is disabled. A bare `\n` would leave the cursor
-/// dangling at the end of the line.
-///
-/// Intentionally emits no `argv[0]`-derived program-name prefix:
-/// other diagnostics route through [`crate::program_name`], but
-/// this body has no access to `argv[0]` and is throwaway code.
-/// PR 5 removes the line entirely, so plumbing the program name
-/// through the session seam just to delete it would be churn.
-fn default_body(_command: &OsString, _args: &[OsString]) -> Result<ExitCode> {
-    eprint!("PTY wrap pending\r\n");
-    Ok(ExitCode::from(2))
+/// `\r\n` line endings are unnecessary here because the
+/// supervisor surfaces the child's exit status through the
+/// returned [`ExitCode`]; nothing in this body writes to host
+/// stdout directly.
+fn default_body(command: &OsString, args: &[OsString]) -> Result<ExitCode> {
+    let size = size::initial_size();
+    tracing::info!(
+        program = %command.to_string_lossy(),
+        cols = size.cols,
+        rows = size.rows,
+        "wrap session: spawning child on PTY"
+    );
+    let mut session = spawn::spawn_child(command, args, size)?;
+    let pump = pump::start_io_pump(&mut session, std::io::stdin(), std::io::stdout())?;
+    session::run_pump_session(session, pump)
 }
 
 #[cfg(test)]

--- a/src/pty/pump.rs
+++ b/src/pty/pump.rs
@@ -19,7 +19,6 @@ use crate::{Error, Result};
 /// Direction tags are preserved so PR 4's supervisor can
 /// attribute join failures (and decide drain ordering) without
 /// relying on field position.
-#[allow(dead_code)] // wired into default_body in PR 5 / #26
 pub(crate) struct IoPump {
     pub(crate) host_to_child: ForwarderHandle,
     pub(crate) child_to_host: ForwarderHandle,
@@ -39,7 +38,6 @@ pub(crate) struct IoPump {
 /// Errors from portable-pty (handle acquisition, fd dup) flow
 /// through [`Error::Pty`], preserving the existing exit-code
 /// classification from `src/error.rs`.
-#[allow(dead_code)] // wired into default_body in PR 5 / #26
 pub(crate) fn start_io_pump<HIn, HOut>(
     session: &mut SpawnedSession,
     host_stdin: HIn,

--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -166,18 +166,18 @@ impl SupervisedChild for PtyChild {
 /// RAII guard that best-effort `kill()`s the child unless
 /// disarmed. Documented invariant: armed until a successful
 /// wait returns and consumes a status. See module-level docs.
-struct KillOnDropGuard {
+pub(crate) struct KillOnDropGuard {
     killer: Option<Box<dyn ChildKiller + Send + Sync>>,
 }
 
 impl KillOnDropGuard {
-    fn armed(killer: Box<dyn ChildKiller + Send + Sync>) -> Self {
+    pub(crate) fn armed(killer: Box<dyn ChildKiller + Send + Sync>) -> Self {
         Self {
             killer: Some(killer),
         }
     }
 
-    fn disarm(&mut self) {
+    pub(crate) fn disarm(&mut self) {
         self.killer = None;
     }
 }

--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -413,8 +413,33 @@ fn extract_join(handle: ForwarderHandle) -> io::Result<ForwarderExit> {
 /// (detaching the underlying OS thread) and synthesize a
 /// `TimedOut` error so the caller can log it.
 fn join_with_budget(handle: ForwarderHandle, budget: Duration) -> io::Result<ForwarderExit> {
-    let deadline = Instant::now() + budget;
     let direction = handle.direction;
+    // Always try a non-blocking check first so a zero-budget call
+    // (production HostToChild) still extracts a finished
+    // forwarder's outcome instead of being treated as a timeout.
+    // Without this, `Deadlines::production().host_to_child_post_exit_budget
+    // = ZERO` would skip the loop entirely and emit a spurious
+    // "exceeded budget" warning on every clean exit.
+    if handle.join.is_finished() {
+        return extract_join(handle);
+    }
+    if budget.is_zero() {
+        // Intentional zero-budget detach (production HostToChild
+        // post-exit). The host->stdin reader has nothing useful
+        // to deliver after the child is gone, so we drop the
+        // handle silently rather than warning. Use `debug!` for
+        // observability without polluting normal-exit logs.
+        tracing::debug!(
+            ?direction,
+            "supervisor: zero-budget detach of unfinished forwarder"
+        );
+        drop(handle);
+        return Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            "forwarder detached with zero budget",
+        ));
+    }
+    let deadline = Instant::now() + budget;
     // Poll-based wait so we never block past the deadline.
     while Instant::now() < deadline {
         if handle.join.is_finished() {
@@ -439,6 +464,11 @@ fn log_forwarder_outcome(direction: Direction, result: Option<io::Result<Forward
         None => {}
         Some(Ok(exit)) => {
             tracing::debug!(?direction, ?exit, "supervisor: forwarder exited cleanly")
+        }
+        Some(Err(e)) if e.kind() == io::ErrorKind::TimedOut => {
+            // join_with_budget has already logged the detach
+            // (warn for budget exceeded, debug for zero-budget).
+            // Avoid double-logging the same condition here.
         }
         Some(Err(e)) => {
             tracing::warn!(?direction, error = %e, "supervisor: forwarder error after child exit")
@@ -625,6 +655,30 @@ mod tests {
             host_to_child,
             child_to_host,
         }
+    }
+
+    /// Regression for chatgpt-codex/copilot reviewer finding
+    /// (PR #91): zero budget must NOT bypass the
+    /// `is_finished()` extraction — a HostToChild forwarder
+    /// that has already finished by the time the supervisor
+    /// reaches the join site must surface its real outcome
+    /// instead of being treated as a timed-out detach.
+    #[test]
+    fn zero_budget_extracts_finished_forwarder() {
+        // EOF input + no-op writer => forwarder finishes
+        // essentially immediately.
+        let reader: Cursor<Vec<u8>> = Cursor::new(Vec::new());
+        let writer: Vec<u8> = Vec::new();
+        let handle = spawn_forwarder(Direction::HostToChild, reader, writer);
+        // Give the forwarder a moment to reach completion so
+        // `is_finished()` returns true at the call site. 50 ms
+        // is generous on every supported runner.
+        std::thread::sleep(Duration::from_millis(50));
+        let result = join_with_budget(handle, Duration::ZERO);
+        assert!(
+            result.is_ok(),
+            "zero-budget join of finished forwarder must extract Ok, got {result:?}"
+        );
     }
 
     /// Regression for rubber-duck finding #1 (PR 5): with

--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -67,7 +67,6 @@ use crate::{Error, Result};
 /// and the supervisor escalates `kill()`. A finite deadline is
 /// only meaningful in tests that need bounded run time.
 #[derive(Debug, Clone, Copy)]
-#[allow(dead_code)] // wired into default_body in PR 5 / #26
 pub(crate) struct Deadlines {
     /// Optional wall-clock deadline on Phase 1 (waiting for the
     /// child). `None` in production (poll forever). Tests pass
@@ -95,7 +94,6 @@ impl Deadlines {
     /// poll cadence. These match the rest of the PTY layer's
     /// per-file constants (see `pty/spawn.rs::real_spawn`,
     /// `pty/pump.rs::real_pump`).
-    #[allow(dead_code)] // wired into default_body in PR 5 / #26
     pub(crate) const fn production() -> Self {
         Self {
             child_wait_deadline: None,
@@ -122,7 +120,6 @@ pub(crate) trait SupervisedChild {
 }
 
 /// Production [`SupervisedChild`] over a `portable-pty` child.
-#[allow(dead_code)] // wired into default_body in PR 5 / #26
 pub(crate) struct PtyChild {
     child: Box<dyn portable_pty::Child + Send + Sync>,
 }
@@ -172,7 +169,6 @@ impl Drop for KillOnDropGuard {
 /// Production entry point. Wraps [`SpawnedSession`] +
 /// [`IoPump`] into the trait-seam form and delegates to
 /// [`run_pump_session_with`].
-#[allow(dead_code)] // wired into default_body in PR 5 / #26
 pub(crate) fn run_pump_session(session: SpawnedSession, pump: IoPump) -> Result<ExitCode> {
     // Bind the master to a named local so it stays alive for
     // the entire supervised session. A wildcard (`master: _`)
@@ -193,7 +189,6 @@ pub(crate) fn run_pump_session(session: SpawnedSession, pump: IoPump) -> Result<
 /// implementation and the time [`Deadlines`]. Exists so unit
 /// tests can drive every branch of the state machine without a
 /// real PTY.
-#[allow(dead_code)] // wired into default_body in PR 5 / #26
 pub(crate) fn run_pump_session_with<C>(
     mut child: C,
     pump: IoPump,

--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -39,10 +39,24 @@
 //!
 //! `host_to_child` is the only forwarder that may stay blocked
 //! after the child exits — it can be sitting in `read()` on real
-//! host stdin with no graceful cancellation primitive. If the
-//! join exceeds [`Deadlines::forwarder_join_budget`] we emit a
-//! `tracing::warn!`, drop the join handle (detaching the OS
-//! thread), and let the parent process termination clean it up.
+//! host stdin with no graceful cancellation primitive. The
+//! supervisor uses two separate join budgets to handle the two
+//! directions:
+//!
+//! - [`Deadlines::forwarder_join_budget`] (5 s in production)
+//!   is the budget for the `ChildToHost` direction. If the
+//!   join exceeds that budget we emit `tracing::warn!`, drop
+//!   the join handle (detaching the OS thread), and let the
+//!   parent process termination clean it up.
+//! - [`Deadlines::host_to_child_post_exit_budget`] is **zero
+//!   in production**. The host->stdin reader has nothing
+//!   useful to deliver after the child is gone, so a
+//!   non-blocking `is_finished()` check decides between
+//!   extracting the real outcome and detaching silently
+//!   (`tracing::debug!`). Without the split, every clean
+//!   interactive exit would block for 5 s waiting on a
+//!   `read()` call that can't be cancelled.
+//!
 //! A first-class cancellation API for forwarders is tracked as a
 //! follow-up — see issue #89 (`pty: cancellable forwarders for
 //! non-EOF host stdin`).

--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -500,7 +500,7 @@ mod tests {
         Arc, Mutex,
     };
     use std::thread;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     /// In-memory mock of a `portable_pty::Child` for unit tests.
     /// State machine: `try_wait` returns `None` `pending_polls`
@@ -684,10 +684,18 @@ mod tests {
         let reader: Cursor<Vec<u8>> = Cursor::new(Vec::new());
         let writer: Vec<u8> = Vec::new();
         let handle = spawn_forwarder(Direction::HostToChild, reader, writer);
-        // Give the forwarder a moment to reach completion so
-        // `is_finished()` returns true at the call site. 50 ms
-        // is generous on every supported runner.
-        std::thread::sleep(Duration::from_millis(50));
+        // Bounded spin instead of a fixed sleep: a contended CI
+        // runner can take longer than any constant we'd pick
+        // here, so poll `is_finished()` up to a generous
+        // deadline before exercising the zero-budget branch.
+        let wait_deadline = Instant::now() + Duration::from_secs(2);
+        while !handle.join.is_finished() && Instant::now() < wait_deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            handle.join.is_finished(),
+            "forwarder did not reach completion within the wait budget"
+        );
         let result = join_with_budget(handle, Duration::ZERO);
         assert!(
             result.is_ok(),

--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -72,10 +72,22 @@ pub(crate) struct Deadlines {
     /// child). `None` in production (poll forever). Tests pass
     /// a tight value (e.g. 50ms) for bounded runtime.
     pub child_wait_deadline: Option<Duration>,
-    /// Maximum time spent joining each forwarder thread after
-    /// the child has exited. On timeout the join handle is
-    /// dropped and a `warn!` is emitted (detached-thread mode).
+    /// Maximum time spent joining the `ChildToHost` forwarder
+    /// thread after the child has exited. On timeout the join
+    /// handle is dropped and a `warn!` is emitted (detached-
+    /// thread mode). Drains pending child output that the
+    /// forwarder may still be writing to host stdout.
     pub forwarder_join_budget: Duration,
+    /// Same as `forwarder_join_budget` but for the
+    /// `HostToChild` direction. Production sets this to **zero**
+    /// because once the child has exited there is nothing useful
+    /// the host->child forwarder can deliver: the user's
+    /// in-flight keystrokes are now meaningless input. Without
+    /// the split, an interactive session blocked in `stdin.read()`
+    /// would hold the supervisor for the full 5 s join budget on
+    /// every clean exit, making each `q9 vim` (etc.) appear to
+    /// hang for 5 s after the wrapped editor quit.
+    pub host_to_child_post_exit_budget: Duration,
     /// Sleep between successive `try_wait` ticks. Keeps the
     /// supervisor from busy-looping; small enough that signal
     /// death is observed promptly.
@@ -98,6 +110,10 @@ impl Deadlines {
         Self {
             child_wait_deadline: None,
             forwarder_join_budget: Duration::from_secs(5),
+            // Detach the host->stdin reader immediately on child
+            // exit; see field doc for why a non-zero value would
+            // hang every interactive session for 5 s.
+            host_to_child_post_exit_budget: Duration::ZERO,
             wait_poll: Duration::from_millis(20),
             post_kill_wait_budget: Duration::from_secs(5),
         }
@@ -322,7 +338,10 @@ where
 
     // Phase 2: drain remaining forwarders within budget.
     if let Some(h) = h2c.take() {
-        h2c_result = Some(join_with_budget(h, deadlines.forwarder_join_budget));
+        h2c_result = Some(join_with_budget(
+            h,
+            deadlines.host_to_child_post_exit_budget,
+        ));
     }
     if let Some(h) = c2h.take() {
         c2h_result = Some(join_with_budget(h, deadlines.forwarder_join_budget));
@@ -521,6 +540,7 @@ mod tests {
         Deadlines {
             child_wait_deadline: Some(Duration::from_secs(2)),
             forwarder_join_budget: Duration::from_millis(500),
+            host_to_child_post_exit_budget: Duration::from_millis(500),
             wait_poll: Duration::from_millis(2),
             post_kill_wait_budget: Duration::from_millis(500),
         }
@@ -571,6 +591,72 @@ mod tests {
             host_to_child,
             child_to_host,
         }
+    }
+
+    /// Build a pump where `HostToChild` is hung in `read()`
+    /// forever but `ChildToHost` terminates instantly. Used by
+    /// the regression test that pins the production
+    /// `host_to_child_post_exit_budget = 0` invariant — the
+    /// supervisor must detach the hung stdin reader without
+    /// waiting the full `forwarder_join_budget`.
+    fn hung_h2c_quiet_c2h_pump() -> IoPump {
+        struct ForeverReader;
+        impl io::Read for ForeverReader {
+            fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+                loop {
+                    std::thread::park_timeout(Duration::from_secs(60));
+                }
+            }
+        }
+        struct DiscardWriter;
+        impl io::Write for DiscardWriter {
+            fn write(&mut self, b: &[u8]) -> io::Result<usize> {
+                Ok(b.len())
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+        let host_to_child = spawn_forwarder(Direction::HostToChild, ForeverReader, DiscardWriter);
+        let c2h_in: Cursor<Vec<u8>> = Cursor::new(Vec::new());
+        let c2h_out: Vec<u8> = Vec::new();
+        let child_to_host = spawn_forwarder(Direction::ChildToHost, c2h_in, c2h_out);
+        IoPump {
+            host_to_child,
+            child_to_host,
+        }
+    }
+
+    /// Regression for rubber-duck finding #1 (PR 5): with
+    /// production deadlines, an interactive `q9` session whose
+    /// `HostToChild` reader is blocked in `stdin.read()` must
+    /// not stall the supervisor for the full
+    /// `forwarder_join_budget` (5 s) on clean child exit. The
+    /// production split sets `host_to_child_post_exit_budget`
+    /// to zero so the hung handle is detached immediately.
+    #[test]
+    fn production_deadlines_detach_hung_host_to_child_immediately() {
+        // child_wait_deadline=None in production; switch to a
+        // bounded value here so the test cannot hang on a
+        // try_wait regression. Keep the per-direction budgets
+        // exactly as production() sets them.
+        let mut deadlines = Deadlines::production();
+        deadlines.child_wait_deadline = Some(Duration::from_secs(2));
+        deadlines.wait_poll = Duration::from_millis(2);
+
+        let child = MockChild::new(ExitStatus::with_exit_code(0), 0);
+        let start = Instant::now();
+        let code = run_pump_session_with(child, hung_h2c_quiet_c2h_pump(), deadlines)
+            .expect("clean exit with hung h2c must still be Ok");
+        let elapsed = start.elapsed();
+
+        assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::SUCCESS));
+        // Generous slack but well under the 5 s production
+        // forwarder_join_budget the bug would have triggered.
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "supervisor stalled on hung HostToChild: {elapsed:?}"
+        );
     }
 
     #[test]
@@ -631,6 +717,7 @@ mod tests {
         let deadlines = Deadlines {
             child_wait_deadline: Some(Duration::from_secs(2)),
             forwarder_join_budget: Duration::from_millis(50),
+            host_to_child_post_exit_budget: Duration::from_millis(50),
             wait_poll: Duration::from_millis(2),
             post_kill_wait_budget: Duration::from_millis(500),
         };
@@ -828,6 +915,7 @@ mod real_session {
         Deadlines {
             child_wait_deadline: Some(WAIT_BUDGET),
             forwarder_join_budget: JOIN_BUDGET,
+            host_to_child_post_exit_budget: JOIN_BUDGET,
             wait_poll: WAIT_POLL,
             post_kill_wait_budget: WAIT_BUDGET,
         }

--- a/src/pty/size.rs
+++ b/src/pty/size.rs
@@ -29,7 +29,6 @@ pub(crate) const FALLBACK_SIZE: PtySize = PtySize {
 
 /// Snapshot the host terminal's current size for a freshly
 /// spawned PTY child.
-#[allow(dead_code)] // wired into default_body in PR 5 / #26
 pub(crate) fn initial_size() -> PtySize {
     initial_size_with(crossterm::terminal::size)
 }

--- a/src/pty/spawn.rs
+++ b/src/pty/spawn.rs
@@ -48,7 +48,6 @@ use crate::{Error, Result};
 /// underlying process. PR 4 / #33 owns the explicit wait+kill
 /// ladder; until then, callers must arrange shutdown
 /// themselves (e.g. via [`portable_pty::Child::clone_killer`]).
-#[allow(dead_code)] // wired into default_body in PR 5 / #26
 pub(crate) struct SpawnedSession {
     pub child: Box<dyn portable_pty::Child + Send + Sync>,
     pub master: Box<dyn MasterPty + Send>,
@@ -60,7 +59,6 @@ pub(crate) struct SpawnedSession {
 /// [`preflight_command`] before invoking portable-pty;
 /// post-`fork` failures from portable-pty itself surface
 /// through [`map_spawn_error`].
-#[allow(dead_code)] // wired into default_body in PR 5 / #26
 pub(crate) fn spawn_child(
     command: &OsStr,
     args: &[std::ffi::OsString],


### PR DESCRIPTION
## Summary

Phase 2 PR 5 — wires the real PTY pump into the Wrap branch by
closing the last two impl issues that made `q9 <cmd>` actually
function instead of printing `PTY wrap pending`.

| Commit | Issue | Theme |
|---|---|---|
| `352b856` | #29 | Bypass raw mode + PTY when stdio is not a TTY |
| `cad5e01` | #26 | Replace `default_body` with real spawn + pump + supervise |
| `dd52958` | — | Detach hung host->child reader on clean exit (rubber-duck finding) |

`Closes #29`
`Closes #26`

## Why

After PR #90 merged the supervisor, every PTY building block was
present (spawn, size, pump, forwarder, supervisor, RawGuard) but
`default_body` was still a placeholder that printed
`"PTY wrap pending\r\n"` and exited 2. PR 5 connects them and
adds the missing non-TTY bypass so pipelines like
`echo hi | q9 cat > out.log` behave correctly.

## What changed

### `352b856` — non-TTY bypass (#29)

* New `non_tty_passthrough(command, args)` runs the child with
  inherited stdio via `std::process::Command::status()` and
  propagates the exit status through
  `portable_pty::ExitStatus::from(...)` into the existing
  `pty::exit::map_exit_status`, so signal-death encoding
  (128 + sig) matches the PTY path.
* `run_session_with` extended with a `passthrough` closure
  parameter; routing is `caps.stdin_is_tty && stdout_is_tty`
  before raw-mode acquisition. Either side non-TTY → bypass.
* New unit tests pin both routing branches, the no-acquire
  invariant on the bypass path, error propagation, and the
  production helper against `true` and a missing command.

### `cad5e01` — wire `default_body` (#26)

* `default_body` now `size::initial_size()` →
  `tracing::info!(program, cols, rows, ...)` →
  `spawn::spawn_child` → `pump::start_io_pump(&mut session,
  stdin(), stdout())` → `session::run_pump_session`.
* Drops the eight `#[allow(dead_code)] // wired into default_body
  in PR 5 / #26` annotations across spawn/size/pump/forward/
  session that PRs 2-4 left as TODO markers.

### `dd52958` — fast detach for hung host->child (rubber-duck)

* Splits `Deadlines::forwarder_join_budget` into a per-direction
  pair: keeps the original 5 s budget for `ChildToHost` (may
  still be flushing the child's last output) and adds
  `host_to_child_post_exit_budget = Duration::ZERO` for
  production. Without this, every interactive `q9 vim` would
  appear to hang for ~5 s after the editor quit while the
  supervisor waited for the stdin reader to unblock.
* Regression test
  `production_deadlines_detach_hung_host_to_child_immediately`
  pins the invariant.

## Validation

* `cargo fmt --check` ✅
* `cargo clippy --all-targets --all-features -- -D warnings` ✅
* `cargo test --all-targets --all-features` → 245 unit + integration tests ✅
* Manual smoke (Linux):
  * `printf 'hello\n' | qorrection cat` → `hello`, exit 0
  * `qorrection false` → exit 1
  * `qorrection nonexistent-cmd-xyz` → `Spawn` diagnostic, exit 127

## Rubber-duck pre-commit pass

Two findings; both addressed in this PR's scope:

1. **must-fix — 5 s tail on every interactive exit**: addressed
   by `dd52958`.
2. **should-fix — `argv[0]` mismatch for `subdir/tool` between
   PTY path and bypass path**: filtered out as **rejected**.
   The PTY path rewrites `subdir/tool` to an absolute path as a
   documented workaround for portable-pty's PATH-walker bug
   (`src/pty/spawn.rs:148-163`); the std `Command` bypass uses
   POSIX `execvp` semantics directly and does NOT need the
   workaround. Forcing the bypass to mimic the workaround would
   propagate the divergence rather than fix it. The right fix is
   upstream in portable-pty.

## Out of scope (queued)

* PR 6 — rexpect E2E pair (#27, #28).
* PR 7 — non-TTY E2E (#30, #31) + #71 helper.

## Review-loop protocol

Same as PR #90: fetch unresolved threads → filter → atomic
commits → 5 gates → reply + resolve → re-request → wait 15 min.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added passthrough strategy for non-TTY stdin/stdout environments, enabling direct child process communication.
  * Implemented automatic TTY detection during session startup.

* **Bug Fixes**
  * Improved post-exit forwarder deadline management with refined cleanup behavior.

* **Tests**
  * Extended test coverage for TTY routing and subprocess exit scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->