### PR TITLE
feat(trigger): log input detections

### DIFF
--- a/docs/trigger-policy.md
+++ b/docs/trigger-policy.md
@@ -31,6 +31,10 @@ this contract. The real host-input pump feeds user bytes through
 through `InputPump::feed_child_output_byte` so alternate-screen state
 can disarm input parsing.
 
+`trigger::input::InputDetector` is the Phase 3 detect-only host-input
+adapter. It forwards bytes unchanged and emits `tracing::info!` only
+when `InputPump` reports a trigger outcome.
+
 `trigger::output::OutputArbiter` is the canonical child-output
 adapter. It forwards child output unchanged and feeds the bytes that
 were accepted by the host writer into the shared `InputPump`.

--- a/docs/trigger-policy.md
+++ b/docs/trigger-policy.md
@@ -32,8 +32,9 @@ through `InputPump::feed_child_output_byte` so alternate-screen state
 can disarm input parsing.
 
 `trigger::input::InputDetector` is the Phase 3 detect-only host-input
-adapter. It forwards bytes unchanged and emits `tracing::info!` only
-when `InputPump` reports a trigger outcome.
+adapter. It forwards host input unchanged to the child writer, feeds
+only the bytes accepted by that writer into the shared `InputPump`, and
+emits `tracing::info!` only when `InputPump` reports a trigger outcome.
 
 `trigger::output::OutputArbiter` is the canonical child-output
 adapter. It forwards child output unchanged and feeds the bytes that

--- a/src/pty/pump.rs
+++ b/src/pty/pump.rs
@@ -12,7 +12,10 @@ use std::io::{Read, Write};
 
 use crate::pty::forward::{spawn_forwarder, Direction, ForwarderHandle};
 use crate::pty::spawn::SpawnedSession;
-use crate::trigger::{input::shared_input_pump, output::OutputArbiter};
+use crate::trigger::{
+    input::{shared_input_pump, InputDetector},
+    output::OutputArbiter,
+};
 use crate::{Error, Result};
 
 /// Owning bundle of the host↔child forwarder threads.
@@ -51,6 +54,7 @@ where
     let pty_reader = session.master.try_clone_reader().map_err(Error::Pty)?;
     let pty_writer = session.master.take_writer().map_err(Error::Pty)?;
     let trigger_input = shared_input_pump();
+    let host_stdin = InputDetector::new(host_stdin, trigger_input.clone());
     let host_stdout = OutputArbiter::new(host_stdout, trigger_input);
 
     let host_to_child = spawn_forwarder(Direction::HostToChild, host_stdin, pty_writer);

--- a/src/pty/pump.rs
+++ b/src/pty/pump.rs
@@ -54,7 +54,7 @@ where
     let pty_reader = session.master.try_clone_reader().map_err(Error::Pty)?;
     let pty_writer = session.master.take_writer().map_err(Error::Pty)?;
     let trigger_input = shared_input_pump();
-    let host_stdin = InputDetector::new(host_stdin, trigger_input.clone());
+    let pty_writer = InputDetector::new(pty_writer, trigger_input.clone());
     let host_stdout = OutputArbiter::new(host_stdout, trigger_input);
 
     let host_to_child = spawn_forwarder(Direction::HostToChild, host_stdin, pty_writer);

--- a/src/trigger/input.rs
+++ b/src/trigger/input.rs
@@ -18,6 +18,7 @@
 //! unchanged; later phases can use the same observations to route
 //! matching trigger bytes away from the child.
 
