### PR TITLE
[5/trigger] arming-wire-into-pump: Wire arming into wrap entry

### DIFF
--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -56,19 +56,25 @@ use crate::{
     Error, Result,
 };
 
+fn trigger_armed(command: &OsString) -> bool {
+    crate::cli::arming::is_armed(command.as_os_str())
+}
+
 /// Run a single PTY-wrapped session for `command` + `args`.
 ///
 /// Snapshots the terminal capabilities, routes through the
 /// non-TTY bypass when either stdin or stdout is not a TTY,
-/// otherwise acquires raw mode for the duration of the session
-/// and invokes the PTY session body. Returns the exit code the
-/// wrapped child should bubble up to the binary entry point.
+/// otherwise snapshots the trigger-arming policy, acquires raw
+/// mode for the duration of the session, and invokes the PTY
+/// session body. Returns the exit code the wrapped child should
+/// bubble up to the binary entry point.
 pub fn run_session(command: OsString, args: Vec<OsString>) -> Result<ExitCode> {
     let caps = detect::detect();
     run_session_with(
         caps,
         command,
         args,
+        trigger_armed,
         crate::term::acquire_raw,
         default_body,
         non_tty_passthrough,
@@ -87,19 +93,22 @@ pub fn run_session(command: OsString, args: Vec<OsString>) -> Result<ExitCode> {
 /// mode. Otherwise acquire raw mode, run `body`, and let the
 /// returned [`RawGuard`] restore the terminal on drop (normal
 /// return, `?` propagation, or panic unwind).
-pub(crate) fn run_session_with<A, B, P>(
+pub(crate) fn run_session_with<Arm, A, B, P>(
     caps: TerminalCaps,
     command: OsString,
     args: Vec<OsString>,
+    arm: Arm,
     acquire: A,
     body: B,
     passthrough: P,
 ) -> Result<ExitCode>
 where
+    Arm: FnOnce(&OsString) -> bool,
     A: FnOnce(&TerminalCaps) -> Result<RawGuard>,
-    B: FnOnce(&OsString, &[OsString]) -> Result<ExitCode>,
+    B: FnOnce(bool, &OsString, &[OsString]) -> Result<ExitCode>,
     P: FnOnce(&OsString, &[OsString]) -> Result<ExitCode>,
 {
+    let armed = arm(&command);
     if !(caps.stdin_is_tty && caps.stdout_is_tty) {
         // Non-TTY bypass: no raw mode, no PTY pump. The child
         // inherits the parent's stdio so pipes/redirects work
@@ -110,7 +119,7 @@ where
     // of the function. `let _ = ...` would drop it immediately
     // and defeat the purpose.
     let _raw = acquire(&caps)?;
-    body(&command, &args)
+    body(armed, &command, &args)
 }
 
 /// Non-TTY bypass body. Spawns `command` + `args` with stdio
@@ -134,10 +143,11 @@ fn non_tty_passthrough(command: &OsString, args: &[OsString]) -> Result<ExitCode
 /// supervisor surfaces the child's exit status through the
 /// returned [`ExitCode`]; nothing in this body writes to host
 /// stdout directly.
-fn default_body(command: &OsString, args: &[OsString]) -> Result<ExitCode> {
+fn default_body(armed: bool, command: &OsString, args: &[OsString]) -> Result<ExitCode> {
     let size = size::initial_size();
     tracing::info!(
         program = %command.to_string_lossy(),
+        armed,
         cols = size.cols,
         rows = size.rows,
         "wrap session: spawning child on PTY"
@@ -151,7 +161,7 @@ fn default_body(command: &OsString, args: &[OsString]) -> Result<ExitCode> {
     // disarmed once `run_pump_session` takes over (it installs
     // its own internal `KillOnDropGuard`).
     let mut kill_guard = session::KillOnDropGuard::armed(session.child.clone_killer());
-    let pump = pump::start_io_pump(&mut session, std::io::stdin(), std::io::stdout())?;
+    let pump = pump::start_io_pump(&mut session, std::io::stdin(), std::io::stdout(), armed)?;
     kill_guard.disarm();
     session::run_pump_session(session, pump)
 }
@@ -190,7 +200,7 @@ mod tests {
     fn no_acquire(_caps: &TerminalCaps) -> Result<RawGuard> {
         panic!("acquire must not run on the non-TTY bypass path");
     }
-    fn no_body(_cmd: &OsString, _args: &[OsString]) -> Result<ExitCode> {
+    fn no_body(_armed: bool, _cmd: &OsString, _args: &[OsString]) -> Result<ExitCode> {
         panic!("body must not run on the non-TTY bypass path");
     }
 
@@ -213,11 +223,12 @@ mod tests {
             caps(),
             OsString::from("dummy"),
             Vec::new(),
+            |_| true,
             move |_caps| {
                 acquired_for_acquire.store(true, Ordering::SeqCst);
                 Ok(RawGuard::noop())
             },
-            move |_cmd, _args| {
+            move |_armed, _cmd, _args| {
                 assert!(
                     acquired_for_body.load(Ordering::SeqCst),
                     "body ran before acquire"
@@ -242,11 +253,12 @@ mod tests {
             caps(),
             OsString::from("dummy"),
             Vec::new(),
+            |_| true,
             move |_caps| {
                 acquire_observed.fetch_add(1, Ordering::SeqCst);
                 Ok(RawGuard::noop())
             },
-            |_cmd, _args| Ok(ExitCode::SUCCESS),
+            |_armed, _cmd, _args| Ok(ExitCode::SUCCESS),
             no_passthrough,
         )
         .unwrap();
@@ -263,8 +275,9 @@ mod tests {
             caps(),
             OsString::from("dummy"),
             Vec::new(),
+            |_| true,
             move |_caps| Ok(observed_guard(counter_for_acquire)),
-            |_cmd, _args| Ok(ExitCode::SUCCESS),
+            |_armed, _cmd, _args| Ok(ExitCode::SUCCESS),
             no_passthrough,
         )
         .unwrap();
@@ -281,8 +294,9 @@ mod tests {
             caps(),
             OsString::from("dummy"),
             Vec::new(),
+            |_| true,
             move |_caps| Ok(observed_guard(counter_for_acquire)),
-            |_cmd, _args| {
+            |_armed, _cmd, _args| {
                 Err(crate::Error::Terminal(std::io::Error::other(
                     "synthetic body failure",
                 )))
@@ -305,8 +319,9 @@ mod tests {
                 caps(),
                 OsString::from("dummy"),
                 Vec::new(),
+                |_| true,
                 move |_caps| Ok(observed_guard(counter_for_call)),
-                |_cmd, _args| -> Result<ExitCode> {
+                |_armed, _cmd, _args| -> Result<ExitCode> {
                     panic!("body boom");
                 },
                 no_passthrough,
@@ -326,12 +341,13 @@ mod tests {
             caps(),
             OsString::from("dummy"),
             Vec::new(),
+            |_| true,
             |_caps| {
                 Err(crate::Error::Terminal(std::io::Error::other(
                     "synthetic acquire failure",
                 )))
             },
-            move |_cmd, _args| {
+            move |_armed, _cmd, _args| {
                 body_observed.store(true, Ordering::SeqCst);
                 Ok(ExitCode::SUCCESS)
             },
@@ -360,6 +376,7 @@ mod tests {
             c,
             OsString::from("dummy"),
             Vec::new(),
+            |_| true,
             no_acquire,
             no_body,
             move |_cmd, _args| {
@@ -392,6 +409,7 @@ mod tests {
             c,
             OsString::from("dummy"),
             Vec::new(),
+            |_| true,
             no_acquire,
             no_body,
             move |_cmd, _args| {
@@ -416,6 +434,7 @@ mod tests {
             c,
             OsString::from("dummy"),
             Vec::new(),
+            |_| true,
             no_acquire,
             no_body,
             |_cmd, _args| {
@@ -426,6 +445,62 @@ mod tests {
         );
 
         assert!(matches!(result, Err(crate::Error::Spawn(_))));
+    }
+
+    #[test]
+    fn run_session_with_passes_armed_true_to_body() {
+        let observed = Arc::new(AtomicBool::new(false));
+        let observed_for_body = Arc::clone(&observed);
+
+        let _exit = run_session_with(
+            caps(),
+            OsString::from("claude"),
+            Vec::new(),
+            |command| {
+                assert_eq!(command, &OsString::from("claude"));
+                true
+            },
+            |_caps| Ok(RawGuard::noop()),
+            move |armed, _cmd, _args| {
+                observed_for_body.store(armed, Ordering::SeqCst);
+                Ok(ExitCode::SUCCESS)
+            },
+            no_passthrough,
+        )
+        .unwrap();
+
+        assert!(
+            observed.load(Ordering::SeqCst),
+            "body should observe armed=true for allowlisted commands"
+        );
+    }
+
+    #[test]
+    fn run_session_with_passes_armed_false_to_body() {
+        let observed = Arc::new(AtomicBool::new(true));
+        let observed_for_body = Arc::clone(&observed);
+
+        let _exit = run_session_with(
+            caps(),
+            OsString::from("vim"),
+            Vec::new(),
+            |command| {
+                assert_eq!(command, &OsString::from("vim"));
+                false
+            },
+            |_caps| Ok(RawGuard::noop()),
+            move |armed, _cmd, _args| {
+                observed_for_body.store(armed, Ordering::SeqCst);
+                Ok(ExitCode::SUCCESS)
+            },
+            no_passthrough,
+        )
+        .unwrap();
+
+        assert!(
+            !observed.load(Ordering::SeqCst),
+            "body should observe armed=false for non-allowlisted commands"
+        );
     }
 
     /// `non_tty_passthrough` is the production bypass body and

--- a/src/pty/pump.rs
+++ b/src/pty/pump.rs
@@ -28,6 +28,85 @@ pub(crate) struct IoPump {
     pub(crate) child_to_host: ForwarderHandle,
 }
 
+enum HostToChildWriter<W> {
+    Armed(InputDetector<W>),
+    Passthrough(W),
+}
+
+impl<W> Write for HostToChildWriter<W>
+where
+    W: Write,
+{
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self {
+            Self::Armed(writer) => writer.write(buf),
+            Self::Passthrough(writer) => writer.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            Self::Armed(writer) => writer.flush(),
+            Self::Passthrough(writer) => writer.flush(),
+        }
+    }
+}
+
+enum ChildToHostWriter<W> {
+    Armed(OutputArbiter<W>),
+    Passthrough(W),
+}
+
+impl<W> Write for ChildToHostWriter<W>
+where
+    W: Write,
+{
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self {
+            Self::Armed(writer) => writer.write(buf),
+            Self::Passthrough(writer) => writer.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            Self::Armed(writer) => writer.flush(),
+            Self::Passthrough(writer) => writer.flush(),
+        }
+    }
+}
+
+struct TriggerWiring<PtyW, HOut> {
+    host_to_child: HostToChildWriter<PtyW>,
+    child_to_host: ChildToHostWriter<HOut>,
+    input: Option<crate::trigger::input::SharedInputPump>,
+}
+
+fn wire_trigger_io<PtyW, HOut>(
+    armed: bool,
+    pty_writer: PtyW,
+    host_stdout: HOut,
+) -> TriggerWiring<PtyW, HOut>
+where
+    PtyW: Write,
+    HOut: Write,
+{
+    if armed {
+        let input = shared_input_pump();
+        TriggerWiring {
+            host_to_child: HostToChildWriter::Armed(InputDetector::new(pty_writer, input.clone())),
+            child_to_host: ChildToHostWriter::Armed(OutputArbiter::new(host_stdout, input.clone())),
+            input: Some(input),
+        }
+    } else {
+        TriggerWiring {
+            host_to_child: HostToChildWriter::Passthrough(pty_writer),
+            child_to_host: ChildToHostWriter::Passthrough(host_stdout),
+            input: None,
+        }
+    }
+}
+
 /// Wire host stdio onto a live `SpawnedSession` and spawn both
 /// forwarder threads.
 ///
@@ -46,6 +125,7 @@ pub(crate) fn start_io_pump<HIn, HOut>(
     session: &mut SpawnedSession,
     host_stdin: HIn,
     host_stdout: HOut,
+    armed: bool,
 ) -> Result<IoPump>
 where
     HIn: Read + Send + 'static,
@@ -53,9 +133,11 @@ where
 {
     let pty_reader = session.master.try_clone_reader().map_err(Error::Pty)?;
     let pty_writer = session.master.take_writer().map_err(Error::Pty)?;
-    let trigger_input = shared_input_pump();
-    let pty_writer = InputDetector::new(pty_writer, trigger_input.clone());
-    let host_stdout = OutputArbiter::new(host_stdout, trigger_input);
+    let TriggerWiring {
+        host_to_child: pty_writer,
+        child_to_host: host_stdout,
+        input: _input,
+    } = wire_trigger_io(armed, pty_writer, host_stdout);
 
     let host_to_child = spawn_forwarder(Direction::HostToChild, host_stdin, pty_writer);
     let child_to_host = spawn_forwarder(Direction::ChildToHost, pty_reader, host_stdout);
@@ -64,6 +146,80 @@ where
         host_to_child,
         child_to_host,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::trigger::parser::Outcome;
+
+    const ENTER_ALT: &[u8] = b"\x1b[?1049h";
+
+    #[test]
+    fn armed_wiring_shares_trigger_state_with_input_detector() {
+        let mut wiring = wire_trigger_io(true, Vec::new(), Vec::new());
+        assert!(matches!(wiring.host_to_child, HostToChildWriter::Armed(_)));
+        assert!(matches!(wiring.child_to_host, ChildToHostWriter::Armed(_)));
+
+        let input = wiring
+            .input
+            .as_ref()
+            .expect("armed wiring should allocate shared trigger state")
+            .clone();
+
+        wiring.host_to_child.write_all(b":").unwrap();
+
+        let mut guard = input.lock().unwrap();
+        assert_eq!(guard.feed_input_byte(b"q"[0]).outcome(), Outcome::None);
+        assert_eq!(guard.feed_input_byte(b"\n"[0]).outcome(), Outcome::Q);
+    }
+
+    #[test]
+    fn armed_wiring_shares_trigger_state_with_output_arbiter() {
+        let mut wiring = wire_trigger_io(true, Vec::new(), Vec::new());
+        let input = wiring
+            .input
+            .as_ref()
+            .expect("armed wiring should allocate shared trigger state")
+            .clone();
+
+        wiring.child_to_host.write_all(ENTER_ALT).unwrap();
+
+        assert!(
+            input.lock().unwrap().is_alt_screen(),
+            "armed output path should keep alt-screen state in sync"
+        );
+    }
+
+    #[test]
+    fn disarmed_wiring_bypasses_trigger_state_entirely() {
+        let mut wiring = wire_trigger_io(false, Vec::new(), Vec::new());
+        assert!(matches!(
+            wiring.host_to_child,
+            HostToChildWriter::Passthrough(_)
+        ));
+        assert!(matches!(
+            wiring.child_to_host,
+            ChildToHostWriter::Passthrough(_)
+        ));
+        assert!(
+            wiring.input.is_none(),
+            "disarmed wiring must not allocate trigger state"
+        );
+
+        wiring.host_to_child.write_all(b":q\n").unwrap();
+        wiring.child_to_host.write_all(ENTER_ALT).unwrap();
+
+        let HostToChildWriter::Passthrough(host_bytes) = wiring.host_to_child else {
+            panic!("disarmed host path should remain a passthrough writer");
+        };
+        assert_eq!(host_bytes, b":q\n");
+
+        let ChildToHostWriter::Passthrough(child_bytes) = wiring.child_to_host else {
+            panic!("disarmed child path should remain a passthrough writer");
+        };
+        assert_eq!(child_bytes, ENTER_ALT);
+    }
 }
 
 // Unix-only real-spawn integration smoke. Exercises
@@ -155,7 +311,8 @@ mod real_pump {
         let sink = SharedSink::default();
         let host_stdin = Cursor::new(Vec::<u8>::new()); // immediate EOF
 
-        let pump = start_io_pump(&mut session, host_stdin, sink.clone()).expect("start_io_pump");
+        let pump =
+            start_io_pump(&mut session, host_stdin, sink.clone(), true).expect("start_io_pump");
 
         // Bounded child wait: if echo regresses, kill it so
         // the master reader unblocks and the child_to_host
@@ -235,7 +392,8 @@ mod real_pump {
         // -> writer drops -> cat sees EOT on slave -> exits.
         let host_stdin = Cursor::new(b"hello\n".to_vec());
 
-        let pump = start_io_pump(&mut session, host_stdin, sink.clone()).expect("start_io_pump");
+        let pump =
+            start_io_pump(&mut session, host_stdin, sink.clone(), true).expect("start_io_pump");
 
         let wait_deadline = Instant::now() + WAIT_BUDGET;
         let status = loop {

--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -1030,7 +1030,7 @@ mod real_session {
         )
         .expect("spawn /bin/sh");
         let sink = SharedSink::default();
-        let pump = start_io_pump(&mut session, Cursor::new(host_stdin), sink.clone())
+        let pump = start_io_pump(&mut session, Cursor::new(host_stdin), sink.clone(), true)
             .expect("start_io_pump");
         let result = run_pump_session_with(
             PtyChild {
@@ -1076,7 +1076,7 @@ mod real_session {
 
         let mut term = session.child.clone_killer();
         let sink = SharedSink::default();
-        let pump = start_io_pump(&mut session, Cursor::new(Vec::<u8>::new()), sink)
+        let pump = start_io_pump(&mut session, Cursor::new(Vec::<u8>::new()), sink, true)
             .expect("start_io_pump");
 
         // Signal the child BEFORE handing the session to the


### PR DESCRIPTION
## Summary
- evaluate the fixed `is_armed` policy once at wrap startup and thread that result through the PTY session seam
- bypass `InputDetector` and `OutputArbiter` entirely for disarmed wraps while preserving the existing armed path and PTY handle acquisition order
- add seam and pump wiring tests that pin shared-state behavior for armed sessions and the no-trigger-state fast-path for disarmed sessions

Closes #51

## Follow-up
- none

## Background
- this keeps non-allowlisted commands off the trigger-state path before animation firing lands in follow-up trigger work such as #52 and the non-armed passthrough coverage tracked by #56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal trigger mechanism architecture to conditionally activate based on command configuration, enabling more efficient I/O handling for different command types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/qorrection/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->