### PR TITLE
docs(trigger): pin bracketed paste policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ There are no other flags. Any unrecognized leading `-…` token
 `qorrection`). Trigger behavior, the 418 gag, and the wrapped
 program allowlist are all built in — none of them are
 configurable in v0.1.
+Detailed trigger edge policies, including bracketed paste, live in
+[docs/trigger-policy.md](docs/trigger-policy.md).
 
 ### Triggers (locked policy)
 

--- a/docs/trigger-policy.md
+++ b/docs/trigger-policy.md
@@ -1,0 +1,35 @@
+# Trigger Pipeline Policy
+
+This document pins the v0.1 behavior for trigger detection edges
+that are easy to change accidentally while wiring the real PTY
+pump.
+
+## Bracketed Paste
+
+`qorrection` is observer-only for DEC private mode 2004:
+
+- it does not emit `ESC[?2004h` or `ESC[?2004l`;
+- it does not strip `ESC[200~` / `ESC[201~` markers;
+- it does not synthesize markers around pasted bytes.
+
+When the wrapped child enables bracketed-paste mode, the terminal
+sends the begin/end markers in the user's input stream. The input
+pump forwards those marker bytes to the child unchanged, while
+`PasteTracker` uses them to temporarily bypass the trigger parser.
+This prevents pasted source text containing `:q`, `:wq`, or `:q!`
+from firing an animation.
+
+When the child does not enable bracketed-paste mode, pasted text
+is indistinguishable from typed text. In that case a pasted `:q`
+line is treated exactly like a typed `:q` line.
+
+## Pump Contract
+
+The input pump must snapshot tracker state before each byte,
+feed the byte into `PasteTracker`, and bypass `Parser` when either
+the pre-byte or post-byte paste state is active. It must also call
+`Parser::reset` on every transition into or out of paste mode.
+
+That pre/post rule keeps the marker bytes themselves away from
+the parser, including the trailing `~` of `ESC[201~`, which is the
+byte that flips the tracker back to non-paste mode.

--- a/src/trigger/paste.rs
+++ b/src/trigger/paste.rs
@@ -10,7 +10,8 @@
 //!
 //! This tracker is a pure observer. It never mutates, buffers,
 //! or steals bytes; the caller keeps forwarding the original
-//! stream unchanged to both the child PTY and the parser. The
+//! stream unchanged to the child PTY and uses the tracker result
+//! to decide whether the trigger parser should see each byte. The
 //! tracker only answers one question:
 //! "after consuming the byte I just gave you, am I currently
 //! inside a bracketed-paste span?".
@@ -32,6 +33,19 @@
 //! the prefix. ESC anywhere -- including inside a paste span --
 //! restarts the recognizer, so a legitimate `\x1b[201~` end
 //! marker is still recognized when paste mode is on.
+//!
+//! ## v0.1 bracketed-paste policy
+//!
+//! The wrapper is **observer-only** for DEC private mode 2004:
+//! it never emits `\x1b[?2004h` / `\x1b[?2004l`, never strips
+//! bracketed-paste markers, and never fabricates them. If the
+//! child enables bracketed-paste mode, the terminal sends
+//! `\x1b[200~` / `\x1b[201~` in the user's input stream; the
+//! pump forwards those bytes to the child unchanged while this
+//! tracker uses them only to decide whether trigger parsing is
+//! temporarily disarmed. If the child does not enable mode 2004,
+//! pasted text is indistinguishable from typed text and remains
+//! eligible for normal trigger parsing.
 
 #[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
 enum State {

--- a/tests/trigger_grammar.rs
+++ b/tests/trigger_grammar.rs
@@ -12,11 +12,14 @@
 //!
 //! ```text
 //!     for each input byte b:
+//!         in_paste_before = paste.in_paste()
+//!         alt_before      = altscreen.is_alt_screen()
 //!         in_paste_after = paste.feed(b)
 //!         alt_after      = altscreen.feed(b)   // output side, but
 //!                                              // wired here for
 //!                                              // grammar tests
-//!         if in_paste_after || alt_after:
+//!         if in_paste_before || in_paste_after ||
+//!            alt_before || alt_after:
 //!             parser.reset()       // disarm boundary
 //!             continue              // bypass parser
 //!         outcome = parser.feed(b)
@@ -87,6 +90,15 @@ fn pasted_then_typed_quit_still_matches_after_paste() {
     stream.extend_from_slice(b"\x1b[201~");
     stream.extend_from_slice(b":q\n");
     assert_eq!(run(&stream), vec![Outcome::Q]);
+}
+
+#[test]
+fn unmarked_paste_like_quit_literal_is_plain_input() {
+    // v0.1 policy: qorrection does not enable bracketed-paste
+    // mode on its own. Without terminal-provided 200~/201~
+    // markers, pasted text and typed text are intentionally
+    // indistinguishable to the trigger pipeline.
+    assert_eq!(run(b":q\n"), vec![Outcome::Q]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- decide v0.1 bracketed paste handling as observer-only for DEC private mode 2004
- document the pump contract for pre/post paste-state bypass and parser reset boundaries
- add a grammar regression for unmarked paste-like `:q` input remaining normal input

## Verification
- `rustup run stable cargo fmt --check`
- `RUSTC=/home/kurone-kito/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc rustup run stable cargo clippy --all-targets -- -D warnings`
- `RUSTC=/home/kurone-kito/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc rustup run stable cargo test --all-targets --all-features`

Closes #41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Extended README with a reference to a detailed trigger policy document.
  * Added new documentation page defining bracketed paste mode behavior for v0.1.
  * Clarified paste tracker behavior and DEC private mode handling in existing documentation.

* **Tests**
  * Added integration test to verify correct handling of bracketed paste scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->