### PR TITLE
test(pty): cover non-tty armed passthrough

### DIFF
--- a/tests/nontty_passthrough.rs
+++ b/tests/nontty_passthrough.rs
@@ -27,9 +27,14 @@ fn piped_stdin_reaches_armed_child_without_animation() {
         .success();
 
     let output = assert.get_output();
-    assert!(
-        String::from_utf8_lossy(&output.stdout).contains(":q"),
-        "expected child stdout to contain piped input, got {:?}",
+    // Equality (not `contains`) so the "without animation"
+    // contract this PR exists to test would actually fail if a
+    // regression appended a plain-text fallback banner or any
+    // other non-escape bytes alongside the trigger payload.
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).replace("\r\n", "\n"),
+        ":q\n",
+        "expected child stdout to be exactly the piped trigger, got {:?}",
         String::from_utf8_lossy(&output.stdout)
     );
     assert_no_escape("stdout", &output.stdout);

--- a/tests/nontty_passthrough.rs
+++ b/tests/nontty_passthrough.rs
@@ -5,7 +5,15 @@ mod support;
 use assert_cmd::Command;
 
 fn q9() -> Command {
-    Command::cargo_bin("q9").expect("q9 bin built")
+    let mut cmd = Command::cargo_bin("q9").expect("q9 bin built");
+    // Hermetic stderr: any future `tracing` call site that
+    // honours `QORRECTION_LOG` from the outer environment would
+    // otherwise make `assert_no_escape("stderr", ...)` flaky on
+    // contributor machines or CI runners that opt in to debug
+    // logging globally. Mirror the convention from
+    // tests/tracing_env.rs and explicitly clear the variable.
+    cmd.env_remove("QORRECTION_LOG");
+    cmd
 }
 
 #[test]

