### PR TITLE
feat(anim): pure frame composer and narrow-terminal fallback

### DIFF
--- a/src/anim/fallback.rs
+++ b/src/anim/fallback.rs
@@ -1,0 +1,165 @@
+//! Plain-text fallback for narrow terminals.
+//!
+//! When the terminal is below 40 columns ([`crate::term::width::
+//! WidthBucket::Tiny`]) the ambulance ASCII car cannot fit, so
+//! the renderer drops the art entirely and emits a single-line
+//! text gag instead. This module owns both the gag strings and
+//! the trigger → gag mapping; the upcoming crossterm renderer
+//! (#47) picks between [`fallback`] and [`super::frame::frame`]
+//! based on the active [`crate::term::width::WidthBucket`].
+//!
+//! The gag strings are intentionally kept short enough to fit
+//! comfortably below 40 columns (the widest is 33 chars), so
+//! even the 30-column fallback bucket renders them on a single
+//! line without terminal-driven wrapping.
+//!
+//! Pure ASCII, single line, no trailing terminator: callers
+//! append their own line-end so this layer stays stylistic-only.
+
+/// A fired quit trigger that the input pump observed.
+///
+/// Mirrors [`crate::trigger::parser::Outcome`] minus the `None`
+/// variant: the fallback gag is only meaningful once a trigger
+/// has actually fired, so we model "no gag" with the absence of
+/// a `Trigger` value rather than a fourth variant. The renderer
+/// is responsible for translating an [`crate::trigger::parser::
+/// Outcome`] into an `Option<Trigger>` before calling
+/// [`fallback`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Trigger {
+    /// `:q` -- standard ambulance gag.
+    Q,
+    /// `:wq` -- ambulance carrying the spec-locked 418 label.
+    Wq,
+    /// `:q!` -- nine-car parade gag.
+    Bang,
+}
+
+/// Single-line plain-text gag emitted at `cols < 40`.
+///
+/// The returned string is `'static`, pure ASCII, and contains no
+/// `\n`. Width is held under 34 columns so the gag fits even at
+/// the narrow end of the fallback bucket; this is verified by
+/// `gags_fit_under_thirty_four_columns` below.
+///
+/// The `[QQ]` prefix mirrors the compact ambulance header used
+/// by the `Small` usage screen (see [`crate::usage::screen`]) so
+/// the fallback feels like the same character muted by the
+/// terminal width budget rather than an unrelated message.
+pub fn fallback(trigger: Trigger) -> &'static str {
+    match trigger {
+        Trigger::Q => "[QQ] Fi-Fo-Fi-Fo... :q copy that.",
+        Trigger::Wq => "[QQ] :wq -- 418 I'm an AI agent.",
+        Trigger::Bang => "[QQ]x9 :q! parade -- 9! = 362880.",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Exhaustive list of the three trigger variants. Adding a
+    /// new variant must update this constant *and* the `match` in
+    /// [`fallback`]; the compiler's exhaustiveness check
+    /// guarantees the second half but not the first, so this
+    /// table guards the test surface.
+    const ALL_TRIGGERS: [Trigger; 3] = [Trigger::Q, Trigger::Wq, Trigger::Bang];
+
+    /// Each trigger maps to a non-empty gag.
+    #[test]
+    fn every_trigger_has_a_gag() {
+        for t in ALL_TRIGGERS {
+            let gag = fallback(t);
+            assert!(!gag.is_empty(), "{t:?} returned empty gag");
+        }
+    }
+
+    /// Distinct triggers produce distinct gags so users can tell
+    /// which command fired even on the narrow fallback path.
+    #[test]
+    fn gags_are_pairwise_distinct() {
+        for (i, a) in ALL_TRIGGERS.iter().enumerate() {
+            for b in ALL_TRIGGERS.iter().skip(i + 1) {
+                assert_ne!(fallback(*a), fallback(*b), "{a:?} and {b:?} share a gag",);
+            }
+        }
+    }
+
+    /// Fallback output is single-line: no embedded `\n` (callers
+    /// add their own terminator) and no embedded `\r`.
+    #[test]
+    fn gags_are_single_line() {
+        for t in ALL_TRIGGERS {
+            let gag = fallback(t);
+            assert!(!gag.contains('\n'), "{t:?} contained LF: {gag:?}");
+            assert!(!gag.contains('\r'), "{t:?} contained CR: {gag:?}");
+        }
+    }
+
+    /// Pure ASCII keeps `chars().count()` equivalent to printed
+    /// columns, matching the rest of the anim layer.
+    #[test]
+    fn gags_are_pure_ascii() {
+        for t in ALL_TRIGGERS {
+            let gag = fallback(t);
+            assert!(gag.is_ascii(), "{t:?} contained non-ASCII: {gag:?}");
+        }
+    }
+
+    /// All gags fit in a 33-column terminal so even the narrow
+    /// end of the fallback bucket renders them without wrapping.
+    /// Hard cap chosen to be at least one column above the longest
+    /// current gag, so accidental drift gets caught by this test.
+    #[test]
+    fn gags_fit_under_thirty_four_columns() {
+        const LIMIT: usize = 33;
+        for t in ALL_TRIGGERS {
+            let gag = fallback(t);
+            let cols = gag.chars().count();
+            assert!(
+                cols <= LIMIT,
+                "{t:?} gag is {cols} cols, exceeds {LIMIT}: {gag:?}",
+            );
+        }
+    }
+
+    /// Each gag references the triggering literal so the user can
+    /// confirm what the wrapper observed.
+    #[test]
+    fn gags_reference_their_trigger_literal() {
+        assert!(fallback(Trigger::Q).contains(":q"));
+        assert!(fallback(Trigger::Wq).contains(":wq"));
+        assert!(fallback(Trigger::Bang).contains(":q!"));
+    }
+
+    /// The `:wq` gag must carry the spec-locked 418 label
+    /// verbatim (issue #11 §4, asset `big.txt`).
+    #[test]
+    fn wq_gag_carries_spec_locked_418_label() {
+        let gag = fallback(Trigger::Wq);
+        assert!(
+            gag.contains("418 I'm an AI agent"),
+            "wq gag missing spec-locked label: {gag:?}",
+        );
+    }
+
+    /// The `:q!` gag references the factorial joke from the
+    /// usage screen (`9! = 362880`) so the parade scene's
+    /// punchline survives the narrow-terminal degradation.
+    #[test]
+    fn bang_gag_keeps_factorial_punchline() {
+        let gag = fallback(Trigger::Bang);
+        assert!(
+            gag.contains("362880"),
+            "bang gag missing 9! = 362880: {gag:?}",
+        );
+    }
+
+    /// `Trigger` is a small `Copy` enum; lock that so callers can
+    /// pass it without `clone()` and pattern-match it freely.
+    #[test]
+    fn trigger_is_copy() {
+        fn assert_copy<T: Copy>() {}
+        assert_copy::<Trigger>();
+    }
+}

