### PR TITLE
chore(idd): install issue-authoring companion skill to .claude/skills/

### DIFF
--- a/.claude/skills/issue-authoring/SKILL.md
+++ b/.claude/skills/issue-authoring/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: issue-authoring
+description: Draft or refine IDD-ready GitHub issues, roadmap issues, and sub-issues before the normal IDD execution loop begins. Use when a request is too large or ambiguous for one reviewable change, when work needs decomposition or dependency encoding, or when the user asks for issue drafting, roadmap planning, or parallelizable task breakdown.
+---
+
+# Issue Authoring
+
+Use this skill to prepare issue-ready work before execution starts.
+Keep the skill concise and treat the repository docs as the canonical
+source for the full contract and schema.
+The canonical source bundle lives in this repository; install copies in
+the agent-specific skill directory your runtime reads.
+
+## Stable Phases
+
+Use two stable phases:
+
+1. **Intake and Clarification** — inspect relevant context, identify
+   ambiguity, run a secondary critique or explicit self-critique, and
+   ask only the questions that block safe issue drafting. Keep
+   clarification bounded; use the repository-local
+   `issueAuthoring.maxClarificationRounds` value when available,
+   otherwise default to 3 rounds.
+2. **Decompose and Draft** — restate the request in implementation
+   terms, split it into atomic tasks, classify readiness, reuse existing
+   issues when safe, and draft the smallest issue shape that preserves
+   dependencies and reviewability.
+
+Preserve low-readiness work in stable buckets: ready, deferred,
+needs-decision, blocked-by-human, and out-of-scope.
+
+## Workflow
+
+1. Read the bundled contract in
+   [references/contract.md](references/contract.md).
+2. Reuse or extend an existing issue before creating a new one.
+3. Choose the smallest safe output shape:
+   - orphan issue for one ready autonomous task only when the target
+     repository is discoverable through `issue-scope: orphan-first` and
+     any configured `orphan-first-policy` approval step can be completed
+     after drafting
+   - roadmap plus sub-issues for multi-task or multi-session work
+   - stable non-ready buckets for deferred, needs-decision,
+     blocked-by-human, or out-of-scope work
+4. Resolve the target repository marker prefix before drafting hidden
+   dependency markers. Use the prefix documented by the target
+   repository's onboarding or IDD docs, and ask the user instead of
+   guessing when the prefix is not discoverable.
+5. Keep dependencies machine-readable and minimal:
+   - roadmap identity via
+     `<!-- <marker-prefix>-roadmap-id: ... -->`
+   - active child issues via roadmap task-list links
+   - issue-to-issue dependencies via `Blocked by #NNN`
+   - sequential roadmap dependencies via
+     `<!-- <marker-prefix>-blocked-by: ... -->` only when a separate
+     roadmap
+     must close first
+   - keep independent sibling work in roadmap task lists unless a true
+     correctness, availability, or ordering constraint requires a
+     dependency edge
+6. Stop at the approval boundary. Drafting issues does not authorize
+   publishing them or starting the IDD execution loop unless the user
+   explicitly asked for that.
+
+## Reference Routing
+
+- For the bundled contract, output schemas, and discoverability guard:
+  read [references/contract.md](references/contract.md).
+- For the bundled boundary between pre-approval drafting and the IDD
+  execution loop: read
+  [references/workflow-boundary.md](references/workflow-boundary.md).
+- For concrete drafting patterns and example prompts: read
+  [references/draft-patterns.md](references/draft-patterns.md).
+- When editing this bundle inside the source repository, keep the
+  bundled references synchronized with the canonical maintenance docs in
+  [../../docs/issue-authoring-skill.md](../../docs/issue-authoring-skill.md)
+  and [../../docs/idd-workflow.md](../../docs/idd-workflow.md).
+
+## Output Checklist
+
+- Preserve low-readiness work in stable buckets instead of dropping it.
+- Keep acceptance criteria explicitly verifiable.
+- Link every active child issue from its roadmap body.
+- Justify each dependency edge and keep independent sibling work as
+  roadmap task-list entries.
+- Record reuse or extension decisions when the skill does not create a
+  new issue.
+- Avoid widening drafting output beyond the user request without saying
+  so.

