### PR TITLE
test(pty): cover signal-death propagation through wrap paths

### DIFF
--- a/src/pty/exit.rs
+++ b/src/pty/exit.rs
@@ -36,6 +36,18 @@
 //! to `signum = 0` — see [`crate::Error::exit_code`] which maps
 //! that to exit `128` (POSIX "killed by signal 0", a defined
 //! sentinel rather than wrapping or panicking).
+//!
+//! ## Test layering
+//!
+//! - **Unit** (this file + [`crate::error`]): mock
+//!   [`portable_pty::ExitStatus`] values cover every recovery
+//!   layer and the saturating `128 + signum` arithmetic.
+//! - **Integration / E2E** (`tests/pty_e2e.rs`,
+//!   `tests/nontty_passthrough.rs`): drive the shipped `q9`
+//!   binary through both wrap branches with `kill -15 $$` and
+//!   assert exit `143`, pinning the full chain
+//!   (`portable-pty` reporting → [`map_exit_status`] →
+//!   [`crate::Error::Signal`] → [`std::process::ExitCode`]).
 
 use std::process::ExitCode;
 

--- a/tests/nontty_passthrough.rs
+++ b/tests/nontty_passthrough.rs
@@ -66,3 +66,28 @@ fn assert_no_escape(label: &str, bytes: &[u8]) {
         String::from_utf8_lossy(bytes)
     );
 }
+
+/// Issue #24 E2E coverage: a non-TTY passthrough child killed
+/// by SIGTERM must surface as host exit `128 + 15 = 143`. The
+/// PTY path is covered by `tests/pty_e2e.rs`; this pins the
+/// other branch in `pty/mod.rs::non_tty_passthrough`, where
+/// `std::process::ExitStatus` flows through
+/// `portable_pty::ExitStatus::from(...)` (which preserves
+/// `ExitStatusExt::signal()` on Unix) and then through
+/// `map_exit_status`.
+///
+/// q9 itself exits cleanly with status 143 — it is *not*
+/// killed by a signal — so `assert_cmd`'s exit-code matcher
+/// is the right surface here.
+#[cfg(unix)]
+#[test]
+fn nontty_sigterm_propagates_as_143() {
+    q9()
+        // Force the non-TTY bypass by piping stdin even though
+        // the helper does not consume it; assert_cmd already
+        // pipes stdout/stderr by default.
+        .write_stdin("")
+        .args(["sh", "-c", "kill -15 $$"])
+        .assert()
+        .code(143);
+}

--- a/tests/nontty_passthrough.rs
+++ b/tests/nontty_passthrough.rs
@@ -82,6 +82,12 @@ fn assert_no_escape(label: &str, bytes: &[u8]) {
 #[cfg(unix)]
 #[test]
 fn nontty_sigterm_propagates_as_143() {
+    // Asserting the stderr diagnostic in addition to the exit
+    // code is what distinguishes a real signal-death (q9 takes
+    // the `Error::Signal` branch and prints
+    // `q9: child terminated by signal 15`) from a hypothetical
+    // child that simply exited cleanly with status 143. Without
+    // this, the test would still pass on the latter false case.
     q9()
         // Force the non-TTY bypass by piping stdin even though
         // the helper does not consume it; assert_cmd already
@@ -89,5 +95,8 @@ fn nontty_sigterm_propagates_as_143() {
         .write_stdin("")
         .args(["sh", "-c", "kill -15 $$"])
         .assert()
-        .code(143);
+        .code(143)
+        .stderr(predicates::str::contains(
+            "child terminated by signal 15",
+        ));
 }

--- a/tests/pty_e2e.rs
+++ b/tests/pty_e2e.rs
@@ -63,14 +63,24 @@ mod unix {
         command.args(["sh", "-c", "kill -15 $$"]);
 
         let mut session = spawn_command(command, Some(TIMEOUT_MS))?;
-        let _remaining = session.exp_eof()?;
+        let remaining = session.exp_eof()?;
 
         match session.process.wait()? {
-            WaitStatus::Exited(_, 143) => Ok(()),
+            WaitStatus::Exited(_, 143) => {}
             other => {
                 panic!("expected q9 to surface SIGTERM as exit 143, got {other:?}")
             }
         }
+
+        // Also assert the diagnostic so the test cannot pass on a
+        // child that merely exited cleanly with status 143; the
+        // PTY merges stdout+stderr so the eprintln from `lib.rs`
+        // appears on the master side captured by `exp_eof`.
+        assert!(
+            remaining.contains("child terminated by signal 15"),
+            "expected SIGTERM diagnostic on PTY output, got {remaining:?}"
+        );
+        Ok(())
     }
 }
 

--- a/tests/pty_e2e.rs
+++ b/tests/pty_e2e.rs
@@ -46,6 +46,32 @@ mod unix {
             other => panic!("expected q9 sh -c 'exit 7' to exit 7, got {other:?}"),
         }
     }