+use std::io::{self, Read};
 use std::sync::{Arc, Mutex};
 
 use super::{
@@ -63,6 +64,59 @@ pub type SharedInputPump = Arc<Mutex<InputPump>>;
 
 pub fn shared_input_pump() -> SharedInputPump {
     Arc::new(Mutex::new(InputPump::new()))
+}
+
+/// Host-input [`Read`] adapter for Phase 3 detect-only wiring.
+///
+/// The adapter preserves the byte stream exactly as read from the
+/// wrapped reader. It only mirrors accepted host-input bytes into
+/// the shared [`InputPump`] and emits an `info` diagnostic when a
+/// trigger literal is detected.
+#[derive(Debug)]
+pub struct InputDetector<R> {
+    inner: R,
+    input: SharedInputPump,
+}
+
+impl<R> InputDetector<R> {
+    pub fn new(inner: R, input: SharedInputPump) -> Self {
+        Self { inner, input }
+    }
+}
+
+impl<R> Read for InputDetector<R>
+where
+    R: Read,
+{
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let n = self.inner.read(buf)?;
+        if n > 0 {
+            observe_detected_input(&self.input, &buf[..n], |outcome| {
+                tracing::info!(?outcome, "trigger detect-only: matched host input trigger");
+            })?;
+        }
+        Ok(n)
+    }
+}
+
+fn observe_detected_input<F>(
+    input: &SharedInputPump,
+    bytes: &[u8],
+    mut on_detect: F,
+) -> io::Result<()>
+where
+    F: FnMut(Outcome),
+{
+    let mut input = input.lock().map_err(|_| {
+        io::Error::other("trigger input pump mutex poisoned while observing host input")
+    })?;
+    for &b in bytes {
+        let outcome = input.feed_input_byte(b).outcome();
+        if outcome != Outcome::None {
+            on_detect(outcome);
+        }
+    }
+    Ok(())
 }
 
 /// Pure state machine for input-side trigger detection.
@@ -137,6 +191,7 @@ impl InputPump {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Cursor;
 
     const BEGIN_PASTE: &[u8] = b"\x1b[200~";
     const END_PASTE: &[u8] = b"\x1b[201~";
@@ -149,6 +204,56 @@ mod tests {
             .map(|&b| pump.feed_input_byte(b).outcome())
             .filter(|&outcome| outcome != Outcome::None)
             .collect()
+    }
+
+    fn detect_for_test(input: &SharedInputPump, bytes: &[u8]) -> Vec<Outcome> {
+        let mut detected = Vec::new();
+        observe_detected_input(input, bytes, |outcome| detected.push(outcome)).unwrap();
+        detected
+    }
+
+    #[test]
+    fn detect_only_helper_reports_plain_trigger() {
+        let input = shared_input_pump();
+        let detected = detect_for_test(&input, b":wq\n");
+
+        assert_eq!(detected, vec![Outcome::Wq]);
+    }
+
+    #[test]
+    fn detect_only_helper_respects_alt_screen_state() {
+        let input = shared_input_pump();
+        input.lock().unwrap().feed_child_output_slice(ENTER_ALT);
+
+        assert_eq!(detect_for_test(&input, b":q\n"), vec![]);
+
+        input.lock().unwrap().feed_child_output_slice(LEAVE_ALT);
+        assert_eq!(detect_for_test(&input, b":q!\n"), vec![Outcome::QBang]);
+    }
+
+    #[test]
+    fn input_detector_forwards_bytes_unchanged() {
+        let input = shared_input_pump();
+        let mut detector = InputDetector::new(Cursor::new(b":q\n".to_vec()), input);
+        let mut out = Vec::new();
+
+        detector.read_to_end(&mut out).unwrap();
+
+        assert_eq!(out, b":q\n");
+    }
+
+    #[test]
+    fn input_detector_preserves_cross_read_state() {
+        let input = shared_input_pump();
+        let mut detector = InputDetector::new(Cursor::new(b":q\n".to_vec()), input.clone());
+        let mut byte = [0u8; 1];
+
+        assert_eq!(detector.read(&mut byte).unwrap(), 1);
+        assert_eq!(detector.read(&mut byte).unwrap(), 1);
+        assert_eq!(detector.read(&mut byte).unwrap(), 1);
+        assert_eq!(detector.read(&mut byte).unwrap(), 0);
+
+        assert_eq!(detect_for_test(&input, b":wq\n"), vec![Outcome::Wq]);
     }
 
     #[test]

--- a/src/trigger/input.rs
+++ b/src/trigger/input.rs
@@ -91,9 +91,11 @@ where
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let n = self.inner.read(buf)?;
         if n > 0 {
-            observe_detected_input(&self.input, &buf[..n], |outcome| {
+            if let Err(err) = observe_detected_input(&self.input, &buf[..n], |outcome| {
                 tracing::info!(?outcome, "trigger detect-only: matched host input trigger");
-            })?;
+            }) {
+                tracing::warn!(error = %err, "trigger detect-only observation failed");
+            }
         }
         Ok(n)
     }
