### PR TITLE
fix(trigger): treat poisoned mutex as non-fatal in OutputArbiter

### DIFF
--- a/src/trigger/input.rs
+++ b/src/trigger/input.rs
@@ -119,9 +119,19 @@ where
     F: FnMut(Outcome),
 {
     let mut detected = Vec::new();
-    let mut input = input.lock().map_err(|_| {
-        io::Error::other("trigger input pump mutex poisoned while observing host input")
-    })?;
+    let mut input = match input.lock() {
+        Ok(guard) => guard,
+        Err(err) => {
+            // The mutex was poisoned by a panic in another thread.  Recover
+            // the inner value so trigger detection continues; the poisoned
+            // state remains but does not affect correctness of the pump itself.
+            tracing::warn!(
+                error = %err,
+                "trigger input pump mutex was poisoned; recovering guard to continue observation"
+            );
+            err.into_inner()
+        }
+    };
     for &b in bytes {
         let outcome = input.feed_input_byte(b).outcome();
         if outcome != Outcome::None {
@@ -390,19 +400,56 @@ mod tests {
     #[test]
     fn input_detector_keeps_forwarding_when_observer_fails() {
         let input = shared_input_pump();
-        let _ = std::panic::catch_unwind({
-            let input = input.clone();
-            move || {
-                let _guard = input.lock().unwrap();
-                panic!("poison trigger input mutex for test");
-            }
-        });
+        assert!(
+            std::panic::catch_unwind({
+                let input = input.clone();
+                move || {
+                    let _guard = input.lock().unwrap();
+                    panic!("poison trigger input mutex for test");
+                }
+            })
+            .is_err(),
+            "catch_unwind must return Err to confirm the mutex was poisoned"
+        );
+        assert!(
+            input.lock().is_err(),
+            "mutex must be poisoned for the test to be meaningful"
+        );
 
         let mut detector = InputDetector::new(Vec::new(), input);
 
         detector.write_all(b":q\n").unwrap();
 
         assert_eq!(detector.inner().as_slice(), b":q\n");
+    }
+
+    #[test]
+    fn observation_continues_after_mutex_is_poisoned() {
+        let input = shared_input_pump();
+        assert!(
+            std::panic::catch_unwind({
+                let input = input.clone();
+                move || {
+                    let _guard = input.lock().unwrap();
+                    panic!("poison the mutex");
+                }
+            })
+            .is_err(),
+            "catch_unwind must return Err to confirm the mutex was poisoned"
+        );
+        assert!(
+            input.lock().is_err(),
+            "mutex must be poisoned for the test to be meaningful"
+        );
+
+        let mut outcomes = Vec::new();
+        observe_detected_input(&input, b":q\n", |outcome| outcomes.push(outcome)).unwrap();
+
+        assert_eq!(
+            outcomes,
+            vec![Outcome::Q],
+            "trigger detection must survive mutex poison recovery"
+        );
     }
 
     #[test]

--- a/src/trigger/input.rs
+++ b/src/trigger/input.rs
@@ -76,11 +76,16 @@ pub fn shared_input_pump() -> SharedInputPump {
 pub struct InputDetector<W> {
     inner: W,
     input: SharedInputPump,
+    poison_warned: bool,
 }
 
 impl<W> InputDetector<W> {
     pub fn new(inner: W, input: SharedInputPump) -> Self {
-        Self { inner, input }
+        Self {
+            inner,
+            input,
+            poison_warned: false,
+        }
     }
 
     #[cfg(test)]
@@ -96,9 +101,14 @@ where
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let written = self.inner.write(buf)?;
         if written > 0 {
-            if let Err(err) = observe_detected_input(&self.input, &buf[..written], |outcome| {
-                tracing::info!(?outcome, "trigger detect-only: matched host input trigger");
-            }) {
+            if let Err(err) = observe_detected_input(
+                &self.input,
+                &buf[..written],
+                &mut self.poison_warned,
+                |outcome| {
+                    tracing::info!(?outcome, "trigger detect-only: matched host input trigger");
+                },
+            ) {
                 tracing::warn!(error = %err, "trigger detect-only observation failed");
             }
         }
@@ -113,6 +123,7 @@ where
 fn observe_detected_input<F>(
     input: &SharedInputPump,
     bytes: &[u8],
+    warned: &mut bool,
     mut on_detect: F,
 ) -> io::Result<()>
 where
@@ -125,10 +136,13 @@ where
             // The mutex was poisoned by a panic in another thread.  Recover
             // the inner value so trigger detection continues; the poisoned
             // state remains but does not affect correctness of the pump itself.
-            tracing::warn!(
-                error = %err,
-                "trigger input pump mutex was poisoned; recovering guard to continue observation"
-            );
+            if !*warned {
+                tracing::warn!(
+                    error = %err,
+                    "trigger input pump mutex was poisoned; recovering guard to continue observation"
+                );
+                *warned = true;
+            }
             err.into_inner()
         }
     };
@@ -302,7 +316,9 @@ mod tests {
 
     fn detect_for_test(input: &SharedInputPump, bytes: &[u8]) -> Vec<Outcome> {
         let mut detected = Vec::new();
-        observe_detected_input(input, bytes, |outcome| detected.push(outcome)).unwrap();
+        let mut warned = false;
+        observe_detected_input(input, bytes, &mut warned, |outcome| detected.push(outcome))
+            .unwrap();
         detected
     }
 
@@ -385,8 +401,9 @@ mod tests {
     fn observe_detected_input_releases_lock_before_callback() {
         let input = shared_input_pump();
         let mut detected = Vec::new();
+        let mut warned = false;
 
-        observe_detected_input(&input, b":q\n", |outcome| {
+        observe_detected_input(&input, b":q\n", &mut warned, |outcome| {
             detected.push(outcome);
             let _guard = input
                 .try_lock()
@@ -398,7 +415,7 @@ mod tests {
     }
 
     #[test]
-    fn input_detector_keeps_forwarding_when_observer_fails() {
+    fn input_detector_keeps_forwarding_when_mutex_is_poisoned() {
         let input = shared_input_pump();
         assert!(
             std::panic::catch_unwind({
@@ -443,13 +460,18 @@ mod tests {
         );
 
         let mut outcomes = Vec::new();
-        observe_detected_input(&input, b":q\n", |outcome| outcomes.push(outcome)).unwrap();
+        let mut warned = false;
+        observe_detected_input(&input, b":q\n", &mut warned, |outcome| {
+            outcomes.push(outcome);
+        })
+        .unwrap();
 
         assert_eq!(
             outcomes,
             vec![Outcome::Q],
             "trigger detection must survive mutex poison recovery"
         );
+        assert!(warned, "poison_warned must be set after first recovery");
     }
 
     #[test]

--- a/src/trigger/output.rs
+++ b/src/trigger/output.rs
@@ -15,17 +15,20 @@ use std::io::{self, Write};
 
 use super::input::SharedInputPump;
 
-fn observe_child_output(input: &SharedInputPump, bytes: &[u8]) {
+fn observe_child_output(input: &SharedInputPump, bytes: &[u8], warned: &mut bool) {
     let mut guard = match input.lock() {
         Ok(guard) => guard,
         Err(err) => {
             // The mutex was poisoned by a panic in another thread.  Recover
             // the inner value so observation continues; the poisoned state
             // remains but does not affect correctness of the pump itself.
-            tracing::warn!(
-                error = %err,
-                "trigger output arbiter mutex was poisoned; recovering guard to continue observation"
-            );
+            if !*warned {
+                tracing::warn!(
+                    error = %err,
+                    "trigger output arbiter mutex was poisoned; recovering guard to continue observation"
+                );
+                *warned = true;
+            }
             err.into_inner()
         }
     };
@@ -38,16 +41,26 @@ fn observe_child_output(input: &SharedInputPump, bytes: &[u8]) {
 pub struct OutputArbiter<W> {
     inner: W,
     input: SharedInputPump,
+    poison_warned: bool,
 }
 
 impl<W> OutputArbiter<W> {
     pub fn new(inner: W, input: SharedInputPump) -> Self {
-        Self { inner, input }
+        Self {
+            inner,
+            input,
+            poison_warned: false,
+        }
     }
 
     #[cfg(test)]
     fn inner(&self) -> &W {
         &self.inner
+    }
+
+    #[cfg(test)]
+    fn poison_warned(&self) -> bool {
+        self.poison_warned
     }
 }
 
@@ -58,7 +71,7 @@ where
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let written = self.inner.write(buf)?;
         if written > 0 {
-            observe_child_output(&self.input, &buf[..written]);
+            observe_child_output(&self.input, &buf[..written], &mut self.poison_warned);
         }
         Ok(written)
     }
@@ -129,6 +142,13 @@ mod tests {
         let mut arbiter = OutputArbiter::new(Vec::new(), input.clone());
         arbiter.write_all(b"hello").unwrap();
         assert_eq!(arbiter.inner(), b"hello");
+        assert!(
+            arbiter.poison_warned(),
+            "poison_warned must be set after first recovery"
+        );
+        // A second write must still succeed without re-logging.
+        arbiter.write_all(b" world").unwrap();
+        assert_eq!(arbiter.inner(), b"hello world");
     }
 
     #[test]

--- a/src/trigger/output.rs
+++ b/src/trigger/output.rs
@@ -16,17 +16,20 @@ use std::io::{self, Write};
 use super::input::SharedInputPump;
 
 fn observe_child_output(input: &SharedInputPump, bytes: &[u8]) {
-    match input.lock() {
-        Ok(mut guard) => {
-            guard.feed_child_output_slice(bytes);
-        }
+    let mut guard = match input.lock() {
+        Ok(guard) => guard,
         Err(err) => {
+            // The mutex was poisoned by a panic in another thread.  Recover
+            // the inner value so observation continues; the poisoned state
+            // remains but does not affect correctness of the pump itself.
             tracing::warn!(
                 error = %err,
-                "trigger output arbiter observation failed; alt-screen state not updated"
+                "trigger output arbiter mutex was poisoned; recovering guard to continue observation"
             );
+            err.into_inner()
         }
-    }
+    };
+    guard.feed_child_output_slice(bytes);
 }
 
 /// Child-output [`Write`] adapter that updates trigger state while

--- a/src/trigger/output.rs
+++ b/src/trigger/output.rs
@@ -110,17 +110,58 @@ mod tests {
     #[test]
     fn write_succeeds_when_mutex_is_poisoned() {
         let input = shared_input_pump();
-        let _ = std::panic::catch_unwind({
-            let input = input.clone();
-            move || {
-                let _guard = input.lock().unwrap();
-                panic!("poison trigger input mutex for test");
-            }
-        });
+        assert!(
+            std::panic::catch_unwind({
+                let input = input.clone();
+                move || {
+                    let _guard = input.lock().unwrap();
+                    panic!("poison trigger input mutex for test");
+                }
+            })
+            .is_err(),
+            "catch_unwind must return Err to confirm the mutex was poisoned"
+        );
+        assert!(
+            input.lock().is_err(),
+            "mutex must be poisoned for the test to be meaningful"
+        );
 
         let mut arbiter = OutputArbiter::new(Vec::new(), input.clone());
         arbiter.write_all(b"hello").unwrap();
         assert_eq!(arbiter.inner(), b"hello");
+    }
+
+    #[test]
+    fn observation_continues_after_mutex_is_poisoned() {
+        let input = shared_input_pump();
+        assert!(
+            std::panic::catch_unwind({
+                let input = input.clone();
+                move || {
+                    let _guard = input.lock().unwrap();
+                    panic!("poison the mutex");
+                }
+            })
+            .is_err(),
+            "catch_unwind must return Err to confirm the mutex was poisoned"
+        );
+        assert!(
+            input.lock().is_err(),
+            "mutex must be poisoned for the test to be meaningful"
+        );
+
+        let mut arbiter = OutputArbiter::new(Vec::new(), input.clone());
+        arbiter.write_all(ENTER_ALT).unwrap();
+
+        // into_inner() recovery must keep alt-screen state up to date.
+        let is_alt = input
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .is_alt_screen();
+        assert!(
+            is_alt,
+            "alt-screen observation must survive mutex poison recovery"
+        );
     }
 
     #[test]

--- a/src/trigger/output.rs
+++ b/src/trigger/output.rs
@@ -15,6 +15,20 @@ use std::io::{self, Write};
 
 use super::input::SharedInputPump;
 
+fn observe_child_output(input: &SharedInputPump, bytes: &[u8]) {
+    match input.lock() {
+        Ok(mut guard) => {
+            guard.feed_child_output_slice(bytes);
+        }
+        Err(err) => {
+            tracing::warn!(
+                error = %err,
+                "trigger output arbiter observation failed; alt-screen state not updated"
+            );
+        }
+    }
+}
+
 /// Child-output [`Write`] adapter that updates trigger state while
 /// preserving byte-for-byte passthrough.
 #[derive(Debug)]
@@ -41,10 +55,7 @@ where
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let written = self.inner.write(buf)?;
         if written > 0 {
-            let mut input = self.input.lock().map_err(|_| {
-                io::Error::other("trigger input pump mutex poisoned while observing child output")
-            })?;
-            input.feed_child_output_slice(&buf[..written]);
+            observe_child_output(&self.input, &buf[..written]);
         }
         Ok(written)
     }
@@ -91,6 +102,22 @@ mod tests {
         fn flush(&mut self) -> io::Result<()> {
             Ok(())
         }
+    }
+
+    #[test]
+    fn write_succeeds_when_mutex_is_poisoned() {
+        let input = shared_input_pump();
+        let _ = std::panic::catch_unwind({
+            let input = input.clone();
+            move || {
+                let _guard = input.lock().unwrap();
+                panic!("poison trigger input mutex for test");
+            }
+        });
+
+        let mut arbiter = OutputArbiter::new(Vec::new(), input.clone());
+        arbiter.write_all(b"hello").unwrap();
+        assert_eq!(arbiter.inner(), b"hello");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the unresolved review finding from #98 ([discussion_r3179295057](https://github.com/kurone-kito/qorrection/pull/98#discussion_r3179295057)).

`OutputArbiter::write` previously returned an `io::Error` when the shared `SharedInputPump` mutex was poisoned. Because `inner.write()` had already accepted bytes before the lock was attempted, this caused the child→host forwarder to stop even though passthrough had succeeded, potentially breaking the wrapped session.

## Changes

- **`src/trigger/input.rs` (production)** — apply the same poison-recovery pattern to `observe_detected_input`, ensuring trigger detection also continues after the shared mutex is poisoned.
- **`src/trigger/output.rs` (tests)** — add `write_succeeds_when_mutex_is_poisoned` regression test; strengthen with poison-precondition assertions and add `observation_continues_after_mutex_is_poisoned` to verify alt-screen state is updated via the recovery path.
- **`src/trigger/input.rs` (tests)** — strengthen existing forwarding test with poison-precondition assertions and add `observation_continues_after_mutex_is_poisoned` to verify trigger detection survives mutex poison.

## Verification

- `cargo fmt --check` ✓
- `cargo clippy --all-targets -- -D warnings` ✓
- `cargo test --all-targets --all-features` ✓