--- a/src/anim/fallback.rs
+++ b/src/anim/fallback.rs
@@ -9,9 +9,9 @@
 //! based on the active [`crate::term::width::WidthBucket`].
 //!
 //! The gag strings are intentionally kept short enough to fit
-//! comfortably below 40 columns (the widest is 33 chars), so
-//! even the 30-column fallback bucket renders them on a single
-//! line without terminal-driven wrapping.
+//! in a single line when the terminal is at least 33 columns wide
+//! (the widest gag is 33 chars). Terminals narrower than 33
+//! columns receive a best-effort output that may wrap.
 //!
 //! Pure ASCII, single line, no trailing terminator: callers
 //! append their own line-end so this layer stays stylistic-only.
@@ -38,8 +38,8 @@ pub enum Trigger {
 /// Single-line plain-text gag emitted at `cols < 40`.
 ///
 /// The returned string is `'static`, pure ASCII, and contains no
-/// `\n`. Width is held under 34 columns so the gag fits even at
-/// the narrow end of the fallback bucket; this is verified by
+/// `\n`. Width is held under 34 columns so the gag fits in a
+/// 33-column terminal; this is verified by
 /// `gags_fit_under_thirty_four_columns` below.
 ///
 /// The `[QQ]` prefix mirrors the compact ambulance header used
@@ -106,10 +106,11 @@ mod tests {
         }
     }
 
