### PR TITLE
feat(anim): add big :wq scene timeline

### DIFF
--- a/src/anim/scene.rs
+++ b/src/anim/scene.rs
@@ -25,18 +25,34 @@ use crate::anim::{
 /// `cols == 0` returns an empty scene because there is no visible
 /// canvas to animate within.
 pub fn q(cols: u16) -> Vec<String> {
+    sweep(car::STD, cols)
+}
+
+/// Build the larger `:wq` ambulance scene.
+///
+/// This timeline follows the same sweep / siren policy as [`q`]
+/// but renders [`car::BIG`], preserving the spec-locked stacked
+/// `WRITE QUEUE` / `418 I'm an AI agent` labels whenever the
+/// full asset is visible.
+pub fn wq(cols: u16) -> Vec<String> {
+    sweep(car::BIG, cols)
+}
+
+/// Sweep one ASCII asset across the visible width using the
+/// standard left-to-right timeline policy.
+fn sweep(car_asset: &str, cols: u16) -> Vec<String> {
     if cols == 0 {
         return Vec::new();
     }
 
-    let car_width = car::max_width(car::STD) as i32;
+    let car_width = car::max_width(car_asset) as i32;
     let start_x = 1 - car_width;
     let end_x = i32::from(cols) - 1;
     let mut phase = SirenPhase::Fi;
     let mut frames = Vec::with_capacity((end_x - start_x + 1) as usize);
 
     for x in start_x..=end_x {
-        let raw = frame::frame(car::STD, x, phase);
+        let raw = frame::frame(car_asset, x, phase);
         frames.push(clip_right(&raw, cols as usize));
         phase = phase.flip();
     }
@@ -151,5 +167,79 @@ mod tests {
         assert!(scene
             .iter()
             .all(|frame| !frame.contains("418 I'm an AI agent")));
+    }
+
+    #[test]
+    fn wq_scene_returns_empty_when_no_columns_are_visible() {
+        assert!(wq(0).is_empty());
+    }
+
+    #[test]
+    fn wq_scene_uses_the_full_visible_sweep_range() {
+        let cols = 140;
+        let scene = wq(cols);
+        let expected = cols as usize + car::max_width(car::BIG) - 1;
+        assert_eq!(scene.len(), expected);
+        assert!(
+            scene
+                .first()
+                .unwrap()
+                .chars()
+                .any(|c| c != ' ' && c != '\n'),
+            "first frame should contain the first visible car sliver",
+        );
+        assert!(
+            scene.last().unwrap().chars().any(|c| c != ' ' && c != '\n'),
+            "last frame should contain the last visible car sliver",
+        );
+    }
+
+    #[test]
+    fn wq_scene_contains_the_full_big_car_when_x_reaches_zero() {
+        let scene = wq(160);
+        let x_zero_idx = car::max_width(car::BIG) - 1;
+        assert_eq!(scene[x_zero_idx], frame::frame(car::BIG, 0, SirenPhase::Fi));
+        assert!(scene[x_zero_idx].contains("WRITE QUEUE"));
+        assert!(scene[x_zero_idx].contains("418 I'm an AI agent"));
+    }
+
+    #[test]
+    fn wq_scene_right_clips_every_row_to_the_requested_width() {
+        let cols = 20;
+        let scene = wq(cols);
+        for frame in &scene {
+            let lines: Vec<&str> = frame.split('\n').collect();
+            assert_eq!(lines.len(), car::height(car::BIG));
+            for line in lines {
+                assert!(
+                    line.len() <= cols as usize,
+                    "line exceeds {cols} cols: {line:?}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn wq_scene_alternates_the_siren_phase_on_successive_positive_offsets() {
+        let scene = wq(160);
+        let car_width = car::max_width(car::BIG);
+        let a = wheel_row(&scene[car_width + 5]);
+        let b = wheel_row(&scene[car_width + 6]);
+
+        if a.starts_with("Fi-Fo-") {
+            assert!(
+                b.starts_with("Fo-Fi-F"),
+                "next frame should flip to Fo-leading trail; got {b:?}",
+            );
+        } else {
+            assert!(
+                a.starts_with("Fo-Fi-"),
+                "expected Fi/Fo lead in positive-offset frame, got {a:?}",
+            );
+            assert!(
+                b.starts_with("Fi-Fo-F"),
+                "next frame should flip back to Fi-leading trail; got {b:?}",
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `anim::scene::wq(cols)` by reusing the existing sweep/clipping timeline policy with `car::BIG`
- keep the `WRITE QUEUE` and `418 I'm an AI agent` labels covered when the big asset is fully visible
- add focused scene tests for full sweep range, `x == 0` rendering, right clipping, and FI/FO alternation

## Testing
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets --all-features`

Closes #44

Follow-up issues: none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Introduced a "WRITE QUEUE" animation scene builder with full sweep animation support and proper label display

* **Refactor**
  - Refactored animation logic to eliminate duplication and improve code maintainability through shared helper functions

* **Tests**
  - Extended test coverage to validate scene generation with various configurations, including width constraints, content visibility, clipping behavior, and animation phase transitions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/qorrection/pull/119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->