--- a/.claude/skills/issue-authoring/agents/openai.yaml
+++ b/.claude/skills/issue-authoring/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Issue Authoring"
+  short_description: "Draft IDD-ready issues and roadmaps"
+  default_prompt: "Use $issue-authoring to draft an IDD-ready issue set for this request."

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -1,0 +1,288 @@
+# Bundled Issue Authoring Contract
+
+This file keeps the `issue-authoring` bundle usable when it is installed
+or copied outside this repository root. It mirrors the canonical
+contract in `docs/issue-authoring-skill.md`.
+
+## Target marker prefix
+
+Resolve the target repository's hidden marker prefix before drafting any
+roadmap or blocked-by marker.
+
+- Use the prefix documented by the target repository's onboarding or
+  IDD instructions.
+- In this source repository the prefix is `idd-skill`, but installed
+  bundles must not assume that value elsewhere.
+- If the prefix is not discoverable from the repository docs or user
+  context, stop and ask instead of emitting a guessed marker.
+
+## Trigger policy
+
+Use this bundle when direct implementation would skip the issue hygiene
+that the IDD execution loop depends on.
+
+Invoke it when one or more of the following are true:
+
+- the request is too large or ambiguous for one reviewable change
+- the likely solution needs decomposition into multiple atomic tasks
+- dependencies or execution order must be made explicit before work can
+  start safely
+- the user wants a roadmap, issue breakdown, or parallelizable work
+  plan
+
+Skip it when all of the following are true:
+
+- the task fits one reviewable change
+- verification is already clear
+- no roadmap, dependency marker, or issue split is needed
+- the user did not ask for issue drafting first
+
+## Stable phases
+
+The bundle uses two stable phases. These names mirror the canonical
+contract and should stay stable for copied bundles.
+
+### 1. Intake and Clarification
+
+In this phase, the agent:
+
+- inspects the relevant code, docs, and existing issues
+- identifies assumptions and ambiguity that affect issue quality
+- runs a secondary critique pass before drafting
+- asks the user only the questions that block safe issue drafting
+
+The critique pass is agent-neutral: use a subagent or rubber-duck
+reviewer when available, otherwise run an explicit self-critique
+locally. Clarification must be bounded; use the repository-local
+`issueAuthoring.maxClarificationRounds` value when available,
+otherwise default to 3 rounds. If safe drafting is still impossible
+after that, stop and report the remaining blockers instead of looping
+indefinitely.
+
+### 2. Decompose and Draft
+
+In this phase, the agent:
+
+- restates the clarified request in implementation-facing terms
+- splits work into atomic tasks
+- checks whether each task is suitable for autonomous execution
+- reuses or extends existing issues before creating new ones
+- drafts orphan issues, roadmap packages, sub-issues, or non-ready
+  buckets as appropriate
+
+## Readiness buckets
+
+Do not silently drop low-confidence or low-readiness work. Route each
+candidate task into one stable bucket:
+
+- **ready**: passes limited scope, clear verification, and autonomous
+  completion
+- **deferred**: plausible, but priority, timing, or decomposition is not
+  strong enough for execution
+- **needs-decision**: depends on a product, policy, or design choice
+- **blocked-by-human**: waits on a person, credential, asset, or outside
+  system
+- **out-of-scope**: does not belong in the repository or skill scope
+
+## Specificity target
+
+Issue drafting should aim for a level of specificity where a
+middle-tier cloud model can implement the task without drifting. This
+is a practical drafting heuristic, not a hard model requirement. The
+goal is to avoid both hidden assumptions that only a top-tier model can
+infer and step-by-step runbooks that cost too much to author.
+
+### Three specificity bands
+
+| Band                | Practical signal                                                                                                          | Drafting response                                                                    |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **Under-specified** | Stable execution likely depends on a frontier cloud model class                                                           | Add missing constraints, split scope, or make acceptance criteria more explicit      |
+| **Target**          | A middle-tier cloud model class can implement the issue without drifting                                                  | Treat this as the preferred drafting target when the execution axes already pass     |
+| **Over-specified**  | Even a lightweight local or compact cloud model class could follow the issue mechanically because it has become a runbook | Remove procedural micromanagement while keeping invariants, file anchors, and checks |
+
+The capability tiers above are practical heuristics, not a fixed
+compatibility matrix or runtime requirement.
+
+### How the specificity target interacts with readiness
+
+This heuristic does not replace the IDD execution axes:
+
+- **Limited scope** still decides whether the work fits one issue or
+  needs a roadmap.
+- **Clear verification** still decides whether success is objectively
+  checkable.
+- **Autonomous completion** still decides whether the task can finish
+  without outside coordination.
+
+An issue can be specific yet still fail A4 or A4.5 because it is too
+broad, not verifiable, or blocked on a human decision. Conversely, an
+issue that passes those gates can still be under-specified if it leaves
+too much implementation shape implicit. The drafting target is therefore
+"ready and stable for a middle-tier model," not "maximally detailed."
+
+## Reuse-first issue policy
+
+Before creating any new issue, check whether the work already has a
+suitable home.
+
+Apply these checks in order:
+
+1. If an existing open issue already matches the task and only lacks the
+   new schema details, extend that issue instead of cloning it.
+2. If an existing open roadmap already owns the initiative, add or
+   refine task-list entries there instead of creating a competing
+   umbrella.
+3. If an existing issue is close but too broad, split follow-up work
+   out of it rather than widening the original issue further.
+4. If an existing issue is already claimed, has an open PR, or is
+   otherwise being actively executed, avoid repurposing it. Create a
+   follow-up issue or extend the roadmap around it instead.
+5. Create a brand-new issue only when no existing issue can absorb the
+   work without harming ownership, clarity, or reviewability.
+
+Report when the bundle reuses, extends, or declines to reuse an issue
+so a later session can follow the reasoning.
+
+## Output chooser
+
+Choose the smallest safe output shape:
+
+- **Orphan issue**: one autonomous task can finish the work, no
+  roadmap-level coordination is needed, and the target repository is
+  discoverable through `issue-scope: orphan-first`. If the repository
+  also uses `orphan-first-policy: maintainer-approved`, surface the
+  required post-publication maintainer approval step. If the repository
+  keeps the default `issue-scope: roadmap` or disables public
+  orphan-first discovery with `orphan-first-policy: public-disabled`,
+  surface that constraint and prefer a roadmap package instead.
+- **Roadmap plus sub-issues**: the request needs visible sequencing,
+  parallel tracks, multiple ready issues, or multi-session handoff.
+- **Stable non-ready buckets**: some work is deferred, blocked by a
+  human, waiting on a decision, or outside the repository scope.
+
+When the repository keeps the broader issue-author approval gate,
+surface the same post-publication approval step for orphan issues,
+roadmaps, and sub-issues whenever the issue author is not
+self-authorizing under the repository's
+`maintainer-approval-actors` policy. The configured ready label from
+`approvalSignals.readyLabelName` (default: `idd:ready`) is accepted
+according to `approvalSignals.labelFreshnessMode` (`presence-only` by
+default, optional `event-freshness`), while standalone `IDD ready`
+comments from a maintainer approval actor must stay fresh against the
+latest issue content and generated-plan update (or an equivalent
+draft-stability signal). Until that approval condition is satisfied,
+route the draft to the
+approval-needed fallback bucket instead of the normal ready-to-start
+set.
+
+## Dependency minimization
+
+Encode a dependency edge only when it reflects a true correctness,
+availability, or ordering constraint.
+
+- keep independent sibling tasks as roadmap task-list entries, with
+  short sequencing or parallelization notes when that helps reviewers or
+  later agents
+- use visible or sequential dependency markers only when the issue
+  cannot start safely until the dependency resolves
+- do not create an artificial serial chain when sibling tasks could be
+  reviewed and verified independently
+- do not split one natural, cohesive change into artificial sibling
+  issues only to widen parallel execution
+
+When an issue keeps a dependency edge, justify each dependency edge in
+the surrounding issue body and confirm that the split still preserves
+natural cohesion.
+
+## Required dependency encoding
+
+- Roadmap identity via `<!-- <marker-prefix>-roadmap-id: ... -->`
+- Active child issues via roadmap task-list links
+- Issue-to-issue dependencies via `Blocked by #NNN`
+- Sequential roadmap dependencies via
+  `<!-- <marker-prefix>-blocked-by: ... -->` only when a separate
+  roadmap
+  must close first
+
+## Required draft content
+
+### Orphan issue
+
+- title with a concise user-facing summary
+- `## Background` or `## Goal`
+- `## Proposed change`
+- `## Acceptance criteria`
+
+Validation expectations:
+
+- no `<marker-prefix>-roadmap-id` marker
+- no `<marker-prefix>-blocked-by` marker
+- acceptance criteria are explicitly verifiable
+- the issue stays discoverable under the target repository's
+  `issue-scope` setting
+
+### Roadmap issue
+
+- title that describes the umbrella initiative
+- `## Goal`
+- `## Background` or `## Why this matters`
+- `## Tracks`
+- `## Success criteria`
+- one `<!-- <marker-prefix>-roadmap-id: <roadmap-id> -->` marker
+
+Validation expectations:
+
+- every active child issue is referenced from the roadmap body
+- the roadmap explains why multiple issues exist
+- sequencing and blocking are explicit
+- each dependency edge is justified and preserves natural cohesion
+
+### Child issue under a roadmap
+
+- title with a concrete task summary
+- `## Background`
+- `## Proposed change`
+- `## Acceptance criteria`
+- optional dependency line or sequential roadmap marker when needed
+
+Validation expectations:
+
+- the issue is referenced from its parent roadmap task list
+- acceptance criteria are locally verifiable
+- any dependency marker is resolvable, intentionally chosen, and
+  justified
+- the issue can be claimed independently without absorbing sibling work
+
+## A4.5 Suitability Gate Alignment
+
+When an issue is published and reaches the IDD discover phase, the A4.5
+pre-claim gate will evaluate it against seven suitability checks. The
+authoring skill should catch these issues before publishing:
+
+| Check                    | Authoring Bucket     | How to Prevent                                                                  |
+| ------------------------ | -------------------- | ------------------------------------------------------------------------------- |
+| Repository Fit (Check 1) | `out-of-scope`       | Ensure issue is scoped to this repository; escalate if it crosses boundaries    |
+| Coherence (Check 2)      | `ready` or escalated | Validate issue body against schema before publish                               |
+| Safety/trust (Check 3)   | `ready` or escalated | Screen issue body for code injection and untrusted markers                      |
+| Duplicates (Check 4)     | `ready` or escalated | Run reuse-first checks before creating a new issue                              |
+| Actionability (Check 5)  | `ready` or escalated | Ensure the issue describes concrete work; escalate if blocked by human decision |
+| Autonomy (Check 6)       | `ready` or escalated | Ensure agent can complete without external coordination                         |
+| Verifiability (Check 7)  | `ready` or escalated | Ensure success is verifiable; escalate if it requires subjective approval       |
+
+Pre-publish validation checklist:
+
+1. **Coherence**: Issue body is well-formed, title+description are
+   clear, intent is parseable
+2. **Safety**: No code injection, marker injection, or untrusted input
+   in issue body
+3. **Uniqueness**: Reuse-first check passed; no duplicate or superseded
+   work
+
+If any check is uncertain, route the issue to `needs-decision` or
+`blocked-by-human` during drafting instead of publishing a
+marginally-ready issue.
+
+## Publication boundary
+
+Drafting issues does not authorize publishing them or starting the IDD
+execution loop unless the user explicitly asked for that next step.

