### PR TITLE
anim-large-art-scene-contract: define the oversized cameo scene contract

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -53,6 +53,7 @@ words:
   - jvim
   - kyuukyuu
   - lossily
+  - nyancat
   - ollama
   - pylint
   - qjunk

--- a/docs/anim-large-art-contract.md
+++ b/docs/anim-large-art-contract.md
@@ -1,0 +1,107 @@
+# Oversized ASCII Cameo Scene Contract
+
+This document pins the post-v0.1 contract for oversized ASCII cameo
+scenes inspired by the energy of tools such as `sl` and `nyancat`
+without copying third-party art or changing the current ambulance gags
+accidentally.
+
+## Status
+
+Oversized scenes are a future enhancement track, not a silent rewrite of
+the current animation layer.
+
+- v0.1 behavior stays unchanged: `:q` uses the standard ambulance,
+  `:wq` uses the larger `418` ambulance, and `:q!` keeps the parade.
+- Future oversized work may only ship behind an explicit integration
+  path that names this contract in code review and tests.
+
+## Trigger Mapping
+
+The first oversized cameo path is reserved for `:wq`.
+
+- `:wq` is the only trigger allowed to upgrade into an oversized cameo
+  scene without another contract update.
+- `:q` must keep the standard ambulance identity.
+- `:q!` must keep the parade identity unless a later issue extends this
+  contract explicitly.
+
+This keeps the current trigger personalities stable while leaving one
+high-signal trigger for a future large-format payoff.
+
+## Eligibility
+
+Oversized scenes are eligible only when the terminal can show the full
+art without horizontal or vertical clipping.
+
+- Minimum width threshold: `cols >= 160`.
+- The renderer must also verify that the terminal has enough visible
+  rows for the full asset plus any fixed top padding used by the scene.
+- If either dimension is insufficient, the renderer must fall back to
+  the existing ambulance scene for that trigger.
+
+The contract deliberately forbids "best effort" partial rendering for
+oversized art. Either the full cameo fits, or the user gets the existing
+scene unchanged.
+
+## Replace vs Augment
+
+Oversized art augments the current `:wq` path; it does not replace the
+ambulance scenes globally.
+
+- The existing ambulance-based scene remains the canonical fallback and
+  compatibility path.
+- A future oversized scene may appear only as the large-terminal branch
+  of the `:wq` renderer decision tree.
+- Future work may choose whether the cameo fully replaces the large
+  `:wq` timeline or appends after a short ambulance lead-in, but that
+  choice must stay entirely within the `:wq` large-terminal branch and
+  must not change `:q` or `:q!`.
+
+## Timing Budget
+
+Oversized scenes must stay deterministic and snapshot-testable.
+
+- Reuse the renderer's fixed frame tick (`50 ms`) rather than
+  introducing scene-specific sleep durations.
+- Encode emphasis by repeating frames in the pure timeline, not by
+  adding ad hoc timers in the renderer.
+- Keep the oversized cameo timeline at or below `60` frames total,
+  including any hold frames.
+- Keep the final visible hold at or below `500 ms` within that frame
+  budget.
+
+This keeps the path short enough for tests and avoids turning a joke
+into a blocking animation.
+
+## Clipping and Fallback
+
+Oversized scenes must fail closed into the existing art path.
+
+- No horizontal clipping of oversized assets is allowed.
+- No vertical clipping of oversized assets is allowed.
+- If asset dimensions, terminal dimensions, or row-budget plumbing are
+  unknown, the implementation must choose the existing ambulance scene.
+- Narrow-terminal text fallback remains unchanged and still owns the
+  `< 40` column bucket.
+
+## Asset Policy
+
+Oversized assets must be repository-local, ASCII-only, and safe to
+embed in the shipped binary.
+
+- Assets must be original to this repository unless a later issue lands
+  a separate, explicit license review path.
+- Assets must stay pure ASCII.
+- Assets must be embedded in the binary as source-controlled text
+  (`include_str!` or equivalent static string data).
+- Snapshot tests must assert the dimensions and contract-significant
+  labels of any oversized asset before renderer integration lands.
+
+## Implementation Boundary
+
+This contract intentionally separates three future concerns:
+
+- `#117` owns original oversized assets.
+- `#118` owns renderer integration.
+- Any trigger expansion beyond `:wq` requires another contract update
+  before implementation.

--- a/docs/anim-large-art-contract.md
+++ b/docs/anim-large-art-contract.md
@@ -91,9 +91,9 @@ embed in the shipped binary.
 
 - Assets must be original to this repository unless a later issue lands
   a separate, explicit license review path.
-- Assets must stay pure ASCII.
-- Assets must be embedded in the binary as source-controlled text
-  (`include_str!` or equivalent static string data).
+- All oversized assets must stay pure ASCII and live in the shipped
+  binary as source-controlled text (`include_str!` or equivalent static
+  string data).
 - Snapshot tests must assert the dimensions and contract-significant
   labels of any oversized asset before renderer integration lands.
 

--- a/src/anim/mod.rs
+++ b/src/anim/mod.rs
@@ -5,6 +5,11 @@
 //! ([`scene`]), narrow-terminal text fallback ([`fallback`]),
 //! the terminal-state RAII guard ([`terminal`]), and the
 //! crossterm-driven presentation loop ([`render`]).
+//!
+//! The post-v0.1 oversized cameo policy is documented in
+//! `docs/anim-large-art-contract.md` so future scene or renderer
+//! work can extend this layer without rewriting the current
+//! ambulance behavior by accident.
 
 pub mod car;
 pub mod fallback;


### PR DESCRIPTION
## Summary
- add `docs/anim-large-art-contract.md` as the canonical post-v0.1 contract for oversized ASCII cameo scenes
- pin trigger mapping, width/fit gates, replace-vs-augment behavior, timing budget, clipping rules, and the original-ASCII asset policy
- point `src/anim/mod.rs` at the new contract so future scene and renderer work can find it from the animation entry point

Closes #116

## Recommended follow-up
- #117 can add original oversized assets against the new ASCII-only / embedded-binary contract
- #118 can wire the large-terminal renderer branch against the `:wq`-only eligibility and fit/fallback rules

## Background
- The contract keeps current v0.1 ambulance behavior intact and reserves the first oversized cameo path for `:wq` only.
- Oversized art is contractually all-or-nothing: if the full asset does not fit, the renderer must fall back to the existing ambulance scene unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a contract describing post‑v0.1 rules for oversized ASCII cameo scenes: trigger keys and upgrade conditions, terminal dimension and visible-row requirements, deterministic timing and snapshot limits, fail‑closed clipping/fallback to existing ambulance art, asset requirements (repo‑local ASCII text and snapshot validation), and boundaries for future expansions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/qorrection/pull/123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->