@@ -254,6 +256,37 @@ mod tests {
         assert_eq!(detector.read(&mut byte).unwrap(), 0);
 
         assert_eq!(detect_for_test(&input, b":wq\n"), vec![Outcome::Wq]);
+    }
+
+    #[test]
+    fn input_detector_observes_into_shared_pump() {
+        let input = shared_input_pump();
+        let mut detector = InputDetector::new(Cursor::new(b":".to_vec()), input.clone());
+        let mut out = Vec::new();
+
+        detector.read_to_end(&mut out).unwrap();
+
+        assert_eq!(out, b":");
+        assert_eq!(detect_for_test(&input, b"q\n"), vec![Outcome::Q]);
+    }
+
+    #[test]
+    fn input_detector_keeps_forwarding_when_observer_fails() {
+        let input = shared_input_pump();
+        let _ = std::panic::catch_unwind({
+            let input = input.clone();
+            move || {
+                let _guard = input.lock().unwrap();
+                panic!("poison trigger input mutex for test");
+            }
+        });
+
+        let mut detector = InputDetector::new(Cursor::new(b":q\n".to_vec()), input);
+        let mut out = Vec::new();
+
+        detector.read_to_end(&mut out).unwrap();
+
+        assert_eq!(out, b":q\n");
     }
 
     #[test]

--- a/src/trigger/input.rs
+++ b/src/trigger/input.rs
@@ -18,7 +18,7 @@
 //! unchanged; later phases can use the same observations to route
 //! matching trigger bytes away from the child.
 
