### PR TITLE
chore(idd): add IDD workflow section to agent entry files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -318,3 +318,13 @@ and CI as project-specific. If a future change requires another
 round of onboarding-style customization (e.g., adopting a new
 language alongside Rust), surface it as a plan-mode proposal
 before editing instructions or workflows.
+
+## IDD Workflow
+
+This project uses Issue-Driven Development (IDD) with parallel AI
+agents. Start with [docs/idd-workflow.md](docs/idd-workflow.md) for
+the cross-agent entry path and phase routing.
+
+Before starting IDD work, open
+`.github/instructions/idd-overview.instructions.md`. Open the routed
+phase file manually when the current step changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,3 +99,14 @@ The full, Copilot-first project guidance lives in
 When that file uses Copilot-specific workflow names, apply the intent
 in Codex using its own interaction model rather than following
 the product terms literally.
+
+## IDD Workflow
+
+This project uses Issue-Driven Development (IDD) with parallel AI
+agents. Start with [docs/idd-workflow.md](docs/idd-workflow.md) for
+the cross-agent entry path and phase routing.
+
+Before starting IDD work, open
+`.github/instructions/idd-overview.instructions.md`. Open the routed
+phase file manually when the current step changes.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,4 +109,3 @@ the cross-agent entry path and phase routing.
 Before starting IDD work, open
 `.github/instructions/idd-overview.instructions.md`. Open the routed
 phase file manually when the current step changes.
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,3 +99,14 @@ The full, Copilot-first project guidance lives in
 When that file uses Copilot-specific workflow names, apply the intent
 in Claude Code using its own interaction model rather than following
 the product terms literally.
+
+## IDD Workflow
+
+This project uses Issue-Driven Development (IDD) with parallel AI
+agents. Start with [docs/idd-workflow.md](docs/idd-workflow.md) for
+the cross-agent entry path and phase routing.
+
+Before starting IDD work, open
+`.github/instructions/idd-overview.instructions.md`. Open the routed
+phase file manually when the current step changes.
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,4 +109,3 @@ the cross-agent entry path and phase routing.
 Before starting IDD work, open
 `.github/instructions/idd-overview.instructions.md`. Open the routed
 phase file manually when the current step changes.
-

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -99,3 +99,14 @@ The full, Copilot-first project guidance lives in
 When that file uses Copilot-specific workflow names, apply the intent
 in Gemini CLI using its own interaction model rather than following
 the product terms literally.
+
+## IDD Workflow
+
+This project uses Issue-Driven Development (IDD) with parallel AI
+agents. Start with [docs/idd-workflow.md](docs/idd-workflow.md) for
+the cross-agent entry path and phase routing.
+
+Before starting IDD work, open
+`.github/instructions/idd-overview.instructions.md`. Open the routed
+phase file manually when the current step changes.
+

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -109,4 +109,3 @@ the cross-agent entry path and phase routing.
 Before starting IDD work, open
 `.github/instructions/idd-overview.instructions.md`. Open the routed
 phase file manually when the current step changes.
-


### PR DESCRIPTION
## Summary

Appends an IDD Workflow section to all four agent entry files so any
agent cloning the repository knows how to start the IDD execution loop.

## Files modified

| File | Change |
|---|---|
| `CLAUDE.md` | Appended after "Canonical reference" section |
| `AGENTS.md` | Appended after "Canonical reference" section |
| `GEMINI.md` | Appended after "Canonical reference" section |
| `.github/copilot-instructions.md` | Appended after "Onboarding" section |

## Section added (identical across all files)

```markdown
## IDD Workflow

This project uses Issue-Driven Development (IDD) with parallel AI
agents. Start with [docs/idd-workflow.md](docs/idd-workflow.md) for
the cross-agent entry path and phase routing.

Before starting IDD work, open
`.github/instructions/idd-overview.instructions.md`. Open the routed
phase file manually when the current step changes.
```

## Verification

- [x] Each file has exactly 1 IDD Workflow section
- [x] All existing sections (Canonical reference, Onboarding, etc.) unchanged
- [x] No community docs modified

## Note on merge order

This PR may be merged before or after #109–#112, but the referenced
file paths (`docs/idd-workflow.md`, `.github/instructions/idd-overview.instructions.md`)
are created by those PRs and should exist in `main` before agents
attempt to follow these links.

## Test plan

- [ ] CI passes (`cargo fmt --check`, `cargo clippy`, `cargo test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an "IDD Workflow" section across agent guides describing the Issue-Driven Development process, linking to the central workflow document, and providing initialization and phase-routing guidance including instructions to consult the overview and manually open the current phase when transitioning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/qorrection/pull/113)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/qorrection/pull/113)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->