-    /// All gags fit in a 33-column terminal so even the narrow
-    /// end of the fallback bucket renders them without wrapping.
-    /// Hard cap chosen to be at least one column above the longest
-    /// current gag, so accidental drift gets caught by this test.
+    /// All gags fit in a 33-column terminal so terminals in the
+    /// 33–39 column range of the fallback bucket render them
+    /// without wrapping. The hard cap equals the longest current
+    /// gag (33 cols); any addition that makes a gag wider fails
+    /// this test immediately.
     #[test]
     fn gags_fit_under_thirty_four_columns() {
         const LIMIT: usize = 33;

--- a/src/anim/fallback.rs
+++ b/src/anim/fallback.rs
@@ -18,20 +18,27 @@
 
 /// A fired quit trigger that the input pump observed.
 ///
-/// Mirrors [`crate::trigger::parser::Outcome`] minus the `None`
-/// variant: the fallback gag is only meaningful once a trigger
-/// has actually fired, so we model "no gag" with the absence of
-/// a `Trigger` value rather than a fourth variant. The renderer
-/// is responsible for translating an [`crate::trigger::parser::
-/// Outcome`] into an `Option<Trigger>` before calling
-/// [`fallback`].
+/// Corresponds to [`crate::trigger::parser::Outcome`] minus the
+/// `None` variant: the fallback gag is only meaningful once a
+/// trigger has actually fired, so we model "no gag" with the
+/// absence of a `Trigger` value rather than a fourth variant. The
+/// renderer is responsible for translating an
+/// [`crate::trigger::parser::Outcome`] into an `Option<Trigger>`
+/// before calling [`fallback`].
+///
+/// Note: variant names follow `Outcome` except that
+/// `Outcome::QBang` maps to [`Trigger::Bang`] to avoid the
+/// redundant `Q` prefix inside this enum's namespace.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Trigger {
     /// `:q` -- standard ambulance gag.
     Q,
     /// `:wq` -- ambulance carrying the spec-locked 418 label.
     Wq,
-    /// `:q!` -- nine-car parade gag.
+    /// `:q!` — nine-car parade gag.
+    ///
+    /// Maps from [`crate::trigger::parser::Outcome::QBang`]; the
+    /// shorter name avoids redundancy with the enum prefix.
     Bang,
 }
 

