### PR TITLE
[4/anim] anim-renderer-crossterm: crossterm-driven renderer

### DIFF
--- a/src/anim/mod.rs
+++ b/src/anim/mod.rs
@@ -3,11 +3,12 @@
 //! Phase C landed the static asset layer ([`car`]); later phases
 //! added the per-frame composer ([`frame`]), timeline builders
 //! ([`scene`]), narrow-terminal text fallback ([`fallback`]),
-//! and the terminal-state RAII guard ([`terminal`]) that the
-//! upcoming crossterm renderer will use.
+//! the terminal-state RAII guard ([`terminal`]), and the
+//! crossterm-driven presentation loop ([`render`]).
 
 pub mod car;
 pub mod fallback;
 pub mod frame;
+pub mod render;
 pub mod scene;
 pub mod terminal;

--- a/src/anim/render.rs
+++ b/src/anim/render.rs
@@ -1,0 +1,399 @@
+//! crossterm-driven animation renderer.
+//!
+//! The public [`render`] entry point owns the side-effecting
+//! presentation loop: choose the appropriate scene for the fired
+//! trigger and current width bucket, enter the alternate screen via
+//! [`super::terminal::TerminalGuard`], draw each frame at the home
+//! cursor position, sleep a fixed tick, and rely on guard drop for
+//! restoration on every exit path.
+
+use std::{io::Write, time::Duration};
+
+use crate::{
+    anim::{fallback, scene, terminal},
+    term::width::{bucket, WidthBucket},
+    trigger::parser::Outcome,
+    Result,
+};
+
+/// Fixed per-frame hold time.
+///
+/// The renderer sleeps after every successful draw, including the
+/// final frame, so the last visible gag remains on screen briefly
+/// before [`terminal::TerminalGuard`] restores the original screen.
+pub const FRAME_DELAY: Duration = Duration::from_millis(50);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PlanKind {
+    Fallback,
+    Tiny,
+    TinyBang,
+    Q,
+    Wq,
+    Bang,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RenderPlan {
+    pub(crate) kind: PlanKind,
+    pub(crate) frames: Vec<String>,
+}
+
+/// Render one fired trigger's animation for the given terminal width.
+pub fn render(outcome: Outcome, cols: u16) -> Result<()> {
+    let mut out = std::io::stdout();
+    render_with(
+        outcome,
+        cols,
+        terminal::acquire,
+        |frame| draw_frame(&mut out, frame),
+        std::thread::sleep,
+    )
+}
+
+/// Test seam covering plan selection, terminal-guard lifetime, and
+/// draw/sleep ordering without touching the real terminal.
+pub(crate) fn render_with<A, D, S>(
+    outcome: Outcome,
+    cols: u16,
+    acquire: A,
+    mut draw: D,
+    mut sleep: S,
+) -> Result<()>
+where
+    A: FnOnce() -> Result<terminal::TerminalGuard>,
+    D: FnMut(&str) -> Result<()>,
+    S: FnMut(Duration),
+{
+    let Some(plan) = render_plan(outcome, cols) else {
+        return Ok(());
+    };
+    if plan.frames.is_empty() {
+        return Ok(());
+    }
+
+    let _guard = acquire()?;
+    for frame in &plan.frames {
+        draw(frame)?;
+        sleep(FRAME_DELAY);
+    }
+    Ok(())
+}
+
+/// Build the pure render plan for one trigger + width combination.
+///
+/// Degrade policy is centralized here so boundary tests can pin it:
+///
+/// - `< 40` columns → one-line trigger-specific fallback gag
+/// - `40..=79`      → tiny ambulance, except `:q!` keeps a tiny parade
+/// - `80..=119`     → standard `:q` scene; `:wq` degrades here because
+///   the big 418-labeled asset does not fit
+/// - `>= 120`       → `:wq` upgrades to the big labeled scene, `:q!`
+///   keeps the parade, `:q` stays on the standard car
+pub(crate) fn render_plan(outcome: Outcome, cols: u16) -> Option<RenderPlan> {
+    let b = bucket(cols);
+    match outcome {
+        Outcome::None => None,
+        Outcome::Q => Some(match b {
+            WidthBucket::Tiny => fallback_plan(fallback::Trigger::Q),
+            WidthBucket::Small => RenderPlan {
+                kind: PlanKind::Tiny,
+                frames: scene::tiny(cols),
+            },
+            WidthBucket::Medium | WidthBucket::Large => RenderPlan {
+                kind: PlanKind::Q,
+                frames: scene::q(cols),
+            },
+        }),
+        Outcome::Wq => Some(match b {
+            WidthBucket::Tiny => fallback_plan(fallback::Trigger::Wq),
+            WidthBucket::Small => RenderPlan {
+                kind: PlanKind::Tiny,
+                frames: scene::tiny(cols),
+            },
+            WidthBucket::Medium => RenderPlan {
+                kind: PlanKind::Q,
+                frames: scene::q(cols),
+            },
+            WidthBucket::Large => RenderPlan {
+                kind: PlanKind::Wq,
+                frames: scene::wq(cols),
+            },
+        }),
+        Outcome::QBang => Some(match b {
+            WidthBucket::Tiny => fallback_plan(fallback::Trigger::Bang),
+            WidthBucket::Small => RenderPlan {
+                kind: PlanKind::TinyBang,
+                frames: scene::tiny_bang(cols),
+            },
+            WidthBucket::Medium | WidthBucket::Large => RenderPlan {
+                kind: PlanKind::Bang,
+                frames: scene::bang(cols),
+            },
+        }),
+    }
+}
+
+fn fallback_plan(trigger: fallback::Trigger) -> RenderPlan {
+    RenderPlan {
+        kind: PlanKind::Fallback,
+        frames: vec![fallback::fallback(trigger).to_string()],
+    }
+}
+
+fn draw_frame<W>(out: &mut W, frame: &str) -> Result<()>
+where
+    W: Write,
+{
+    crossterm::queue!(
+        out,
+        crossterm::cursor::MoveTo(0, 0),
+        crossterm::terminal::Clear(crossterm::terminal::ClearType::All),
+    )?;
+    write!(out, "{frame}")?;
+    out.flush()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        panic::AssertUnwindSafe,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc, Mutex,
+        },
+    };
+
+    #[test]
+    fn render_plan_returns_none_when_no_trigger_fired() {
+        assert_eq!(render_plan(Outcome::None, 120), None);
+    }
+
+    #[test]
+    fn render_plan_uses_fallback_below_forty_columns() {
+        let q = render_plan(Outcome::Q, 39).unwrap();
+        let wq = render_plan(Outcome::Wq, 0).unwrap();
+        let bang = render_plan(Outcome::QBang, 12).unwrap();
+
+        assert_eq!(q.kind, PlanKind::Fallback);
+        assert_eq!(
+            q.frames,
+            vec![fallback::fallback(fallback::Trigger::Q).to_string()]
+        );
+        assert_eq!(wq.kind, PlanKind::Fallback);
+        assert_eq!(
+            wq.frames,
+            vec![fallback::fallback(fallback::Trigger::Wq).to_string()]
+        );
+        assert_eq!(bang.kind, PlanKind::Fallback);
+        assert_eq!(
+            bang.frames,
+            vec![fallback::fallback(fallback::Trigger::Bang).to_string()]
+        );
+    }
+
+    #[test]
+    fn render_plan_selects_expected_bucket_variants() {
+        assert_eq!(render_plan(Outcome::Q, 40).unwrap().kind, PlanKind::Tiny);
+        assert_eq!(render_plan(Outcome::Q, 79).unwrap().kind, PlanKind::Tiny);
+        assert_eq!(render_plan(Outcome::Q, 80).unwrap().kind, PlanKind::Q);
+        assert_eq!(render_plan(Outcome::Q, 140).unwrap().kind, PlanKind::Q);
+
+        assert_eq!(render_plan(Outcome::Wq, 40).unwrap().kind, PlanKind::Tiny);
+        assert_eq!(render_plan(Outcome::Wq, 119).unwrap().kind, PlanKind::Q);
+        assert_eq!(render_plan(Outcome::Wq, 120).unwrap().kind, PlanKind::Wq);
+
+        assert_eq!(
+            render_plan(Outcome::QBang, 79).unwrap().kind,
+            PlanKind::TinyBang
+        );
+        assert_eq!(
+            render_plan(Outcome::QBang, 80).unwrap().kind,
+            PlanKind::Bang
+        );
+        assert_eq!(
+            render_plan(Outcome::QBang, 140).unwrap().kind,
+            PlanKind::Bang
+        );
+    }
+
+    #[test]
+    fn render_plan_small_bucket_uses_tiny_timelines() {
+        let q = render_plan(Outcome::Q, 40).unwrap();
+        let bang = render_plan(Outcome::QBang, 40).unwrap();
+
+        assert_eq!(q.frames, scene::tiny(40));
+        assert_eq!(bang.frames, scene::tiny_bang(40));
+    }
+
+    #[test]
+    fn render_plan_medium_wq_degrades_to_the_standard_scene() {
+        let plan = render_plan(Outcome::Wq, 119).unwrap();
+
+        assert_eq!(plan.kind, PlanKind::Q);
+        assert_eq!(plan.frames, scene::q(119));
+        assert!(plan
+            .frames
+            .iter()
+            .all(|frame| !frame.contains("418 I'm an AI agent")));
+    }
+
+    #[test]
+    fn render_plan_large_wq_preserves_the_big_418_scene() {
+        let plan = render_plan(Outcome::Wq, 120).unwrap();
+
+        assert_eq!(plan.kind, PlanKind::Wq);
+        assert_eq!(plan.frames, scene::wq(120));
+        assert!(plan
+            .frames
+            .iter()
+            .any(|frame| frame.contains("418 I'm an AI agent")));
+    }
+
+    #[test]
+    fn render_with_none_is_a_no_op() {
+        let draws = Arc::new(AtomicUsize::new(0));
+        let sleeps = Arc::new(AtomicUsize::new(0));
+        let acquires = Arc::new(AtomicUsize::new(0));
+
+        let draw_counter = Arc::clone(&draws);
+        let sleep_counter = Arc::clone(&sleeps);
+        let acquire_counter = Arc::clone(&acquires);
+
+        render_with(
+            Outcome::None,
+            120,
+            move || {
+                acquire_counter.fetch_add(1, Ordering::SeqCst);
+                Ok(terminal::TerminalGuard::noop())
+            },
+            move |_frame| {
+                draw_counter.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            },
+            move |_delay| {
+                sleep_counter.fetch_add(1, Ordering::SeqCst);
+            },
+        )
+        .unwrap();
+
+        assert_eq!(acquires.load(Ordering::SeqCst), 0);
+        assert_eq!(draws.load(Ordering::SeqCst), 0);
+        assert_eq!(sleeps.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn render_with_draws_sleeps_and_restores_for_single_frame_fallback() {
+        let events = Arc::new(Mutex::new(Vec::<String>::new()));
+        let acquire_events = Arc::clone(&events);
+        let draw_events = Arc::clone(&events);
+        let sleep_events = Arc::clone(&events);
+
+        render_with(
+            Outcome::Q,
+            39,
+            move || {
+                Ok(terminal::TerminalGuard::with_restore_hook(move || {
+                    acquire_events.lock().unwrap().push("restore".to_string());
+                }))
+            },
+            move |frame| {
+                draw_events.lock().unwrap().push(format!("draw:{frame}"));
+                Ok(())
+            },
+            move |delay| {
+                sleep_events
+                    .lock()
+                    .unwrap()
+                    .push(format!("sleep:{delay:?}"));
+            },
+        )
+        .unwrap();
+
+        let events = events.lock().unwrap().clone();
+        assert_eq!(
+            events,
+            vec![
+                format!("draw:{}", fallback::fallback(fallback::Trigger::Q)),
+                format!("sleep:{FRAME_DELAY:?}"),
+                "restore".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn render_with_sleeps_once_per_drawn_frame() {
+        let draws = Arc::new(AtomicUsize::new(0));
+        let sleeps = Arc::new(AtomicUsize::new(0));
+
+        let draw_counter = Arc::clone(&draws);
+        let sleep_counter = Arc::clone(&sleeps);
+
+        render_with(
+            Outcome::Q,
+            40,
+            || Ok(terminal::TerminalGuard::noop()),
+            move |_frame| {
+                draw_counter.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            },
+            move |_delay| {
+                sleep_counter.fetch_add(1, Ordering::SeqCst);
+            },
+        )
+        .unwrap();
+
+        let expected = scene::tiny(40).len();
+        assert_eq!(draws.load(Ordering::SeqCst), expected);
+        assert_eq!(sleeps.load(Ordering::SeqCst), expected);
+    }
+
+    #[test]
+    fn render_with_restores_when_draw_fails_after_acquire() {
+        let restores = Arc::new(AtomicUsize::new(0));
+        let restore_counter = Arc::clone(&restores);
+
+        let err = render_with(
+            Outcome::Q,
+            39,
+            move || {
+                Ok(terminal::TerminalGuard::with_restore_hook(move || {
+                    restore_counter.fetch_add(1, Ordering::SeqCst);
+                }))
+            },
+            |_frame| Err(std::io::Error::other("draw failed").into()),
+            |_delay| {},
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, crate::Error::Terminal(_)));
+        assert_eq!(restores.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn render_with_restores_when_draw_panics() {
+        let restores = Arc::new(AtomicUsize::new(0));
+        let restore_counter = Arc::clone(&restores);
+
+        let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+            let _ = render_with(
+                Outcome::Q,
+                39,
+                move || {
+                    Ok(terminal::TerminalGuard::with_restore_hook(move || {
+                        restore_counter.fetch_add(1, Ordering::SeqCst);
+                    }))
+                },
+                |_frame| -> Result<()> {
+                    panic!("boom");
+                },
+                |_delay| {},
+            );
+        }));
+
+        assert!(result.is_err());
+        assert_eq!(restores.load(Ordering::SeqCst), 1);
+    }
+}

--- a/src/anim/scene.rs
+++ b/src/anim/scene.rs
@@ -30,6 +30,16 @@ pub fn q(cols: u16) -> Vec<String> {
     sweep(car::STD, cols)
 }
 
+/// Build the compact 40-79 column ambulance scene.
+///
+/// This is the renderer's "small bucket" degrade path: when the
+/// terminal is wide enough for art but too narrow for the standard
+/// car, the animation keeps the same sweep / siren policy while
+/// switching to [`car::TINY`].
+pub fn tiny(cols: u16) -> Vec<String> {
+    sweep(car::TINY, cols)
+}
+
 /// Build the larger `:wq` ambulance scene.
 ///
 /// This timeline follows the same sweep / siren policy as [`q`]
@@ -49,6 +59,15 @@ pub fn wq(cols: u16) -> Vec<String> {
 /// multi-car convoy.
 pub fn bang(cols: u16) -> Vec<String> {
     parade(car::STD, cols, BANG_CARS)
+}
+
+/// Build the small-bucket `:q!` parade.
+///
+/// The renderer uses this when `40 <= cols < 80`: the trigger keeps
+/// its parade identity, but the body shrinks to [`car::TINY`] so the
+/// narrow viewport still gets a recognisably animated convoy.
+pub fn tiny_bang(cols: u16) -> Vec<String> {
+    parade(car::TINY, cols, BANG_CARS)
 }
 
 /// Sweep one ASCII asset across the visible width using the


### PR DESCRIPTION
## Summary
- add `anim::render` with a pure width-bucket plan selector and a crossterm draw loop guarded by `anim::terminal::TerminalGuard`
- add small-bucket `scene::tiny` and `scene::tiny_bang` degrade paths so `:q`, `:wq`, and `:q!` keep animation identity below the standard-car width
- cover fallback/no-op behavior, draw/sleep ordering, restore-on-error/panic, and the `:wq` 120-column boundary with focused unit tests

Closes #47

## Recommended follow-up
- #48 can snapshot the renderer-facing animation output now that the render plan is centralized
- #49 can pin width-bucket boundaries directly against `anim::render::render_plan`
- #52 can wire the pump into this renderer entry point

## Background
- `:wq` keeps the big `418 I'm an AI agent` scene only at `cols >= 120`; below that it degrades to the standard scene so medium widths do not clip the label
- `:q!` keeps its parade identity in the small bucket by switching to a `car::TINY` convoy instead of falling back to plain text


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added animation rendering system with frame-based playback capabilities
  * Responsive display design that adapts to various terminal widths
  * Enhanced support for compact terminals (40–79 columns)
  * Multiple animation variants tailored to different exit scenarios
  * Terminal state is automatically managed and restored

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/qorrection/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->