+
+    /// Issue #24 E2E coverage: a PTY child killed by SIGTERM
+    /// must propagate as host exit `128 + 15 = 143`. The unit
+    /// tests in `src/pty/exit.rs` and `src/error.rs` cover the
+    /// type-level mapping with mocks; this exercises the full
+    /// chain (real `portable-pty` reporting → `map_exit_status`
+    /// → `Error::Signal` → `ExitCode`) for the wrap path.
+    #[test]
+    fn q9_pty_sigterm_propagates_as_143() -> Result<(), Box<dyn std::error::Error>> {
+        let mut command = q9();
+        // `kill -TERM $$` raises SIGTERM in the shell itself, so
+        // `Child::wait` reports termination by signal 15. Using
+        // an explicit numeric signal avoids depending on `kill`'s
+        // signal-name parsing across distributions.
+        command.args(["sh", "-c", "kill -15 $$"]);
+
+        let mut session = spawn_command(command, Some(TIMEOUT_MS))?;
+        let _remaining = session.exp_eof()?;
+
+        match session.process.wait()? {
+            WaitStatus::Exited(_, 143) => Ok(()),
+            other => {
+                panic!("expected q9 to surface SIGTERM as exit 143, got {other:?}")
+            }
+        }
+    }
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
## Summary

Closes #24.

The audit on this issue found that the production wiring for child
exit-code propagation was already complete:

- `src/pty/exit.rs::map_exit_status` performs the
  `portable_pty::ExitStatus` → `Result<ExitCode, Error>` mapping with
  a three-layer signal-name → signum recovery (libc `strsignal` reverse
  lookup, English POSIX allowlist, `"Signal N"` parse).
- `src/error.rs::Error::exit_code` maps `Error::Signal { signum }` to
  `128 + clamp(signum, 0, 127)`.
- Both wrap entry points feed into them: the PTY path via
  `pty/session.rs::run_pump_session`, the non-TTY path via
  `pty/mod.rs::non_tty_passthrough` plus
  `portable_pty::ExitStatus::from(std::process::ExitStatus)` (which
  preserves Unix `ExitStatusExt::signal()`).
- Unit tests cover the type-level mapping.

What was missing was an **end-to-end** test exercising the
*signal-death* branch through the full chain. Existing E2E coverage
only hit clean numeric exits (0 and 7).

## Changes

Test-only PR.

- `tests/pty_e2e.rs` — new `q9_pty_sigterm_propagates_as_143`
  (`#[cfg(unix)]`, rexpect, `q9 sh -c 'kill -15 $$'`); asserts both
  `WaitStatus::Exited(_, 143)` and the `child terminated by signal 15`
  diagnostic on PTY output.
- `tests/nontty_passthrough.rs` — new `nontty_sigterm_propagates_as_143`
  (`#[cfg(unix)]`, assert_cmd, stdin piped to force the non-TTY
  bypass); asserts exit code 143 plus the same diagnostic on stderr.
- `src/pty/exit.rs` — module-level docs gain a "Test layering" section
  pointing at the unit-vs-E2E split.

The diagnostic assertions distinguish a real `Error::Signal` flow
from a hypothetical child that merely exited cleanly with status 143
(rubber-duck finding).

## Out of scope

- Windows ConPTY signal coverage — POSIX signal semantics do not
  apply; tracked by #65.
- SIGKILL coverage — adds little signal that SIGTERM does not, and
  is more variable on contended runners.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features` (was 277, now 279)

## Commits

- `f870c93` — test(pty): cover SIGTERM propagation through PTY wrap path
- `0007d54` — test(pty): cover SIGTERM propagation through non-TTY wrap path
- `4c18307` — docs(pty/exit): note unit-vs-integration test layering
- `8272d23` — test(pty): assert signal diagnostic alongside exit code 143


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for testing signal and exit code mapping behavior across recovery layers.

* **Tests**
  * Added end-to-end tests for signal termination handling in TTY and non-TTY modes, ensuring exit codes are correctly propagated when processes are terminated by signals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->