### PR TITLE
test(trigger): table input pump modes

### DIFF
--- a/src/trigger/input.rs
+++ b/src/trigger/input.rs
@@ -255,12 +255,39 @@ mod tests {
         }
     }
 
+    #[derive(Debug, Clone, Copy)]
+    enum PumpStep {
+        Host(&'static [u8]),
+        Child(&'static [u8]),
+    }
+
+    struct PumpCase {
+        name: &'static str,
+        steps: &'static [PumpStep],
+        expected_outcomes: &'static [Outcome],
+        final_in_paste: bool,
+        final_alt_screen: bool,
+    }
+
     fn outcomes_for_input(pump: &mut InputPump, bytes: &[u8]) -> Vec<Outcome> {
         bytes
             .iter()
             .map(|&b| pump.feed_input_byte(b).outcome())
             .filter(|&outcome| outcome != Outcome::None)
             .collect()
+    }
+
+    fn outcomes_for_steps(pump: &mut InputPump, steps: &[PumpStep]) -> Vec<Outcome> {
+        let mut outcomes = Vec::new();
+        for step in steps {
+            match step {
+                PumpStep::Host(bytes) => outcomes.extend(outcomes_for_input(pump, bytes)),
+                PumpStep::Child(bytes) => {
+                    pump.feed_child_output_slice(bytes);
+                }
+            }
+        }
+        outcomes
     }
 
     fn detect_for_test(input: &SharedInputPump, bytes: &[u8]) -> Vec<Outcome> {
@@ -384,6 +411,55 @@ mod tests {
         assert_eq!(outcomes_for_input(&mut pump, b":q\n"), vec![Outcome::Q]);
         assert!(!pump.in_paste());
         assert!(!pump.is_alt_screen());
+    }
+
+    #[test]
+    fn pump_input_modes_follow_table() {
+        let cases = [
+            PumpCase {
+                name: "normal prompt input arms all quit literals",
+                steps: &[PumpStep::Host(b":q\n:wq\n:q!\n")],
+                expected_outcomes: &[Outcome::Q, Outcome::Wq, Outcome::QBang],
+                final_in_paste: false,
+                final_alt_screen: false,
+            },
+            PumpCase {
+                name: "bracketed paste bypasses triggers then rearms",
+                steps: &[
+                    PumpStep::Host(BEGIN_PASTE),
+                    PumpStep::Host(b":q\n:wq\n:q!\n"),
+                    PumpStep::Host(END_PASTE),
+                    PumpStep::Host(b":wq\n"),
+                ],
+                expected_outcomes: &[Outcome::Wq],
+                final_in_paste: false,
+                final_alt_screen: false,
+            },
+            PumpCase {
+                name: "alternate screen bypasses triggers then rearms",
+                steps: &[
+                    PumpStep::Child(ENTER_ALT),
+                    PumpStep::Host(b":q\n:wq\n:q!\n"),
+                    PumpStep::Child(LEAVE_ALT),
+                    PumpStep::Host(b":q!\n"),
+                ],
+                expected_outcomes: &[Outcome::QBang],
+                final_in_paste: false,
+                final_alt_screen: false,
+            },
+        ];
+
+        for case in cases {
+            let mut pump = InputPump::new();
+            assert_eq!(
+                outcomes_for_steps(&mut pump, case.steps),
+                case.expected_outcomes,
+                "{}",
+                case.name
+            );
+            assert_eq!(pump.in_paste(), case.final_in_paste, "{}", case.name);
+            assert_eq!(pump.is_alt_screen(), case.final_alt_screen, "{}", case.name);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a table-driven unit test for InputPump normal, bracketed-paste, and alternate-screen modes
- model host input and child output steps in the same scenario table so bypass and rearm behaviour are asserted together

## Verification
- rustup run stable cargo fmt --check
- RUSTC=/home/kurone-kito/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc rustup run stable cargo test trigger::input
- RUSTC=/home/kurone-kito/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc rustup run stable cargo clippy --all-targets -- -D warnings
- RUSTC=/home/kurone-kito/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc rustup run stable cargo test --all-targets --all-features

Rubber-duck self-review: test-only, low-risk change; manually reviewed the diff for coverage, overlap with existing tests, and production-code impact. No findings retained.

Closes #39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved internal test infrastructure for better maintainability and code organization.

---

**Note:** This release contains internal improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->