--- a/.claude/skills/issue-authoring/references/draft-patterns.md
+++ b/.claude/skills/issue-authoring/references/draft-patterns.md
@@ -1,0 +1,259 @@
+# Draft Patterns
+
+Load this file after reading
+[`contract.md`](contract.md) when you need concrete examples or a quick
+chooser for output shapes.
+
+## Example triggers
+
+- "Break this request into IDD-ready issues before we implement
+  anything."
+- "Draft a roadmap for this feature and split the ready work."
+- "Turn this broad request into reviewable orphan issues."
+- "Check whether an existing issue should be extended instead of opening
+  a new one."
+
+## Output chooser
+
+Draft an orphan issue only when one autonomous task can finish the work
+and the target repository is discoverable through `issue-scope:
+orphan-first`. If the repository uses `orphan-first-policy:
+maintainer-approved`, include a post-publication approval step after the
+final issue content is stable. If a public repository uses
+`orphan-first-policy: public-disabled`, draft a roadmap package instead.
+
+If the repository keeps the broader secure-by-default issue-author
+approval gate, use the same post-publication approval note whenever the
+issue author will not be self-authorizing under the repository's
+`maintainer-approval-actors` policy. The configured ready label from
+`approvalSignals.readyLabelName` (default: `idd:ready`) is accepted
+according to `approvalSignals.labelFreshnessMode` (`presence-only` by
+default, optional `event-freshness`), while standalone `IDD ready`
+comments from a maintainer approval actor must stay fresh against the
+latest issue content and generated-plan update (or an equivalent
+draft-stability signal). Until that approval condition is
+satisfied, later discovery should treat the issue as part of the
+approval-needed fallback bucket instead of the normal ready-to-start
+set.
+
+Draft a roadmap plus sub-issues when the request needs visible
+sequencing, parallel tracks, or multi-session handoff.
+
+Draft only stable non-ready buckets when the work still depends on a
+human decision, missing asset, or unclear verification.
+
+## Specificity target
+
+Execution-ready issue drafts should land in a middle band:
+
+- **Under-specified**: a high-range model still has to infer the real
+  implementation shape because the issue names only a vague goal,
+  omits the likely surface to edit, or leaves verification too loose.
+- **Target range**: a solid mid-tier cloud model can hold a stable plan
+  without extra clarification. The issue points at the relevant
+  document, schema, or code surface, explains the constraint, and keeps
+  acceptance criteria verifiable without dictating every edit.
+- **Over-specified**: even a lightweight model could follow the issue as
+  a script because the body prescribes exact edit order, wording, or
+  implementation steps that reviewers do not need.
+
+If a draft feels like it needs a high-range model just to guess the intended
+change, it is still too vague. If it reads like line-by-line assembly
+instructions, it is too detailed.
+
+## Specificity checklist before publishing
+
+Before you publish a ready issue, confirm:
+
+- the title and background name the concrete artifact or surface that
+  should change
+- a mid-tier cloud model could choose a stable implementation direction
+  without hidden repository archaeology or a follow-up clarification loop
+- the acceptance criteria verify the outcome, not a step-by-step
+  implementation recipe
+- candidate files, examples, and notes act as cues rather than an
+  exhaustive script
+- removing one concrete detail would make the issue feel high-range-only,
+  while adding more detail would start turning it into a lightweight
+  model script
+
+## Example orphan issue
+
+- `## Background` or `## Goal`
+- `## Proposed change`
+- `## Acceptance criteria`
+- optional `## Candidate files`
+
+Use this shape when the work is narrow enough to pass the IDD viability
+gate on its own and the target repository can actually discover orphan
+issues. If the repository keeps the default `issue-scope: roadmap`,
+prefer a one-item roadmap package instead of publishing a standalone
+orphan issue.
+
+## Example roadmap package
+
+Roadmap issue:
+
+- `## Goal`
+- `## Background` or `## Why this matters`
+- `## Tracks`
+- `## Success criteria`
+- one `<!-- <marker-prefix>-roadmap-id: ... -->` marker
+
+Child issue:
+
+- title with a concrete task summary
+- `## Background`
+- `## Proposed change`
+- `## Acceptance criteria`
+- optional dependency line or sequential roadmap marker when needed
+
+Keep ready child issues in the roadmap task list rather than grouping
+them with hidden dependency markers.
+
+## Dependency minimization examples
+
+### Natural parallel decomposition
+
+Roadmap `## Tracks` excerpt:
+
+```md
+- [ ] #401 — update the issue-authoring contract
+- [ ] #402 — add draft-pattern examples
+
+_Parallel note: #401 and #402 can proceed independently once the roadmap
+exists because neither task depends on the other's output._
+```
+
+This is the preferred shape for sibling tasks that can be reviewed and
+verified independently. The roadmap keeps both tasks visible in its task
+list, and the short note explains the safe parallelism without adding a
+fake `Blocked by` edge.
+
+### Artificial decomposition
+
+Bad serial chain:
+
+```md
+#401 — update the issue-authoring contract
+#402 — add draft-pattern examples
+
+Blocked by #401
+```
+
+This is over-serialized when `#402` can be reviewed and verified without
+waiting for `#401`. Do not create a serial chain just to make the order
+feel tidy.
+
+Bad split for parallelism:
+
+```md
+#410 — add one checklist bullet
+#411 — add one example paragraph
+#412 — add one anti-pattern sentence
+```
+
+This is an artificial split when the three edits form one natural,
+cohesive authoring change. Do not break a single reviewable task into
+multiple sibling issues only to widen parallel execution.
+
+Resolve `<marker-prefix>` from the target repository's onboarding or IDD
+docs before publishing the draft. Use `idd-skill` only when the target
+repository actually configured that prefix.
+
+## Handling duplicates and non-ready outcomes
+
+Before publishing an issue, apply a reuse-first decision tree:
+
+1. Is an existing open issue a better fit? If yes, extend it instead of
+   creating a new one. Add a comment linking to the new schema request.
+2. Is the work already complete in a closed issue or merged PR? If yes,
+   create a reference or learning note instead of reopening it.
+3. Is a parent roadmap already managing this work? If yes, add it to the
+   task list instead of filing independently.
+4. Does the issue have any of these properties? If yes, escalate to
+   `needs-decision` or `blocked-by-human` during drafting:
+   - Unclear intent or malformed body (→ fix during drafting or mark needs-decision)
+   - Requires maintainer or product decision (→ mark needs-decision)
+   - Blocked by external work or human coordination (→ mark
+     blocked-by-human)
+   - Depends on unavailable resources or credentials (→ mark blocked-by-human)
+5. Otherwise, publish as `ready`.
+
+### A4.5 prevention checklist
+
+The A4.5 suitability gate will later evaluate published issues. Prevent
+common failures by validating before publish:
+
+- **Coherence**: Issue body is well-formed; title and description are
+  clear; intent is parseable
+- **Safety**: No code injection, marker injection, or untrusted input in
+  issue body
+- **Uniqueness**: Reuse-first check passed; the work is not a duplicate
+  or superseded
+
+## Specificity examples
+
+### Under-specified draft
+
+**Title**: `docs: improve issue authoring guidance`
+
+Background: issue authoring should be clearer for agents.
+
+Acceptance criteria:
+
+- issue authoring is more consistent
+- examples are improved
+
+This is too vague because the draft does not tell the next agent which
+authoring surface to edit, what kind of guidance is missing, or how a
+reviewer would verify success. A high-range model would need to infer
+the real task from surrounding repository context.
+
+### Target range draft
+
+**Title**: `docs: add specificity checklist to issue authoring draft patterns`
+
+Background:
+`skills/issue-authoring/references/draft-patterns.md` explains output
+shapes, but it does not yet show how to judge whether an issue body is
+too vague or too scripted for execution.
+
+Acceptance criteria:
+
+- `draft-patterns.md` includes a pre-publication specificity checklist
+- the guidance distinguishes under-specified, target range, and
+  over-specified issue drafts
+- the examples focus on issue body wording and acceptance criteria
+  granularity instead of prescribing implementation order
+
+This is the target range because the next agent knows where to work, why
+the change matters, and how to verify it, while still retaining freedom
+to decide the exact wording and structure.
+
+### Over-specified draft
+
+**Title**: `docs: add specificity checklist to issue authoring draft patterns`
+
+Proposed change:
+
+1. Insert a new `## Specificity target` heading after `## Output chooser`.
+2. Add exactly three bullets named `Under-specified`, `Target range`,
+   and `Over-specified`.
+3. Add a five-item checklist using the exact sentence order shown in the
+   draft.
+4. Copy the same example phrasing across every example block without
+   changing any wording.
+
+This is too detailed for authoring because it turns the issue into an
+implementation script. Reviewers usually need the target outcome and the
+verification shape, not a rigid edit order.
+
+## Publication boundary
+
+If the user asked for drafts only, stop after reporting the issue set,
+assumptions, and non-ready buckets.
+
+If the user explicitly asked to publish issues, create or update them
+and then stop unless they also separately asked to start the IDD
+execution loop.