--- a/tests/nontty_passthrough.rs
+++ b/tests/nontty_passthrough.rs
@@ -1,0 +1,55 @@
+//! Non-TTY passthrough tests for the shipped `q9` binary.
+
+mod support;
+
+use assert_cmd::Command;
+
+fn q9() -> Command {
+    Command::cargo_bin("q9").expect("q9 bin built")
+}
+
+#[test]
+fn piped_stdin_reaches_armed_child_without_animation() {
+    let helper = support::ArmedHelper::echo_stdin();
+    let assert = q9()
+        .env("PATH", helper.path())
+        .arg(helper.command())
+        .write_stdin(":q\n")
+        .assert()
+        .success();
+
+    let output = assert.get_output();
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains(":q"),
+        "expected child stdout to contain piped input, got {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert_no_escape("stdout", &output.stdout);
+    assert_no_escape("stderr", &output.stderr);
+}
+
+#[test]
+fn redirected_stdout_from_armed_child_contains_no_ansi_escape() {
+    let helper = support::ArmedHelper::plain_stdout();
+    let assert = q9()
+        .env("PATH", helper.path())
+        .arg(helper.command())
+        .assert()
+        .success();
+
+    let output = assert.get_output();
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).replace("\r\n", "\n"),
+        "plain-output\n"
+    );
+    assert_no_escape("stdout", &output.stdout);
+    assert_no_escape("stderr", &output.stderr);
+}
+
+fn assert_no_escape(label: &str, bytes: &[u8]) {
+    assert!(
+        !bytes.contains(&0x1b),
+        "expected no ANSI escape bytes in {label}, got {:?}",
+        String::from_utf8_lossy(bytes)
+    );
+}

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,0 +1,90 @@
+//! Shared integration-test fixtures.
+
+use std::ffi::{OsStr, OsString};
+use std::path::PathBuf;
+
+/// Tempdir-backed helper named like an armed AI CLI.
+///
+/// The helper lives at the front of a synthetic PATH so tests
+/// can invoke an allowlisted command name without changing the
+/// production arming policy.
+pub struct ArmedHelper {
+    _dir: tempfile::TempDir,
+    command: OsString,
+    path: OsString,
+}
+
+impl ArmedHelper {
+    /// Create a helper that echoes one stdin line to stdout.
+    pub fn echo_stdin() -> Self {
+        Self::from_scripts(
+            "#!/bin/sh\ncat\n",
+            "@echo off\r\nsetlocal EnableDelayedExpansion\r\nset /p line=\r\necho(!line!\r\n",
+        )
+    }
+
+    /// Create a helper that writes deterministic plain stdout.
+    pub fn plain_stdout() -> Self {
+        Self::from_scripts(
+            "#!/bin/sh\nprintf 'plain-output\\n'\n",
+            "@echo off\r\necho plain-output\r\n",
+        )
+    }
+
+    /// Command name to pass to `q9`.
+    pub fn command(&self) -> &OsStr {
+        &self.command
+    }
+
+    /// PATH value with the helper directory prepended.
+    pub fn path(&self) -> &OsStr {
+        &self.path
+    }
+
+    fn from_scripts(unix_body: &str, windows_body: &str) -> Self {
+        let dir = tempfile::tempdir().expect("create armed-helper tempdir");
+        let (command, body) = helper_script(unix_body, windows_body);
+        let script = dir.path().join(command);
+        std::fs::write(&script, body).expect("write armed-helper script");
+        make_executable(&script);
+        let path = path_with_front(dir.path().to_path_buf());
+
+        Self {
+            _dir: dir,
+            command: command.into(),
+            path,
+        }
+    }
+}
+
+#[cfg(unix)]
+fn helper_script<'a>(unix_body: &'a str, _windows_body: &'a str) -> (&'static str, &'a str) {
+    ("claude", unix_body)
+}
+
+#[cfg(windows)]
+fn helper_script<'a>(_unix_body: &'a str, windows_body: &'a str) -> (&'static str, &'a str) {
+    ("claude.cmd", windows_body)
+}
+
+#[cfg(unix)]
+fn make_executable(path: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut perms = std::fs::metadata(path)
+        .expect("stat armed-helper script")
+        .permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(path, perms).expect("chmod armed-helper script");
+}
+
+#[cfg(windows)]
+fn make_executable(_path: &std::path::Path) {}
+
+fn path_with_front(front: PathBuf) -> OsString {
+    let mut paths = vec![front];
+    if let Some(existing) = std::env::var_os("PATH") {
+        paths.extend(std::env::split_paths(&existing));
+    }
+    std::env::join_paths(paths).expect("join PATH entries")
+}

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -16,9 +16,14 @@ pub struct ArmedHelper {
 
 impl ArmedHelper {
     /// Create a helper that echoes one stdin line to stdout.
+    ///
+    /// Both platforms read exactly one line of stdin and emit it
+    /// followed by a single LF, so the fixture's contract is
+    /// identical regardless of whether the underlying shell is
+    /// `/bin/sh` or `cmd.exe`.
     pub fn echo_stdin() -> Self {
         Self::from_scripts(
-            "#!/bin/sh\ncat\n",
+            "#!/bin/sh\nIFS= read -r line\nprintf '%s\\n' \"$line\"\n",
             "@echo off\r\nsetlocal EnableDelayedExpansion\r\nset /p line=\r\necho(!line!\r\n",
         )
     }


### PR DESCRIPTION
## Summary

- Add a tempdir-backed armed helper fixture named like an allowlisted AI CLI.
- Cover piped stdin passthrough for `:q` without animation bytes.
- Cover redirected/captured stdout from an armed helper with no ANSI escape bytes.

## Verification

- rustup run stable cargo fmt --check
- RUSTC=/home/kurone-kito/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc rustup run stable cargo clippy --all-targets -- -D warnings
- RUSTC=/home/kurone-kito/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc rustup run stable cargo test --test nontty_passthrough
- RUSTC=/home/kurone-kito/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc rustup run stable cargo test --all-targets --all-features

Closes #30
Closes #31
Closes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for non-TTY passthrough behavior, including validation of output correctness and verification that ANSI escape sequences are not present in output streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->