--- a/src/anim/frame.rs
+++ b/src/anim/frame.rs
@@ -236,7 +236,7 @@ mod tests {
 
     /// A clip wider than the longest car row produces all-empty
     /// rows, but the row count is still preserved so animation
-    /// timelines do not desync.
+    /// timelines do not fall out of sync.
     #[test]
     fn frame_negative_offset_beyond_line_length_emits_empty() {
         let out = frame(car::TINY, -100, SirenPhase::Fi);

--- a/src/anim/frame.rs
+++ b/src/anim/frame.rs
@@ -1,0 +1,323 @@
+//! Pure frame generator for the moving-car animation.
+//!
+//! Composes a single rendered frame from three inputs: a car
+//! ASCII asset (one of the variants in [`crate::anim::car`]), the
+//! car's horizontal position, and the current siren phase. The
+//! output is a multi-line `String` with no trailing newline so
+//! callers can append cursor or clear sequences without an extra
+//! blank row.
+//!
+//! The function is intentionally oblivious to terminal width,
+//! scene type, and animation timing: scene orchestrators (Phase
+//! F #43-#45) walk this generator across an `x` range and a
+//! siren cycle to drive the visible motion. Right-side clipping
+//! is also the caller's job — this module only handles the
+//! left-edge geometry (positive offsets pad with spaces, negative
+//! offsets clip into the body).
+//!
+//! Pure ASCII in, pure ASCII out: the asset bytes stay 7-bit and
+//! the siren trail is built from `'F'`, `'i'`, `'o'`, `'-'` only,
+//! so `chars().count()` equals the printed column count.
+
+use crate::anim::car;
+
+/// Two-state FI-FO siren cycle.
+///
+/// Scenes flip the phase every animation tick so the trailing
+/// label oscillates `Fi -> Fo -> Fi -> ...`, producing the
+/// audible-feeling "FI-FO-FI-FO" trail from the spec lock (issue
+/// #11 §4). The phase encodes which syllable currently *leads*
+/// the trail; the second syllable always follows immediately
+/// after a separator dash.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SirenPhase {
+    /// Trail leads with `Fi`.
+    #[default]
+    Fi,
+    /// Trail leads with `Fo`.
+    Fo,
+}
+
+impl SirenPhase {
+    /// The two-character syllable currently leading the trail.
+    pub fn syllable(self) -> &'static str {
+        match self {
+            Self::Fi => "Fi",
+            Self::Fo => "Fo",
+        }
+    }
+
+    /// Toggle to the opposite phase. Two flips return to start.
+    pub fn flip(self) -> Self {
+        match self {
+            Self::Fi => Self::Fo,
+            Self::Fo => Self::Fi,
+        }
+    }
+}
+
+/// Render a single animation frame.
+///
+/// `car_asset` is the multi-line ASCII art (typically
+/// [`car::TINY`], [`car::STD`], or [`car::BIG`]). The function
+/// does not validate the asset's identity — it only consumes
+/// lines via [`car::lines`].
+///
+/// `x_offset` is the column of the car's leftmost edge:
+///
+/// - `x_offset == 0`: every car row starts at column 0; no siren
+///   trail is drawn (there is no canvas to its left).
+/// - `x_offset > 0`: each non-wheel row is padded with `x_offset`
+///   leading spaces; the wheel row (the last row of the asset)
+///   is prefixed with the siren trail filling those columns.
+/// - `x_offset < 0`: the leading `(-x_offset)` characters of
+///   every row are clipped (car partially off-screen on the
+///   left). When `(-x_offset)` exceeds a row's width the row is
+///   emitted as an empty line. No siren trail is drawn — the
+///   trail only exists when there is canvas to the *left* of the
+///   car.
+///
+/// `phase` selects which syllable leads the siren trail when one
+/// is drawn. See [`SirenPhase`].
+///
+/// The returned string joins rows with `\n` and has no trailing
+/// newline; the row count always equals `car::lines(car_asset)
+/// .len()`.
+pub fn frame(car_asset: &str, x_offset: i32, phase: SirenPhase) -> String {
+    let lines = car::lines(car_asset);
+    let last_idx = lines.len().saturating_sub(1);
+    let trail_width = x_offset.max(0) as usize;
+    let mut out = String::new();
+    for (i, line) in lines.iter().enumerate() {
+        if x_offset >= 0 {
+            if i == last_idx {
+                push_siren_trail(&mut out, phase, trail_width);
+            } else {
+                for _ in 0..trail_width {
+                    out.push(' ');
+                }
+            }
+            out.push_str(line);
+        } else {
+            let drop = (-x_offset) as usize;
+            if drop < line.len() {
+                out.push_str(&line[drop..]);
+            }
+        }
+        if i < last_idx {
+            out.push('\n');
+        }
+    }
+    out
+}
+
+/// Push exactly `width` characters of the siren trail into `out`.
+///
+/// The repeating unit is `"Fi-Fo-"` (or `"Fo-Fi-"` when `phase`
+/// is [`SirenPhase::Fo`]) — six characters covering both
+/// syllables and their separators. The function repeats the unit
+/// and truncates to `width`, so very small widths still emit a
+/// useful prefix (e.g. `width == 1` → `"F"`, `width == 5` →
+/// `"Fi-Fo"`).
+fn push_siren_trail(out: &mut String, phase: SirenPhase, width: usize) {
+    if width == 0 {
+        return;
+    }
+    let unit: &str = match phase {
+        SirenPhase::Fi => "Fi-Fo-",
+        SirenPhase::Fo => "Fo-Fi-",
+    };
+    let unit_bytes = unit.as_bytes();
+    out.reserve(width);
+    for i in 0..width {
+        out.push(unit_bytes[i % unit_bytes.len()] as char);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `x == 0` reproduces the asset verbatim (with no trailing
+    /// newline) and never emits a siren trail.
+    #[test]
+    fn frame_at_zero_emits_car_only() {
+        let out = frame(car::TINY, 0, SirenPhase::Fi);
+        let expected = car::lines(car::TINY).join("\n");
+        assert_eq!(out, expected);
+        assert!(!out.contains("Fi"), "no trail at x=0; got {out:?}");
+    }
+
+    /// Positive `x` pads non-wheel rows with leading spaces; only
+    /// the wheel row carries the siren trail.
+    #[test]
+    fn frame_pads_top_rows_with_spaces() {
+        let out = frame(car::TINY, 6, SirenPhase::Fi);
+        let lines: Vec<&str> = out.split('\n').collect();
+        let car_lines = car::lines(car::TINY);
+        assert_eq!(lines.len(), car_lines.len());
+        for (i, l) in lines.iter().enumerate().take(lines.len() - 1) {
+            assert!(
+                l.starts_with("      "),
+                "non-wheel row {i} missing space pad; got {l:?}",
+            );
+            assert!(
+                !l.contains("Fi") && !l.contains("Fo"),
+                "non-wheel row {i} carries trail; got {l:?}",
+            );
+        }
+        let wheel = lines.last().unwrap();
+        assert!(
+            wheel.starts_with("Fi-Fo-"),
+            "wheel row missing trail; got {wheel:?}",
+        );
+    }
+
+    /// At small positive `x` the trail is the head of one repeating
+    /// unit, including degenerate cases like `width == 1`.
+    #[test]
+    fn frame_short_trail_truncates_unit() {
+        for (x, expected) in [
+            (1, "F"),
+            (2, "Fi"),
+            (3, "Fi-"),
+            (4, "Fi-F"),
+            (5, "Fi-Fo"),
+            (6, "Fi-Fo-"),
+            (7, "Fi-Fo-F"),
+        ] {
+            let out = frame(car::TINY, x, SirenPhase::Fi);
+            let wheel = out.rsplit('\n').next().unwrap();
+            assert!(
+                wheel.starts_with(expected),
+                "x={x}: wheel {wheel:?} does not start with {expected:?}",
+            );
+        }
+    }
+
+    /// Phase `Fo` swaps the leading syllable.
+    #[test]
+    fn frame_phase_fo_swaps_siren_lead() {
+        let out = frame(car::TINY, 12, SirenPhase::Fo);
+        let wheel = out.rsplit('\n').next().unwrap();
+        assert!(
+            wheel.starts_with("Fo-Fi-Fo-Fi-"),
+            "wheel {wheel:?} does not lead with Fo",
+        );
+    }
+
+    /// Negative offsets clip the leading characters from every
+    /// row and never emit a trail.
+    #[test]
+    fn frame_negative_offset_clips_left() {
+        let out = frame(car::TINY, -3, SirenPhase::Fi);
+        let lines: Vec<&str> = out.split('\n').collect();
+        let car_lines = car::lines(car::TINY);
+        assert_eq!(lines.len(), car_lines.len());
+        for (i, (l, c)) in lines.iter().zip(car_lines.iter()).enumerate() {
+            let expected = if c.len() > 3 { &c[3..] } else { "" };
+            assert_eq!(*l, expected, "row {i} clipped wrong");
+        }
+        assert!(!out.contains("Fi") && !out.contains("Fo"));
+    }
+
+    /// A clip wider than the longest car row produces all-empty
+    /// rows, but the row count is still preserved so animation
+    /// timelines do not desync.
+    #[test]
+    fn frame_negative_offset_beyond_line_length_emits_empty() {
+        let out = frame(car::TINY, -100, SirenPhase::Fi);
+        let lines: Vec<&str> = out.split('\n').collect();
+        assert_eq!(lines.len(), car::lines(car::TINY).len());
+        for l in lines {
+            assert!(l.is_empty(), "row not empty: {l:?}");
+        }
+    }
+
+    /// Non-degenerate frames (those with visible content on the
+    /// last row) end without a trailing newline so callers can
+    /// append cursor or clear sequences without an extra blank
+    /// row. When the entire frame is clipped to empty rows the
+    /// output is exactly `(n_rows - 1)` newlines, which is the
+    /// natural `lines.join("\n")` semantics; the row-count
+    /// contract still holds.
+    #[test]
+    fn frame_has_no_trailing_newline_when_last_row_visible() {
+        // TINY's wheel row is 8 chars; x = -7 still leaves one
+        // visible character on it, so no trailing newline.
+        for x in [-7i32, -3, 0, 1, 5, 12, 200] {
+            for phase in [SirenPhase::Fi, SirenPhase::Fo] {
+                let out = frame(car::TINY, x, phase);
+                assert!(
+                    !out.ends_with('\n'),
+                    "x={x} phase={phase:?}: trailing newline in {out:?}",
+                );
+            }
+        }
+    }
+
+    /// Output is always pure ASCII (the assets are ASCII and the
+    /// trail uses only `F i o -`), so width math stays honest.
+    #[test]
+    fn frame_is_pure_ascii() {
+        for asset in [car::TINY, car::STD, car::BIG] {
+            for x in [-5i32, 0, 7, 40] {
+                for phase in [SirenPhase::Fi, SirenPhase::Fo] {
+                    let out = frame(asset, x, phase);
+                    assert!(out.is_ascii(), "non-ASCII bytes for x={x} phase={phase:?}",);
+                }
+            }
+        }
+    }
+
+    /// Row count is always the asset's row count, regardless of
+    /// `x` or phase. Scenes rely on this to align frames with a
+    /// fixed cursor-up count.
+    #[test]
+    fn frame_row_count_matches_asset() {
+        for asset in [car::TINY, car::STD, car::BIG] {
+            let expected = car::lines(asset).len();
+            for x in [-100i32, -1, 0, 1, 50] {
+                let out = frame(asset, x, SirenPhase::Fi);
+                let got = out.split('\n').count();
+                assert_eq!(got, expected, "asset rows={expected} x={x} got={got}");
+            }
+        }
+    }
+
+    /// The empty asset edge-case: `lines.len()` is 1 (an empty
+    /// string splits into one empty line). `frame` must not panic
+    /// and must emit one empty row.
+    #[test]
+    fn frame_empty_asset_does_not_panic() {
+        let out = frame("", 5, SirenPhase::Fi);
+        // Empty asset → one empty wheel row → trail-only output.
+        assert_eq!(out, "Fi-Fo");
+    }
+
+    #[test]
+    fn siren_phase_flip_is_involutive() {
+        assert_eq!(SirenPhase::Fi.flip(), SirenPhase::Fo);
+        assert_eq!(SirenPhase::Fo.flip(), SirenPhase::Fi);
+        assert_eq!(SirenPhase::Fi.flip().flip(), SirenPhase::Fi);
+    }
+
+    #[test]
+    fn siren_phase_syllables_are_two_ascii_chars() {
+        for phase in [SirenPhase::Fi, SirenPhase::Fo] {
+            let s = phase.syllable();
+            assert_eq!(s.len(), 2);
+            assert!(s.is_ascii());
+        }
+        assert_ne!(
+            SirenPhase::Fi.syllable(),
+            SirenPhase::Fo.syllable(),
+            "syllables must differ",
+        );
+    }
+
+    #[test]
+    fn siren_phase_default_is_fi() {
+        assert_eq!(SirenPhase::default(), SirenPhase::Fi);
+    }
+}

--- a/src/anim/frame.rs
+++ b/src/anim/frame.rs
@@ -84,6 +84,7 @@ impl SirenPhase {
 /// newline; the row count always equals `car::lines(car_asset)
 /// .len()`.
 pub fn frame(car_asset: &str, x_offset: i32, phase: SirenPhase) -> String {
+    debug_assert!(car_asset.is_ascii(), "frame() requires ASCII car_asset");
     let lines = car::lines(car_asset);
     let last_idx = lines.len().saturating_sub(1);
     let trail_width = x_offset.max(0) as usize;

--- a/src/anim/frame.rs
+++ b/src/anim/frame.rs
@@ -274,6 +274,30 @@ mod tests {
         }
     }
 
+    /// When the last row is fully clipped the preceding `\n`
+    /// separator becomes the last byte — the "no trailing newline"
+    /// guarantee only applies when the final row is non-empty.
+    ///
+    /// Uses a synthetic short-last-row asset so the clip is
+    /// unambiguous: x=-3 clips the 2-char last row completely
+    /// while leaving content on the first two rows.
+    #[test]
+    fn frame_last_row_clipped_ends_with_newline() {
+        // 3-row asset where the last row (2 chars) is shorter than
+        // the first two (5 chars each).  car::lines strips the
+        // trailing \n before splitting.
+        let asset = "AAAAA\nBBBBB\nCC\n";
+        let out = frame(asset, -3, SirenPhase::Fi);
+        // x=-3 clips 3 chars: rows 0 and 1 ("AAAAA","BBBBB") each
+        // yield 2 visible chars; row 2 ("CC") is fully clipped.
+        // Expected: "AA\nBB\n" (the last \n is the row-1 separator,
+        // not a new terminator).
+        assert_eq!(
+            out, "AA\nBB\n",
+            "expected visible rows + trailing separator; got {out:?}",
+        );
+    }
+
     /// Output is always pure ASCII (the assets are ASCII and the
     /// trail uses only `F i o -`), so width math stays honest.
     #[test]

--- a/src/anim/frame.rs
+++ b/src/anim/frame.rs
@@ -300,12 +300,12 @@ mod tests {
     }
 
     /// The empty asset edge-case: `lines.len()` is 1 (an empty
-    /// string splits into one empty line). `frame` must not panic
-    /// and must emit one empty row.
+    /// string splits into one empty line). `frame` must not panic;
+    /// with `x=5` the wheel row is empty so the output is the
+    /// 5-character siren trail `"Fi-Fo"` with no car body.
     #[test]
     fn frame_empty_asset_does_not_panic() {
         let out = frame("", 5, SirenPhase::Fi);
-        // Empty asset → one empty wheel row → trail-only output.
         assert_eq!(out, "Fi-Fo");
     }
 

--- a/src/anim/frame.rs
+++ b/src/anim/frame.rs
@@ -99,9 +99,9 @@ pub fn frame(car_asset: &str, x_offset: i32, phase: SirenPhase) -> String {
             }
             out.push_str(line);
         } else {
-            let drop = (-x_offset) as usize;
-            if drop < line.len() {
-                out.push_str(&line[drop..]);
+            let drop = x_offset.unsigned_abs() as usize;
+            if let Some(tail) = line.get(drop..) {
+                out.push_str(tail);
             }
         }
         if i < last_idx {
@@ -219,6 +219,19 @@ mod tests {
             assert_eq!(*l, expected, "row {i} clipped wrong");
         }
         assert!(!out.contains("Fi") && !out.contains("Fo"));
+    }
+
+    /// `x_offset == i32::MIN` must not overflow (negating i32::MIN
+    /// panics in debug and wraps in release). All rows are clipped
+    /// to empty, and the row count is preserved.
+    #[test]
+    fn frame_i32_min_does_not_panic() {
+        let out = frame(car::TINY, i32::MIN, SirenPhase::Fi);
+        let lines: Vec<&str> = out.split('\n').collect();
+        assert_eq!(lines.len(), car::lines(car::TINY).len());
+        for l in lines {
+            assert!(l.is_empty(), "row not empty: {l:?}");
+        }
     }
 
     /// A clip wider than the longest car row produces all-empty

--- a/src/anim/frame.rs
+++ b/src/anim/frame.rs
@@ -3,9 +3,10 @@
 //! Composes a single rendered frame from three inputs: a car
 //! ASCII asset (one of the variants in [`crate::anim::car`]), the
 //! car's horizontal position, and the current siren phase. The
-//! output is a multi-line `String` with no trailing newline so
-//! callers can append cursor or clear sequences without an extra
-//! blank row.
+//! output is a multi-line `String` that joins rendered rows with
+//! `\n`. When the last rendered row is non-empty the string has
+//! no trailing newline; when the last row is empty after clipping
+//! the preceding `\n` separator becomes the final byte.
 //!
 //! The function is intentionally oblivious to terminal width,
 //! scene type, and animation timing: scene orchestrators (Phase
@@ -59,9 +60,9 @@ impl SirenPhase {
 /// Render a single animation frame.
 ///
 /// `car_asset` is the multi-line ASCII art (typically
-/// [`car::TINY`], [`car::STD`], or [`car::BIG`]). The function
-/// does not validate the asset's identity — it only consumes
-/// lines via [`car::lines`].
+/// [`car::TINY`], [`car::STD`], or [`car::BIG`]) and must be
+/// pure ASCII (`debug_assert!`-enforced in debug builds); the
+/// function does not otherwise validate the asset's identity.
 ///
 /// `x_offset` is the column of the car's leftmost edge:
 ///
@@ -80,9 +81,12 @@ impl SirenPhase {
 /// `phase` selects which syllable leads the siren trail when one
 /// is drawn. See [`SirenPhase`].
 ///
-/// The returned string joins rows with `\n` and has no trailing
-/// newline; the row count always equals `car::lines(car_asset)
-/// .len()`.
+/// The returned string joins rendered rows with `\n`. When the
+/// final rendered row is non-empty the string has no trailing
+/// newline; when it is empty (e.g. a large negative `x_offset`
+/// clips the entire last row) the preceding `\n` separator is the
+/// last byte. The row count always equals
+/// `car::lines(car_asset).len()`.
 pub fn frame(car_asset: &str, x_offset: i32, phase: SirenPhase) -> String {
     debug_assert!(car_asset.is_ascii(), "frame() requires ASCII car_asset");
     let lines = car::lines(car_asset);

--- a/src/anim/mod.rs
+++ b/src/anim/mod.rs
@@ -7,4 +7,5 @@
 //! renderer follow in subsequent commits.
 
 pub mod car;
+pub mod fallback;
 pub mod frame;

--- a/src/anim/mod.rs
+++ b/src/anim/mod.rs
@@ -1,10 +1,10 @@
 //! Animation primitives.
 //!
-//! Phase C landed the static asset layer ([`car`]); Phase F
-//! incrementally adds the pure-function pieces that scenes will
-//! orchestrate. So far this comprises the per-frame composer
-//! ([`frame`]); the dumb-TTY fallback and crossterm-driven
-//! renderer follow in subsequent commits.
+//! Phase C landed the static asset layer ([`car`]); Phase F adds
+//! the pure-function pieces that scenes will orchestrate. This
+//! includes the per-frame composer ([`frame`]) and the dumb-TTY
+//! fallback ([`fallback`]); the crossterm-driven renderer follows
+//! in a subsequent commit.
 
 pub mod car;
 pub mod fallback;

--- a/src/anim/mod.rs
+++ b/src/anim/mod.rs
@@ -1,7 +1,10 @@
 //! Animation primitives.
 //!
-//! Phase C lands only the static asset layer ([`car`]); Phase F
-//! adds the siren generator, scene orchestration, and dumb-TTY
-//! fallback on top.
+//! Phase C landed the static asset layer ([`car`]); Phase F
+//! incrementally adds the pure-function pieces that scenes will
+//! orchestrate. So far this comprises the per-frame composer
+//! ([`frame`]); the dumb-TTY fallback and crossterm-driven
+//! renderer follow in subsequent commits.
 
 pub mod car;
+pub mod frame;


### PR DESCRIPTION
## Summary

- **`anim::frame`** (#42): introduces `SirenPhase` (Fi/Fo enum with `flip()` and `syllable()`) and `frame(car_asset, x_offset, phase)` — the pure renderer that composes one animation frame. Positive `x_offset` pads non-wheel rows with spaces and prepends the repeating FI-FO siren trail to the wheel row; negative offsets clip the car's left edge. 13 unit tests.
- **`anim::fallback`** (#46): introduces a local `Trigger` enum and `fallback(trigger)` that returns a ≤33-column pure-ASCII single-line gag for `WidthBucket::Tiny` terminals. Gag strings carry the spec-locked "418 I'm an AI agent" label and the `9! = 362880` factorial punchline. 10 unit tests.
- Both modules are wired into `anim::mod` and are intentionally oblivious to terminal width, timing, or crossterm — the Phase F (#43–#45) scene orchestrators will consume them.

All 310 tests pass. `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.

## Test plan

- [x] `cargo test --all-targets --all-features` — 310/310 green
- [x] `cargo fmt --check` — no diff
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings
- [x] Rubber-duck self-review — one stale doc comment found and fixed in a follow-up commit, no further findings

Closes #42, #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a plain-text fallback for narrow terminals that shows concise single-line ASCII messages for quit-style commands.
  * Introduced an ASCII frame generator for the car animation with positional offsets, phased siren visuals, clipping behavior, and stable multi-line output.
  * Expanded the animation module to expose these pure-function components for improved terminal rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->