### PR TITLE
feat(trigger): observe alt screen output

### DIFF
--- a/docs/trigger-policy.md
+++ b/docs/trigger-policy.md
@@ -31,6 +31,10 @@ this contract. The real host-input pump feeds user bytes through
 through `InputPump::feed_child_output_byte` so alternate-screen state
 can disarm input parsing.
 
+`trigger::output::OutputArbiter` is the canonical child-output
+adapter. It forwards child output unchanged and feeds the bytes that
+were accepted by the host writer into the shared `InputPump`.
+
 The input pump must snapshot tracker state before each byte,
 feed the byte into `PasteTracker`, and bypass `Parser` when either
 the pre-byte or post-byte paste state is active. It must also call

--- a/src/pty/pump.rs
+++ b/src/pty/pump.rs
@@ -12,6 +12,7 @@ use std::io::{Read, Write};
 
 use crate::pty::forward::{spawn_forwarder, Direction, ForwarderHandle};
 use crate::pty::spawn::SpawnedSession;
+use crate::trigger::{input::shared_input_pump, output::OutputArbiter};
 use crate::{Error, Result};
 
 /// Owning bundle of the host↔child forwarder threads.
@@ -49,6 +50,8 @@ where
 {
     let pty_reader = session.master.try_clone_reader().map_err(Error::Pty)?;
     let pty_writer = session.master.take_writer().map_err(Error::Pty)?;
+    let trigger_input = shared_input_pump();
+    let host_stdout = OutputArbiter::new(host_stdout, trigger_input);
 
     let host_to_child = spawn_forwarder(Direction::HostToChild, host_stdin, pty_writer);
     let child_to_host = spawn_forwarder(Direction::ChildToHost, pty_reader, host_stdout);

--- a/src/trigger/input.rs
+++ b/src/trigger/input.rs
@@ -18,6 +18,8 @@
 //! unchanged; later phases can use the same observations to route
 //! matching trigger bytes away from the child.
 
+use std::sync::{Arc, Mutex};
+
 use super::{
     altscreen::AltScreenTracker,
     parser::{Outcome, Parser},
@@ -53,6 +55,14 @@ impl InputObservation {
             Self::Parsed(outcome) => outcome,
         }
     }
+}
+
+/// Shared input-pump state used by the host-input and child-output
+/// pump halves.
+pub type SharedInputPump = Arc<Mutex<InputPump>>;
+
+pub fn shared_input_pump() -> SharedInputPump {
+    Arc::new(Mutex::new(InputPump::new()))
 }
 
 /// Pure state machine for input-side trigger detection.

--- a/src/trigger/mod.rs
+++ b/src/trigger/mod.rs
@@ -4,6 +4,7 @@
 //! typed a Vim-style quit literal at an interactive prompt:
 //!
 //! - [`input`]     -- combined input-side pump state machine
+//! - [`output`]    -- child-output arbiter that updates alt-screen state
 //! - [`paste`]     -- bracketed-paste tracker (suppress while pasted)
 //! - [`altscreen`] -- alt-screen tracker on the **output** side
 //!   (suppress while a TUI like vim is up)
@@ -15,5 +16,6 @@
 
 pub mod altscreen;
 pub mod input;
+pub mod output;
 pub mod parser;
 pub mod paste;