--- a/.claude/skills/issue-authoring/references/workflow-boundary.md
+++ b/.claude/skills/issue-authoring/references/workflow-boundary.md
@@ -1,0 +1,88 @@
+# Workflow Boundary
+
+This bundle handles pre-approval issue drafting only.
+
+## Handoff sequence
+
+The issue-authoring bundle fits into a three-phase handoff:
+
+### Phase 1: Drafting (this bundle)
+
+- Skill drafts issues in the target repository
+- Issues move through readiness buckets: `deferred` → `ready` or
+  → escalation bucket (`needs-decision`, `blocked-by-human`, `out-of-scope`)
+- User approves the issue set before any publication
+
+### Phase 2: Publishing (user-authorized handoff)
+
+- User explicitly asks for publication
+- Bundled skill creates or updates issues in the target repository
+- User verifies the published issues look correct
+- Published issues remain on hold until user explicitly requests IDD execution
+
+### Phase 3: Execution (separate IDD loop)
+
+- User explicitly asks to start the IDD execution loop
+- Target repository's `.github/instructions/idd-discover.instructions.md`
+  takes over
+- IDD discover phase runs A0-T/A0-O/A1-A4.5 gates
+- Suitable issues are claimed, worked, and merged
+
+**Approval boundaries**:
+
+- **After drafting** (Phase 1 → Phase 2): User must explicitly approve the
+  issue set
+- **After publishing** (Phase 2 → Phase 3): User must explicitly request IDD
+  execution
+- **No implicit progression**: Each handoff requires explicit user request.
+  The bundle must not auto-transition to publishing or execution.
+
+## A4.5 Gate Timing
+
+The IDD discover phase evaluates published issues through the A4.5
+pre-claim suitability gate. This gate runs after an issue is published
+but before it is claimed for work.
+
+**Why A4.5 exists**: Issues drafted with incomplete information or from
+assumptions that did not hold when published may fail A4.5 checks
+(incoherent, unsafe, duplicate, etc.). A4.5 catches these before they
+waste agent time during work.
+
+**Prevention during drafting**: This bundle is where coherence, safety,
+and uniqueness should be validated **before** publishing. The three
+A4.5 prevention checks (coherence, safety, uniqueness) correspond to
+bucket escalation triggers during drafting:
+
+- If an issue might be incoherent → escalate to `needs-decision` during
+  drafting
+- If an issue might contain untrusted input → escalate to `blocked-by-human`
+  or fix during drafting
+- If an issue might be a duplicate → run reuse-first checks during
+  drafting before publishing
+
+When these prevent-during-drafting checks are applied correctly, published
+issues will pass A4.5; if they do not, A4.5 will catch them at discover
+time and report the specific failure (unclear, invalid, duplicate).
+
+## Use this bundle to
+
+- prepare IDD-ready orphan issues when the target repository supports
+  `issue-scope: orphan-first`, including any required
+  `orphan-first-policy` approval handoff
+- prepare roadmap packages and child issues when work needs visible
+  sequencing or parallel tracks
+- surface non-ready buckets instead of guessing through blockers
+
+## Do not use this bundle to
+
+- start the Discover -> Claim -> Work loop implicitly
+- treat bundled references as a replacement for repository execution
+  instructions
+- publish issues unless the user explicitly asked for publishing
+
+## Handoff to execution
+
+After the user approves the issue set, wait for a separate request to
+publish the issues or start the IDD execution loop. Only then should
+the workflow hand off to the repository's normal entry file and routed
+`.github/instructions/*.instructions.md` phase files.

