### PR TITLE
feat(anim): add terminal-state renderer guard

### DIFF
--- a/src/anim/mod.rs
+++ b/src/anim/mod.rs
@@ -1,13 +1,13 @@
 //! Animation primitives.
 //!
-//! Phase C landed the static asset layer ([`car`]); Phase F adds
-//! the pure-function pieces that scenes will orchestrate. This
-//! includes the per-frame composer ([`frame`]), the dumb-TTY
-//! fallback ([`fallback`]), and the first timeline builder
-//! ([`scene`]); the crossterm-driven renderer follows in a
-//! subsequent commit.
+//! Phase C landed the static asset layer ([`car`]); later phases
+//! added the per-frame composer ([`frame`]), timeline builders
+//! ([`scene`]), narrow-terminal text fallback ([`fallback`]),
+//! and the terminal-state RAII guard ([`terminal`]) that the
+//! upcoming crossterm renderer will use.
 
 pub mod car;
 pub mod fallback;
 pub mod frame;
 pub mod scene;
+pub mod terminal;

--- a/src/anim/terminal.rs
+++ b/src/anim/terminal.rs
@@ -1,0 +1,272 @@
+//! Drop-based alternate-screen + cursor-visibility RAII guard.
+//!
+//! The animation renderer needs a short-lived "presentation
+//! mode": switch into the terminal's alternate screen, hide the
+//! cursor, draw frames, then restore the original screen on
+//! every exit path. Like [`crate::term::guard::RawGuard`], this
+//! wrapper makes restoration a destructor concern so normal
+//! return and panic unwinding share the same cleanup path.
+//!
+//! Scope for this phase:
+//!
+//! - [`acquire`] enters the alternate screen and hides the
+//!   cursor.
+//! - [`Drop`] shows the cursor and leaves the alternate screen
+//!   with best-effort semantics.
+//! - If acquisition fails after the alternate screen is entered
+//!   but before the cursor is hidden, the restore path runs
+//!   immediately so the terminal is not left half-mutated.
+//!
+//! The renderer loop itself lands in `#47`; this module only
+//! owns the terminal-state guard.
+
+use crate::Result;
+
+/// RAII guard that restores the normal terminal presentation on
+/// drop.
+///
+/// Construct via [`acquire`]. While the guard is alive the
+/// renderer may assume the terminal is on the alternate screen
+/// and the cursor is hidden.
+pub struct TerminalGuard {
+    on_drop: Option<Box<dyn FnOnce() + Send + 'static>>,
+}
+
+impl std::fmt::Debug for TerminalGuard {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TerminalGuard")
+            .field("armed", &self.is_armed())
+            .finish()
+    }
+}
+
+impl TerminalGuard {
+    /// Whether this guard currently owns the terminal
+    /// presentation state.
+    pub fn is_armed(&self) -> bool {
+        self.on_drop.is_some()
+    }
+
+    /// Construct a no-op guard.
+    pub fn noop() -> Self {
+        Self { on_drop: None }
+    }
+
+    /// Test-only constructor for drop-path assertions without
+    /// touching the real terminal.
+    ///
+    /// The hook must not panic. A panic during `Drop` while the
+    /// thread is already unwinding aborts the process.
+    #[cfg(test)]
+    pub(crate) fn with_restore_hook<H>(hook: H) -> Self
+    where
+        H: FnOnce() + Send + 'static,
+    {
+        Self {
+            on_drop: Some(Box::new(hook)),
+        }
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        if let Some(hook) = self.on_drop.take() {
+            hook();
+        }
+    }
+}
+
+/// Enter the alternate screen and hide the cursor.
+pub fn acquire() -> Result<TerminalGuard> {
+    acquire_with(
+        || {
+            let mut out = std::io::stdout();
+            crossterm::execute!(out, crossterm::terminal::EnterAlternateScreen)?;
+            Ok(())
+        },
+        || {
+            let mut out = std::io::stdout();
+            crossterm::execute!(out, crossterm::cursor::Hide)?;
+            Ok(())
+        },
+        || {
+            || {
+                let mut out = std::io::stdout();
+                let _ = crossterm::execute!(out, crossterm::cursor::Show);
+                let _ = crossterm::execute!(out, crossterm::terminal::LeaveAlternateScreen);
+            }
+        },
+    )
+}
+
+/// Side-effect-free wiring core for tests.
+fn acquire_with<EA, HC, MR, D>(
+    enter_alt: EA,
+    hide_cursor: HC,
+    make_restore: MR,
+) -> Result<TerminalGuard>
+where
+    EA: FnOnce() -> Result<()>,
+    HC: FnOnce() -> Result<()>,
+    MR: FnOnce() -> D,
+    D: FnOnce() + Send + 'static,
+{
+    enter_alt()?;
+
+    let mut restore = Some(make_restore());
+    if let Err(err) = hide_cursor() {
+        if let Some(restore) = restore.take() {
+            restore();
+        }
+        return Err(err);
+    }
+
+    Ok(TerminalGuard {
+        on_drop: Some(Box::new(
+            restore
+                .take()
+                .expect("restore hook must exist after successful acquire"),
+        )),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    #[test]
+    fn noop_guard_is_not_armed() {
+        let guard = TerminalGuard::noop();
+        assert!(!guard.is_armed());
+        drop(guard);
+    }
+
+    #[test]
+    fn armed_guard_runs_restore_on_normal_drop() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        {
+            let observed = Arc::clone(&counter);
+            let _guard = TerminalGuard::with_restore_hook(move || {
+                observed.fetch_add(1, Ordering::SeqCst);
+            });
+        }
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn armed_guard_runs_restore_on_panic() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let observed = Arc::clone(&counter);
+
+        let result = std::panic::catch_unwind(move || {
+            let _guard = TerminalGuard::with_restore_hook(move || {
+                observed.fetch_add(1, Ordering::SeqCst);
+            });
+            panic!("boom");
+        });
+
+        assert!(result.is_err());
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn acquire_with_success_arms_and_restores_once() {
+        let enter_calls = Arc::new(AtomicUsize::new(0));
+        let hide_calls = Arc::new(AtomicUsize::new(0));
+        let restore_calls = Arc::new(AtomicUsize::new(0));
+
+        {
+            let enter_observed = Arc::clone(&enter_calls);
+            let hide_observed = Arc::clone(&hide_calls);
+            let restore_observed = Arc::clone(&restore_calls);
+
+            let guard = acquire_with(
+                move || {
+                    enter_observed.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                },
+                move || {
+                    hide_observed.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                },
+                move || {
+                    move || {
+                        restore_observed.fetch_add(1, Ordering::SeqCst);
+                    }
+                },
+            )
+            .unwrap();
+
+            assert!(guard.is_armed());
+            assert_eq!(enter_calls.load(Ordering::SeqCst), 1);
+            assert_eq!(hide_calls.load(Ordering::SeqCst), 1);
+            assert_eq!(restore_calls.load(Ordering::SeqCst), 0);
+        }
+
+        assert_eq!(restore_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn acquire_with_enter_failure_returns_error_without_restore() {
+        let hide_calls = Arc::new(AtomicUsize::new(0));
+        let restore_calls = Arc::new(AtomicUsize::new(0));
+
+        let hide_observed = Arc::clone(&hide_calls);
+        let restore_observed = Arc::clone(&restore_calls);
+
+        let err = acquire_with(
+            move || Err(std::io::Error::other("enter failed").into()),
+            move || {
+                hide_observed.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            },
+            move || {
+                move || {
+                    restore_observed.fetch_add(1, Ordering::SeqCst);
+                }
+            },
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, crate::Error::Terminal(_)));
+        assert_eq!(hide_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(restore_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn acquire_with_hide_failure_restores_immediately() {
+        let enter_calls = Arc::new(AtomicUsize::new(0));
+        let hide_calls = Arc::new(AtomicUsize::new(0));
+        let restore_calls = Arc::new(AtomicUsize::new(0));
+
+        let enter_observed = Arc::clone(&enter_calls);
+        let hide_observed = Arc::clone(&hide_calls);
+        let restore_observed = Arc::clone(&restore_calls);
+
+        let err = acquire_with(
+            move || {
+                enter_observed.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            },
+            move || {
+                hide_observed.fetch_add(1, Ordering::SeqCst);
+                Err(std::io::Error::other("hide failed").into())
+            },
+            move || {
+                move || {
+                    restore_observed.fetch_add(1, Ordering::SeqCst);
+                }
+            },
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, crate::Error::Terminal(_)));
+        assert_eq!(enter_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(hide_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(restore_calls.load(Ordering::SeqCst), 1);
+    }
+}


### PR DESCRIPTION
## Summary
- add `anim::terminal::TerminalGuard` to own alternate-screen entry, cursor hiding, and best-effort restore on drop
- rollback immediately when cursor hiding fails after entering the alternate screen so the terminal never stays half-mutated
- add focused unit tests for normal drop, panic unwind, enter failure, and hide-failure rollback

Closes #50

## Follow-up
- #47 will consume this guard for the crossterm frame draw/sleep/restore renderer loop

## Rationale
- the guard mirrors the existing `term::RawGuard` pattern so terminal-state cleanup stays test-injectable without wiring the renderer main loop in the same change

## Testing
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets --all-features`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Terminal alternate screen management with automatic cursor visibility control and guaranteed state restoration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/qorrection/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->