--- a/src/trigger/output.rs
+++ b/src/trigger/output.rs
@@ -1,0 +1,139 @@
+//! Output-side trigger arbiter.
+//!
+//! `OutputArbiter` is a [`Write`] adapter for the child-to-host
+//! pump. It forwards child output unchanged while feeding the
+//! accepted bytes into the shared [`super::input::InputPump`] so
+//! alternate-screen CSI sequences can disarm input-side trigger
+//! parsing.
+//!
+//! The adapter observes only bytes accepted by the wrapped writer.
+//! This keeps partial writes safe: the forwarder will retry the
+//! remaining suffix, and those bytes are observed exactly when that
+//! retry is accepted.
+
+use std::io::{self, Write};
+
+use super::input::SharedInputPump;
+
+/// Child-output [`Write`] adapter that updates trigger state while
+/// preserving byte-for-byte passthrough.
+#[derive(Debug)]
+pub struct OutputArbiter<W> {
+    inner: W,
+    input: SharedInputPump,
+}
+
+impl<W> OutputArbiter<W> {
+    pub fn new(inner: W, input: SharedInputPump) -> Self {
+        Self { inner, input }
+    }
+
+    #[cfg(test)]
+    fn inner(&self) -> &W {
+        &self.inner
+    }
+}
+
+impl<W> Write for OutputArbiter<W>
+where
+    W: Write,
+{
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let written = self.inner.write(buf)?;
+        if written > 0 {
+            let mut input = self.input.lock().map_err(|_| {
+                io::Error::other("trigger input pump mutex poisoned while observing child output")
+            })?;
+            input.feed_child_output_slice(&buf[..written]);
+        }
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::trigger::input::shared_input_pump;
+
+    const ENTER_ALT: &[u8] = b"\x1b[?1049h";
+    const LEAVE_ALT: &[u8] = b"\x1b[?1049l";
+
+    #[derive(Debug, Default)]
+    struct OneByteWriter {
+        bytes: Vec<u8>,
+    }
+
+    impl Write for OneByteWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            if buf.is_empty() {
+                return Ok(0);
+            }
+            self.bytes.push(buf[0]);
+            Ok(1)
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct ZeroWriter;
+
+    impl Write for ZeroWriter {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Ok(0)
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn forwards_output_unchanged() {
+        let input = shared_input_pump();
+        let mut arbiter = OutputArbiter::new(Vec::new(), input.clone());
+
+        arbiter.write_all(b"hello").unwrap();
+
+        assert_eq!(arbiter.inner(), b"hello");
+        assert!(!input.lock().unwrap().is_alt_screen());
+    }
+
+    #[test]
+    fn feeds_alt_screen_enter_and_leave() {
+        let input = shared_input_pump();
+        let mut arbiter = OutputArbiter::new(Vec::new(), input.clone());
+
+        arbiter.write_all(ENTER_ALT).unwrap();
+        assert!(input.lock().unwrap().is_alt_screen());
+
+        arbiter.write_all(LEAVE_ALT).unwrap();
+        assert!(!input.lock().unwrap().is_alt_screen());
+    }
+
+    #[test]
+    fn partial_writes_are_observed_once() {
+        let input = shared_input_pump();
+        let mut arbiter = OutputArbiter::new(OneByteWriter::default(), input.clone());
+
+        arbiter.write_all(ENTER_ALT).unwrap();
+
+        assert_eq!(arbiter.inner().bytes, ENTER_ALT);
+        assert!(input.lock().unwrap().is_alt_screen());
+    }
+
+    #[test]
+    fn unwritten_bytes_are_not_observed() {
+        let input = shared_input_pump();
+        let mut arbiter = OutputArbiter::new(ZeroWriter, input.clone());
+
+        assert_eq!(arbiter.write(ENTER_ALT).unwrap(), 0);
+
+        assert!(!input.lock().unwrap().is_alt_screen());
+    }
+}


### PR DESCRIPTION
## Summary
- add `trigger::output::OutputArbiter` as the child-output `Write` adapter for alt-screen observation
- share `InputPump` state behind `Arc<Mutex<_>>` so output can disarm future input-side detection
- wrap the current child-to-host PTY forwarder with the arbiter while preserving byte-for-byte passthrough

## Verification
- `rustup run stable cargo fmt --check`
- `RUSTC=/home/kurone-kito/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc rustup run stable cargo test trigger::output`
- `RUSTC=/home/kurone-kito/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc rustup run stable cargo test pty::pump::real_pump`
- `RUSTC=/home/kurone-kito/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc rustup run stable cargo clippy --all-targets -- -D warnings`
- `RUSTC=/home/kurone-kito/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc rustup run stable cargo test --all-targets --all-features`

Closes #40