-use std::io::{self, Read};
+use std::io::{self, Write};
 use std::sync::{Arc, Mutex};
 
 use super::{
@@ -66,38 +66,47 @@ pub fn shared_input_pump() -> SharedInputPump {
     Arc::new(Mutex::new(InputPump::new()))
 }
 
-/// Host-input [`Read`] adapter for Phase 3 detect-only wiring.
+/// Host-input [`Write`] adapter for Phase 3 detect-only wiring.
 ///
-/// The adapter preserves the byte stream exactly as read from the
-/// wrapped reader. It only mirrors accepted host-input bytes into
-/// the shared [`InputPump`] and emits an `info` diagnostic when a
-/// trigger literal is detected.
+/// The adapter preserves the byte stream exactly as accepted by the
+/// wrapped writer. It only mirrors accepted host-input bytes into the
+/// shared [`InputPump`] and emits an `info` diagnostic when a trigger
+/// literal is detected.
 #[derive(Debug)]
-pub struct InputDetector<R> {
-    inner: R,
+pub struct InputDetector<W> {
+    inner: W,
     input: SharedInputPump,
 }
 
-impl<R> InputDetector<R> {
-    pub fn new(inner: R, input: SharedInputPump) -> Self {
+impl<W> InputDetector<W> {
+    pub fn new(inner: W, input: SharedInputPump) -> Self {
         Self { inner, input }
+    }
+
+    #[cfg(test)]
+    fn inner(&self) -> &W {
+        &self.inner
     }
 }
 
-impl<R> Read for InputDetector<R>
+impl<W> Write for InputDetector<W>
 where
-    R: Read,
+    W: Write,
 {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let n = self.inner.read(buf)?;
-        if n > 0 {
-            if let Err(err) = observe_detected_input(&self.input, &buf[..n], |outcome| {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let written = self.inner.write(buf)?;
+        if written > 0 {
+            if let Err(err) = observe_detected_input(&self.input, &buf[..written], |outcome| {
                 tracing::info!(?outcome, "trigger detect-only: matched host input trigger");
             }) {
                 tracing::warn!(error = %err, "trigger detect-only observation failed");
             }
         }
-        Ok(n)
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
     }
 }
 
@@ -199,12 +208,52 @@ impl InputPump {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Cursor;
 
     const BEGIN_PASTE: &[u8] = b"\x1b[200~";
     const END_PASTE: &[u8] = b"\x1b[201~";
     const ENTER_ALT: &[u8] = b"\x1b[?1049h";
     const LEAVE_ALT: &[u8] = b"\x1b[?1049l";
+
+    #[derive(Debug, Default)]
+    struct OneByteWriter {
+        bytes: Vec<u8>,
+    }
+
+    impl Write for OneByteWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            if buf.is_empty() {
+                return Ok(0);
+            }
+            self.bytes.push(buf[0]);
+            Ok(1)
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct BrokenPipeAfterOne {
+        bytes: Vec<u8>,
+    }
+
+    impl Write for BrokenPipeAfterOne {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            if buf.is_empty() {
+                return Ok(0);
+            }
+            if self.bytes.is_empty() {
+                self.bytes.push(buf[0]);
+                return Ok(1);
+            }
+            Err(io::Error::new(io::ErrorKind::BrokenPipe, "closed"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
 
     fn outcomes_for_input(pump: &mut InputPump, bytes: &[u8]) -> Vec<Outcome> {
         bytes
@@ -242,24 +291,21 @@ mod tests {
     #[test]
     fn input_detector_forwards_bytes_unchanged() {
         let input = shared_input_pump();
-        let mut detector = InputDetector::new(Cursor::new(b":q\n".to_vec()), input);
-        let mut out = Vec::new();
+        let mut detector = InputDetector::new(Vec::new(), input);
 
-        detector.read_to_end(&mut out).unwrap();
+        detector.write_all(b":q\n").unwrap();
 
-        assert_eq!(out, b":q\n");
+        assert_eq!(detector.inner().as_slice(), b":q\n");
     }
 
     #[test]
-    fn input_detector_preserves_cross_read_state() {
+    fn input_detector_preserves_cross_write_state() {
         let input = shared_input_pump();
-        let mut detector = InputDetector::new(Cursor::new(b":q\n".to_vec()), input.clone());
-        let mut byte = [0u8; 1];
+        let mut detector = InputDetector::new(Vec::new(), input.clone());
 
-        assert_eq!(detector.read(&mut byte).unwrap(), 1);
-        assert_eq!(detector.read(&mut byte).unwrap(), 1);
-        assert_eq!(detector.read(&mut byte).unwrap(), 1);
-        assert_eq!(detector.read(&mut byte).unwrap(), 0);
+        assert_eq!(detector.write(b":").unwrap(), 1);
+        assert_eq!(detector.write(b"q").unwrap(), 1);
+        assert_eq!(detector.write(b"\n").unwrap(), 1);
 
         assert_eq!(detect_for_test(&input, b":wq\n"), vec![Outcome::Wq]);
     }
@@ -267,13 +313,35 @@ mod tests {
     #[test]
     fn input_detector_observes_into_shared_pump() {
         let input = shared_input_pump();
-        let mut detector = InputDetector::new(Cursor::new(b":".to_vec()), input.clone());
-        let mut out = Vec::new();
+        let mut detector = InputDetector::new(Vec::new(), input.clone());
 
-        detector.read_to_end(&mut out).unwrap();
+        detector.write_all(b":").unwrap();
 
-        assert_eq!(out, b":");
+        assert_eq!(detector.inner().as_slice(), b":");
         assert_eq!(detect_for_test(&input, b"q\n"), vec![Outcome::Q]);
+    }
+
+    #[test]
+    fn input_detector_observes_only_accepted_write_prefix() {
+        let input = shared_input_pump();
+        let mut detector = InputDetector::new(OneByteWriter::default(), input.clone());
+
+        assert_eq!(detector.write(b":q").unwrap(), 1);
+
+        assert_eq!(detector.inner().bytes.as_slice(), b":");
+        assert_eq!(detect_for_test(&input, b"\n"), vec![]);
+    }
+
+    #[test]
+    fn input_detector_skips_broken_pipe_suffix() {
+        let input = shared_input_pump();
+        let mut detector = InputDetector::new(BrokenPipeAfterOne::default(), input.clone());
+
+        let err = detector.write_all(b":q").unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
+        assert_eq!(detector.inner().bytes.as_slice(), b":");
+        assert_eq!(detect_for_test(&input, b"\n"), vec![]);
     }
 
     #[test]
@@ -303,12 +371,11 @@ mod tests {
             }
         });
 
-        let mut detector = InputDetector::new(Cursor::new(b":q\n".to_vec()), input);
-        let mut out = Vec::new();
+        let mut detector = InputDetector::new(Vec::new(), input);
 
-        detector.read_to_end(&mut out).unwrap();
+        detector.write_all(b":q\n").unwrap();
 
-        assert_eq!(out, b":q\n");
+        assert_eq!(detector.inner().as_slice(), b":q\n");
     }
 
     #[test]

--- a/src/trigger/input.rs
+++ b/src/trigger/input.rs
@@ -109,14 +109,20 @@ fn observe_detected_input<F>(
 where
     F: FnMut(Outcome),
 {
+    let mut detected = Vec::new();
     let mut input = input.lock().map_err(|_| {
         io::Error::other("trigger input pump mutex poisoned while observing host input")
     })?;
     for &b in bytes {
         let outcome = input.feed_input_byte(b).outcome();
         if outcome != Outcome::None {
-            on_detect(outcome);
+            detected.push(outcome);
         }
+    }
+    drop(input);
+
+    for outcome in detected {
+        on_detect(outcome);
     }
     Ok(())
 }
@@ -268,6 +274,22 @@ mod tests {
 
         assert_eq!(out, b":");
         assert_eq!(detect_for_test(&input, b"q\n"), vec![Outcome::Q]);
+    }
+
+    #[test]
+    fn observe_detected_input_releases_lock_before_callback() {
+        let input = shared_input_pump();
+        let mut detected = Vec::new();
+
+        observe_detected_input(&input, b":q\n", |outcome| {
+            detected.push(outcome);
+            let _guard = input
+                .try_lock()
+                .expect("input mutex should be released before detection callback");
+        })
+        .unwrap();
+
+        assert_eq!(detected, vec![Outcome::Q]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `trigger::input::InputDetector` as the detect-only host-input `Read` adapter
- log trigger outcomes with `tracing::info!` while keeping host input bytes unchanged
- wire the detector into the PTY host-to-child forwarder using the shared `InputPump` state

## Verification
- `rustup run stable cargo fmt --check`
- `RUSTC=/home/kurone-kito/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc rustup run stable cargo test trigger::input`
- `RUSTC=/home/kurone-kito/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc rustup run stable cargo test pty::pump::real_pump`
- `RUSTC=/home/kurone-kito/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc rustup run stable cargo clippy --all-targets -- -D warnings`
- `RUSTC=/home/kurone-kito/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc rustup run stable cargo test --all-targets --all-features`

Closes #38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified trigger input detection behavior and its detect-only contract within the pipeline.

* **New Features**
  * Added a detect-only input adapter that forwards host input unchanged while observing and logging trigger outcomes.

* **Bug Fixes / Robustness**
  * Input forwarding now continues when observation encounters errors; callbacks run after observation locks are released.

* **Tests**
  * Expanded tests for detection, cross-read state, alt-screen disarming, callback ordering, and error/mutex scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->