--- a/.gitignore
+++ b/.gitignore
@@ -128,8 +128,9 @@ $RECYCLE.BIN/
 **/*.rs.bk
 
 ### AI Agents ###
-# Claude Code local config
-.claude/
+# Claude Code local config (except shared skills)
+.claude/*
+!.claude/skills/
 
 # OpenAI Codex sandbox
 .codex/


### PR DESCRIPTION
## Summary

- Copies 5 companion skill files verbatim from
  `github:kurone-kito/idd-skill@main` `skills/issue-authoring/` to
  `.claude/skills/issue-authoring/` (no placeholder substitution).
- Modifies `.gitignore` to track `.claude/skills/` while keeping other
  `.claude/` content (local config, session state) untracked.

## `.gitignore` change

```diff
-# Claude Code local config
-.claude/
+# Claude Code local config (except shared skills)
+.claude/*
+!.claude/skills/
```

This lets shared skill bundles be version-controlled so any agent
session cloning the repo gets the companion skill without manual
installation.

## Files added

- `.claude/skills/issue-authoring/SKILL.md`
- `.claude/skills/issue-authoring/agents/openai.yaml`
- `.claude/skills/issue-authoring/references/contract.md`
- `.claude/skills/issue-authoring/references/draft-patterns.md`
- `.claude/skills/issue-authoring/references/workflow-boundary.md`

## Test plan

- [x] `.claude/settings.local.json` is not tracked (gitignored)
- [x] All 5 skill files are tracked
- [ ] CI passes (`cargo fmt --check`, `cargo clippy`, `cargo test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added comprehensive issue-authoring skill specification with contract definitions, draft patterns, and workflow boundary documentation.
  * Updated repository configuration to allow tracking of shared skills directory.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/qorrection/pull/112)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->