### PR TITLE
feat(pty): cancel host input forwarders after child exit

### DIFF
--- a/src/pty/forward.rs
+++ b/src/pty/forward.rs
@@ -14,9 +14,18 @@
 //! [`super::pump`].
 
 use std::io::{self, Read, Write};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+#[cfg(unix)]
+use std::os::fd::RawFd;
 
 const BUF_LEN: usize = 8 * 1024;
+const CANCEL_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 /// Direction tag carried in [`ForwarderHandle`] so PR 4's
 /// supervisor can attribute join failures to the right pipe.
@@ -41,6 +50,124 @@ pub(crate) enum ForwarderExit {
     WriterClosed { bytes: u64 },
 }
 
+#[derive(Clone, Default)]
+pub(crate) struct CancelHandle {
+    inner: Arc<AtomicBool>,
+}
+
+impl CancelHandle {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn cancel(&self) {
+        self.inner.store(true, Ordering::SeqCst);
+    }
+
+    pub(crate) fn is_cancelled(&self) -> bool {
+        self.inner.load(Ordering::SeqCst)
+    }
+}
+
+pub(crate) struct CancellableReader<R> {
+    inner: R,
+    cancel: CancelHandle,
+    #[cfg(unix)]
+    poll_fd: Option<RawFd>,
+}
+
+impl<R> CancellableReader<R> {
+    #[cfg(any(not(unix), test))]
+    pub(crate) fn new(inner: R, cancel: CancelHandle) -> Self {
+        // Cooperative fallback: callers that cannot surface a
+        // pollable fd still get a pre-read cancel check, but an
+        // already-blocking `inner.read()` remains up to the
+        // wrapped reader to break out of.
+        Self {
+            inner,
+            cancel,
+            #[cfg(unix)]
+            poll_fd: None,
+        }
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn with_poll_fd(inner: R, cancel: CancelHandle, poll_fd: RawFd) -> Self {
+        // Production unix path: poll the real host-stdin fd in
+        // short intervals so post-exit cancellation can wake a
+        // forwarder that would otherwise sit in a blocking read.
+        Self {
+            inner,
+            cancel,
+            poll_fd: Some(poll_fd),
+        }
+    }
+
+    fn cancel_handle(&self) -> CancelHandle {
+        self.cancel.clone()
+    }
+
+    #[cfg(unix)]
+    fn poll_readable(&self, poll_fd: RawFd) -> io::Result<()> {
+        loop {
+            if self.cancel.is_cancelled() {
+                return Ok(());
+            }
+            let mut fd = libc::pollfd {
+                fd: poll_fd,
+                events: libc::POLLIN,
+                revents: 0,
+            };
+            let timeout_ms = CANCEL_POLL_INTERVAL.as_millis() as libc::c_int;
+            // SAFETY: `fd` points to a valid stack-allocated `pollfd`
+            // for the duration of the call, `nfds` matches that single
+            // entry, and `timeout_ms` is a bounded integer millisecond
+            // timeout. `poll_fd` is borrowed only for readiness checks;
+            // the actual read stays on `self.inner`.
+            let rc = unsafe { libc::poll(&mut fd, 1, timeout_ms) };
+            if rc < 0 {
+                let err = io::Error::last_os_error();
+                if err.kind() == io::ErrorKind::Interrupted {
+                    continue;
+                }
+                return Err(err);
+            }
+            if rc == 0 {
+                continue;
+            }
+            if (fd.revents & libc::POLLNVAL) != 0 {
+                return Err(io::Error::other("cancellable reader poll saw invalid fd"));
+            }
+            if (fd.revents & (libc::POLLIN | libc::POLLHUP | libc::POLLERR)) != 0 {
+                return Ok(());
+            }
+        }
+    }
+}
+
+impl<R> Read for CancellableReader<R>
+where
+    R: Read,
+{
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        #[cfg(unix)]
+        if let Some(poll_fd) = self.poll_fd {
+            self.poll_readable(poll_fd)?;
+            if self.cancel.is_cancelled() {
+                return Ok(0);
+            }
+            return self.inner.read(buf);
+        }
+        if self.cancel.is_cancelled() {
+            return Ok(0);
+        }
+        self.inner.read(buf)
+    }
+}
+
 /// A spawned forwarder thread plus its direction tag.
 ///
 /// The thread keeps running until [`ForwarderExit`] is
@@ -49,6 +176,15 @@ pub(crate) enum ForwarderExit {
 pub(crate) struct ForwarderHandle {
     pub(crate) direction: Direction,
     pub(crate) join: JoinHandle<io::Result<ForwarderExit>>,
+    cancel: Option<CancelHandle>,
+}
+
+impl ForwarderHandle {
+    pub(crate) fn cancel(&self) {
+        if let Some(cancel) = &self.cancel {
+            cancel.cancel();
+        }
+    }
 }
 
 /// Spawn a thread that copies bytes from `reader` into
@@ -66,7 +202,29 @@ where
     W: Write + Send + 'static,
 {
     let join = thread::spawn(move || run_forwarder(&mut reader, &mut writer));
-    ForwarderHandle { direction, join }
+    ForwarderHandle {
+        direction,
+        join,
+        cancel: None,
+    }
+}
+
+pub(crate) fn spawn_cancellable_forwarder<R, W>(
+    direction: Direction,
+    mut reader: CancellableReader<R>,
+    mut writer: W,
+) -> ForwarderHandle
+where
+    R: Read + Send + 'static,
+    W: Write + Send + 'static,
+{
+    let cancel = reader.cancel_handle();
+    let join = thread::spawn(move || run_forwarder(&mut reader, &mut writer));
+    ForwarderHandle {
+        direction,
+        join,
+        cancel: Some(cancel),
+    }
 }
 
 fn run_forwarder<R, W>(reader: &mut R, writer: &mut W) -> io::Result<ForwarderExit>

--- a/src/pty/forward.rs
+++ b/src/pty/forward.rs
@@ -177,6 +177,7 @@ pub(crate) struct ForwarderHandle {
     pub(crate) direction: Direction,
     pub(crate) join: JoinHandle<io::Result<ForwarderExit>>,
     cancel: Option<CancelHandle>,
+    cancel_wakes_read: bool,
 }
 
 impl ForwarderHandle {
@@ -184,6 +185,10 @@ impl ForwarderHandle {
         if let Some(cancel) = &self.cancel {
             cancel.cancel();
         }
+    }
+
+    pub(crate) fn cancel_wakes_read(&self) -> bool {
+        self.cancel_wakes_read
     }
 }
 
@@ -206,6 +211,7 @@ where
         direction,
         join,
         cancel: None,
+        cancel_wakes_read: false,
     }
 }
 
@@ -213,6 +219,7 @@ pub(crate) fn spawn_cancellable_forwarder<R, W>(
     direction: Direction,
     mut reader: CancellableReader<R>,
     mut writer: W,
+    cancel_wakes_read: bool,
 ) -> ForwarderHandle
 where
     R: Read + Send + 'static,
@@ -224,6 +231,7 @@ where
         direction,
         join,
         cancel: Some(cancel),
+        cancel_wakes_read,
     }
 }
 

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -51,6 +51,9 @@ mod spawn;
 use std::ffi::OsString;
 use std::process::{Command, ExitCode};
 
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+
 use crate::{
     term::{detect, RawGuard, TerminalCaps},
     Error, Result,
@@ -161,6 +164,19 @@ fn default_body(armed: bool, command: &OsString, args: &[OsString]) -> Result<Ex
     // disarmed once `run_pump_session` takes over (it installs
     // its own internal `KillOnDropGuard`).
     let mut kill_guard = session::KillOnDropGuard::armed(session.child.clone_killer());
+    #[cfg(unix)]
+    let pump = {
+        let host_stdin = std::io::stdin();
+        let host_stdin_fd = host_stdin.as_raw_fd();
+        pump::start_io_pump_pollable(
+            &mut session,
+            host_stdin,
+            std::io::stdout(),
+            armed,
+            host_stdin_fd,
+        )?
+    };
+    #[cfg(not(unix))]
     let pump = pump::start_io_pump(&mut session, std::io::stdin(), std::io::stdout(), armed)?;
     kill_guard.disarm();
     session::run_pump_session(session, pump)

--- a/src/pty/pump.rs
+++ b/src/pty/pump.rs
@@ -132,6 +132,7 @@ fn start_io_pump_with_reader<HIn, HOut>(
     host_stdin: CancellableReader<HIn>,
     host_stdout: HOut,
     armed: bool,
+    host_cancel_wakes_read: bool,
 ) -> Result<IoPump>
 where
     HIn: Read + Send + 'static,
@@ -145,7 +146,12 @@ where
         input: _input,
     } = wire_trigger_io(armed, pty_writer, host_stdout);
 
-    let host_to_child = spawn_cancellable_forwarder(Direction::HostToChild, host_stdin, pty_writer);
+    let host_to_child = spawn_cancellable_forwarder(
+        Direction::HostToChild,
+        host_stdin,
+        pty_writer,
+        host_cancel_wakes_read,
+    );
     let child_to_host = spawn_forwarder(Direction::ChildToHost, pty_reader, host_stdout);
 
     Ok(IoPump {
@@ -171,6 +177,7 @@ where
         CancellableReader::new(host_stdin, host_cancel),
         host_stdout,
         armed,
+        false,
     )
 }
 
@@ -192,6 +199,7 @@ where
         CancellableReader::with_poll_fd(host_stdin, host_cancel, host_stdin_fd),
         host_stdout,
         armed,
+        true,
     )
 }
 

--- a/src/pty/pump.rs
+++ b/src/pty/pump.rs
@@ -10,7 +10,13 @@
 
 use std::io::{Read, Write};
 
-use crate::pty::forward::{spawn_forwarder, Direction, ForwarderHandle};
+#[cfg(unix)]
+use std::os::fd::RawFd;
+
+use crate::pty::forward::{
+    spawn_cancellable_forwarder, spawn_forwarder, CancelHandle, CancellableReader, Direction,
+    ForwarderHandle,
+};
 use crate::pty::spawn::SpawnedSession;
 use crate::trigger::{
     input::{shared_input_pump, InputDetector},
@@ -121,9 +127,9 @@ where
 /// Errors from portable-pty (handle acquisition, fd dup) flow
 /// through [`Error::Pty`], preserving the existing exit-code
 /// classification from `src/error.rs`.
-pub(crate) fn start_io_pump<HIn, HOut>(
+fn start_io_pump_with_reader<HIn, HOut>(
     session: &mut SpawnedSession,
-    host_stdin: HIn,
+    host_stdin: CancellableReader<HIn>,
     host_stdout: HOut,
     armed: bool,
 ) -> Result<IoPump>
@@ -139,13 +145,54 @@ where
         input: _input,
     } = wire_trigger_io(armed, pty_writer, host_stdout);
 
-    let host_to_child = spawn_forwarder(Direction::HostToChild, host_stdin, pty_writer);
+    let host_to_child = spawn_cancellable_forwarder(Direction::HostToChild, host_stdin, pty_writer);
     let child_to_host = spawn_forwarder(Direction::ChildToHost, pty_reader, host_stdout);
 
     Ok(IoPump {
         host_to_child,
         child_to_host,
     })
+}
+
+#[cfg(any(not(unix), test))]
+pub(crate) fn start_io_pump<HIn, HOut>(
+    session: &mut SpawnedSession,
+    host_stdin: HIn,
+    host_stdout: HOut,
+    armed: bool,
+) -> Result<IoPump>
+where
+    HIn: Read + Send + 'static,
+    HOut: Write + Send + 'static,
+{
+    let host_cancel = CancelHandle::new();
+    start_io_pump_with_reader(
+        session,
+        CancellableReader::new(host_stdin, host_cancel),
+        host_stdout,
+        armed,
+    )
+}
+
+#[cfg(unix)]
+pub(crate) fn start_io_pump_pollable<HIn, HOut>(
+    session: &mut SpawnedSession,
+    host_stdin: HIn,
+    host_stdout: HOut,
+    armed: bool,
+    host_stdin_fd: RawFd,
+) -> Result<IoPump>
+where
+    HIn: Read + Send + 'static,
+    HOut: Write + Send + 'static,
+{
+    let host_cancel = CancelHandle::new();
+    start_io_pump_with_reader(
+        session,
+        CancellableReader::with_poll_fd(host_stdin, host_cancel, host_stdin_fd),
+        host_stdout,
+        armed,
+    )
 }
 
 #[cfg(test)]

--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -35,31 +35,27 @@
 //! (panic, early `?`, …) until it's disarmed by a successful
 //! wait. The guard is unit-tested via `catch_unwind`.
 //!
-//! ## Detached-thread degraded mode
+//! ## Post-exit host-input cancellation
 //!
-//! `host_to_child` is the only forwarder that may stay blocked
-//! after the child exits — it can be sitting in `read()` on real
-//! host stdin with no graceful cancellation primitive. The
-//! supervisor uses two separate join budgets to handle the two
-//! directions:
+//! `host_to_child` is the only forwarder that can still be
+//! waiting on host input after the child exits. Issue #89 wires a
+//! cancellation token into that direction so the supervisor can
+//! ask the forwarder to break out of its host-stdin wait before
+//! attempting the bounded post-exit join. The join budgets remain
+//! split because the two directions still have different drain
+//! roles:
 //!
 //! - [`Deadlines::forwarder_join_budget`] (5 s in production)
 //!   is the budget for the `ChildToHost` direction. If the
 //!   join exceeds that budget we emit `tracing::warn!`, drop
 //!   the join handle (detaching the OS thread), and let the
 //!   parent process termination clean it up.
-//! - [`Deadlines::host_to_child_post_exit_budget`] is **zero
-//!   in production**. The host->stdin reader has nothing
-//!   useful to deliver after the child is gone, so a
-//!   non-blocking `is_finished()` check decides between
-//!   extracting the real outcome and detaching silently
-//!   (`tracing::debug!`). Without the split, every clean
-//!   interactive exit would block for 5 s waiting on a
-//!   `read()` call that can't be cancelled.
-//!
-//! A first-class cancellation API for forwarders is tracked as a
-//! follow-up — see issue #89 (`pty: cancellable forwarders for
-//! non-EOF host stdin`).
+//! - [`Deadlines::host_to_child_post_exit_budget`] is a short
+//!   bounded join window for the cancelled `HostToChild`
+//!   direction. Once cancellation is signalled there is no
+//!   useful user input left to deliver, so the budget only needs
+//!   to be long enough for the poll loop to observe the cancel
+//!   bit and exit cleanly instead of detaching immediately.
 
 use std::io;
 use std::process::ExitCode;
@@ -92,15 +88,11 @@ pub(crate) struct Deadlines {
     /// thread mode). Drains pending child output that the
     /// forwarder may still be writing to host stdout.
     pub forwarder_join_budget: Duration,
-    /// Same as `forwarder_join_budget` but for the
-    /// `HostToChild` direction. Production sets this to **zero**
-    /// because once the child has exited there is nothing useful
-    /// the host->child forwarder can deliver: the user's
-    /// in-flight keystrokes are now meaningless input. Without
-    /// the split, an interactive session blocked in `stdin.read()`
-    /// would hold the supervisor for the full 5 s join budget on
-    /// every clean exit, making each `q9 vim` (etc.) appear to
-    /// hang for 5 s after the wrapped editor quit.
+    /// Same as `forwarder_join_budget` but for the cancelled
+    /// `HostToChild` direction. Production keeps this short:
+    /// once the child has exited the host->child forwarder has no
+    /// useful work left, so the budget only needs to cover one
+    /// or two poll intervals of the cancellable read loop.
     pub host_to_child_post_exit_budget: Duration,
     /// Sleep between successive `try_wait` ticks. Keeps the
     /// supervisor from busy-looping; small enough that signal
@@ -124,10 +116,10 @@ impl Deadlines {
         Self {
             child_wait_deadline: None,
             forwarder_join_budget: Duration::from_secs(5),
-            // Detach the host->stdin reader immediately on child
-            // exit; see field doc for why a non-zero value would
-            // hang every interactive session for 5 s.
-            host_to_child_post_exit_budget: Duration::ZERO,
+            // Give the cancelled host->stdin reader enough time
+            // to observe the cancel bit and join cleanly without
+            // reintroducing the old multi-second post-exit hang.
+            host_to_child_post_exit_budget: Duration::from_millis(250),
             wait_poll: Duration::from_millis(20),
             post_kill_wait_budget: Duration::from_secs(5),
         }
@@ -352,6 +344,7 @@ where
 
     // Phase 2: drain remaining forwarders within budget.
     if let Some(h) = h2c.take() {
+        h.cancel();
         h2c_result = Some(join_with_budget(
             h,
             deadlines.host_to_child_post_exit_budget,
@@ -429,20 +422,15 @@ fn extract_join(handle: ForwarderHandle) -> io::Result<ForwarderExit> {
 fn join_with_budget(handle: ForwarderHandle, budget: Duration) -> io::Result<ForwarderExit> {
     let direction = handle.direction;
     // Always try a non-blocking check first so a zero-budget call
-    // (production HostToChild) still extracts a finished
-    // forwarder's outcome instead of being treated as a timeout.
-    // Without this, `Deadlines::production().host_to_child_post_exit_budget
-    // = ZERO` would skip the loop entirely and emit a spurious
-    // "exceeded budget" warning on every clean exit.
+    // still extracts a finished forwarder's outcome instead of
+    // being treated as a timeout.
     if handle.join.is_finished() {
         return extract_join(handle);
     }
     if budget.is_zero() {
-        // Intentional zero-budget detach (production HostToChild
-        // post-exit). The host->stdin reader has nothing useful
-        // to deliver after the child is gone, so we drop the
-        // handle silently rather than warning. Use `debug!` for
-        // observability without polluting normal-exit logs.
+        // Intentional zero-budget detach. Keep this branch for
+        // test seams that want an immediate detach path without
+        // waiting for the poll loop.
         tracing::debug!(
             ?direction,
             "supervisor: zero-budget detach of unfinished forwarder"
@@ -493,10 +481,12 @@ fn log_forwarder_outcome(direction: Direction, result: Option<io::Result<Forward
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pty::forward::{spawn_forwarder, Direction};
+    use crate::pty::forward::{
+        spawn_cancellable_forwarder, spawn_forwarder, CancelHandle, CancellableReader, Direction,
+    };
     use std::io::{self, Cursor};
     use std::sync::{
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc, Mutex,
     };
     use std::thread;
@@ -637,19 +627,24 @@ mod tests {
         }
     }
 
-    /// Build a pump where `HostToChild` is hung in `read()`
-    /// forever but `ChildToHost` terminates instantly. Used by
-    /// the regression test that pins the production
-    /// `host_to_child_post_exit_budget = 0` invariant — the
-    /// supervisor must detach the hung stdin reader without
-    /// waiting the full `forwarder_join_budget`.
-    fn hung_h2c_quiet_c2h_pump() -> IoPump {
-        struct ForeverReader;
-        impl io::Read for ForeverReader {
+    /// Build a pump where `HostToChild` waits until the
+    /// supervisor signals cancellation, while `ChildToHost`
+    /// terminates instantly. The returned flag flips when the
+    /// blocked reader observed cancellation and exited.
+    fn cancellable_h2c_quiet_c2h_pump() -> (IoPump, Arc<AtomicBool>) {
+        struct CancelAwareForeverReader {
+            cancel: CancelHandle,
+            started: Arc<AtomicBool>,
+            exited: Arc<AtomicBool>,
+        }
+        impl io::Read for CancelAwareForeverReader {
             fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
-                loop {
-                    std::thread::park_timeout(Duration::from_secs(60));
+                self.started.store(true, Ordering::SeqCst);
+                while !self.cancel.is_cancelled() {
+                    std::thread::park_timeout(Duration::from_millis(10));
                 }
+                self.exited.store(true, Ordering::SeqCst);
+                Ok(0)
             }
         }
         struct DiscardWriter;
@@ -661,14 +656,40 @@ mod tests {
                 Ok(())
             }
         }
-        let host_to_child = spawn_forwarder(Direction::HostToChild, ForeverReader, DiscardWriter);
+        let host_cancel = CancelHandle::new();
+        let started = Arc::new(AtomicBool::new(false));
+        let exited = Arc::new(AtomicBool::new(false));
+        let host_to_child = spawn_cancellable_forwarder(
+            Direction::HostToChild,
+            CancellableReader::new(
+                CancelAwareForeverReader {
+                    cancel: host_cancel.clone(),
+                    started: Arc::clone(&started),
+                    exited: Arc::clone(&exited),
+                },
+                host_cancel,
+            ),
+            DiscardWriter,
+        );
         let c2h_in: Cursor<Vec<u8>> = Cursor::new(Vec::new());
         let c2h_out: Vec<u8> = Vec::new();
         let child_to_host = spawn_forwarder(Direction::ChildToHost, c2h_in, c2h_out);
-        IoPump {
-            host_to_child,
-            child_to_host,
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !started.load(Ordering::SeqCst) && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
         }
+        assert!(
+            started.load(Ordering::SeqCst),
+            "host->child forwarder did not enter read() within the wait budget"
+        );
+
+        (
+            IoPump {
+                host_to_child,
+                child_to_host,
+            },
+            exited,
+        )
     }
 
     /// Regression for chatgpt-codex/copilot reviewer finding
@@ -703,15 +724,13 @@ mod tests {
         );
     }
 
-    /// Regression for rubber-duck finding #1 (PR 5): with
-    /// production deadlines, an interactive `q9` session whose
-    /// `HostToChild` reader is blocked in `stdin.read()` must
-    /// not stall the supervisor for the full
-    /// `forwarder_join_budget` (5 s) on clean child exit. The
-    /// production split sets `host_to_child_post_exit_budget`
-    /// to zero so the hung handle is detached immediately.
+    /// Regression for issue #89: with production deadlines, an
+    /// interactive `q9` session whose `HostToChild` reader is
+    /// blocked on host input must be cancelled and joined within
+    /// the short post-exit budget rather than hanging until the
+    /// child->host budget expires.
     #[test]
-    fn production_deadlines_detach_hung_host_to_child_immediately() {
+    fn production_deadlines_cancel_hung_host_to_child_before_join() {
         // child_wait_deadline=None in production; switch to a
         // bounded value here so the test cannot hang on a
         // try_wait regression. Keep the per-direction budgets
@@ -721,14 +740,19 @@ mod tests {
         deadlines.wait_poll = Duration::from_millis(2);
 
         let child = MockChild::new(ExitStatus::with_exit_code(0), 0);
+        let (pump, exited) = cancellable_h2c_quiet_c2h_pump();
         let start = Instant::now();
-        let code = run_pump_session_with(child, hung_h2c_quiet_c2h_pump(), deadlines)
+        let code = run_pump_session_with(child, pump, deadlines)
             .expect("clean exit with hung h2c must still be Ok");
         let elapsed = start.elapsed();
 
         assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::SUCCESS));
-        // Generous slack but well under the 5 s production
-        // forwarder_join_budget the bug would have triggered.
+        assert!(
+            exited.load(Ordering::SeqCst),
+            "host->child reader should observe cancellation before supervisor returns"
+        );
+        // Generous slack but well under the old multi-second
+        // budget the degraded mode would have hit.
         assert!(
             elapsed < Duration::from_millis(500),
             "supervisor stalled on hung HostToChild: {elapsed:?}"
@@ -967,12 +991,15 @@ mod tests {
 #[cfg(all(test, unix))]
 mod real_session {
     use super::*;
-    use crate::pty::pump::start_io_pump;
+    use crate::pty::pump::{start_io_pump, start_io_pump_pollable};
     use crate::pty::spawn::spawn_child;
     use portable_pty::PtySize;
     use std::ffi::{OsStr, OsString};
     use std::io::Cursor;
+    use std::os::fd::AsRawFd;
+    use std::os::unix::net::UnixStream;
     use std::sync::{Arc, Mutex};
+    use tracing_subscriber::fmt::MakeWriter;
 
     const JOIN_BUDGET: Duration = Duration::from_secs(5);
     const WAIT_BUDGET: Duration = Duration::from_secs(5);
@@ -1016,6 +1043,36 @@ mod real_session {
         }
         fn flush(&mut self) -> io::Result<()> {
             Ok(())
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct SharedLog {
+        inner: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl SharedLog {
+        fn snapshot(&self) -> String {
+            String::from_utf8_lossy(&self.inner.lock().unwrap()).into_owned()
+        }
+    }
+
+    impl io::Write for SharedLog {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.inner.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for SharedLog {
+        type Writer = SharedLog;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
         }
     }
 
@@ -1103,6 +1160,61 @@ mod real_session {
             ),
             other => panic!("expected Signal, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn supervisor_cancels_pollable_host_stdin_after_signal_death() {
+        let mut session =
+            spawn_child(OsStr::new("/bin/cat"), &[], pty_size_80x24()).expect("spawn /bin/cat");
+
+        let mut term = session.child.clone_killer();
+        let sink = SharedSink::default();
+        let (host_stdin, _hold_open) = UnixStream::pair().expect("unix stream pair");
+        let host_stdin_fd = host_stdin.as_raw_fd();
+        let pump = start_io_pump_pollable(&mut session, host_stdin, sink, true, host_stdin_fd)
+            .expect("start pollable pump");
+
+        let logs = SharedLog::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(logs.clone())
+            .with_ansi(false)
+            .without_time()
+            .with_target(false)
+            .with_max_level(tracing::Level::DEBUG)
+            .finish();
+
+        let start = Instant::now();
+        let res = tracing::subscriber::with_default(subscriber, || {
+            term.kill().expect("signal cat via clone_killer");
+            run_pump_session_with(
+                PtyChild {
+                    child: session.child,
+                },
+                pump,
+                supervisor_deadlines(),
+            )
+        });
+        let elapsed = start.elapsed();
+        drop(session.master);
+
+        let err = res.expect_err("signal death must surface");
+        match err {
+            Error::Signal { signum } => assert_eq!(signum, 1),
+            other => panic!("expected Signal, got {other:?}"),
+        }
+        assert!(
+            elapsed < JOIN_BUDGET,
+            "pollable host stdin cancellation should finish within join budget: {elapsed:?}"
+        );
+        let captured = logs.snapshot();
+        assert!(
+            !captured.contains("forwarder join exceeded budget"),
+            "host->child forwarder should join instead of timing out: {captured}"
+        );
+        assert!(
+            !captured.contains("zero-budget detach"),
+            "host->child forwarder should no longer use zero-budget detach: {captured}"
+        );
     }
 
     #[test]

--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -1086,13 +1086,12 @@ mod real_session {
     }
 
     fn supervisor_deadlines() -> Deadlines {
-        Deadlines {
-            child_wait_deadline: Some(WAIT_BUDGET),
-            forwarder_join_budget: JOIN_BUDGET,
-            host_to_child_post_exit_budget: JOIN_BUDGET,
-            wait_poll: WAIT_POLL,
-            post_kill_wait_budget: WAIT_BUDGET,
-        }
+        let mut deadlines = Deadlines::production();
+        deadlines.child_wait_deadline = Some(WAIT_BUDGET);
+        deadlines.forwarder_join_budget = JOIN_BUDGET;
+        deadlines.wait_poll = WAIT_POLL;
+        deadlines.post_kill_wait_budget = WAIT_BUDGET;
+        deadlines
     }
 
     /// Shared `Write` sink so the integration test can inspect

--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -52,10 +52,15 @@
 //!   parent process termination clean it up.
 //! - [`Deadlines::host_to_child_post_exit_budget`] is a short
 //!   bounded join window for the cancelled `HostToChild`
-//!   direction. Once cancellation is signalled there is no
-//!   useful user input left to deliver, so the budget only needs
-//!   to be long enough for the poll loop to observe the cancel
-//!   bit and exit cleanly instead of detaching immediately.
+//!   direction, but only when cancellation is known to wake the
+//!   blocked read (the unix pollable stdin path, or a test seam
+//!   that models the same behavior). Once cancellation is
+//!   signalled there is no useful user input left to deliver, so
+//!   the budget only needs to be long enough for the poll loop to
+//!   observe the cancel bit and exit cleanly instead of
+//!   detaching immediately. Non-wakeable readers retain the old
+//!   zero-budget detach path to avoid reintroducing a post-exit
+//!   delay or warning.
 
 use std::io;
 use std::process::ExitCode;
@@ -89,10 +94,12 @@ pub(crate) struct Deadlines {
     /// forwarder may still be writing to host stdout.
     pub forwarder_join_budget: Duration,
     /// Same as `forwarder_join_budget` but for the cancelled
-    /// `HostToChild` direction. Production keeps this short:
-    /// once the child has exited the host->child forwarder has no
-    /// useful work left, so the budget only needs to cover one
-    /// or two poll intervals of the cancellable read loop.
+    /// `HostToChild` direction when cancellation can wake the
+    /// blocked read. Production keeps this short: once the child
+    /// has exited the host->child forwarder has no useful work
+    /// left, so the budget only needs to cover one or two poll
+    /// intervals of the wakeable cancel loop. Non-wakeable
+    /// readers still detach with a zero budget.
     pub host_to_child_post_exit_budget: Duration,
     /// Sleep between successive `try_wait` ticks. Keeps the
     /// supervisor from busy-looping; small enough that signal
@@ -345,10 +352,12 @@ where
     // Phase 2: drain remaining forwarders within budget.
     if let Some(h) = h2c.take() {
         h.cancel();
-        h2c_result = Some(join_with_budget(
-            h,
-            deadlines.host_to_child_post_exit_budget,
-        ));
+        let budget = if h.cancel_wakes_read() {
+            deadlines.host_to_child_post_exit_budget
+        } else {
+            Duration::ZERO
+        };
+        h2c_result = Some(join_with_budget(h, budget));
     }
     if let Some(h) = c2h.take() {
         c2h_result = Some(join_with_budget(h, deadlines.forwarder_join_budget));
@@ -670,6 +679,7 @@ mod tests {
                 host_cancel,
             ),
             DiscardWriter,
+            true,
         );
         let c2h_in: Cursor<Vec<u8>> = Cursor::new(Vec::new());
         let c2h_out: Vec<u8> = Vec::new();
@@ -690,6 +700,43 @@ mod tests {
             },
             exited,
         )
+    }
+
+    /// Build a pump where `HostToChild` ignores cancellation once
+    /// its blocking read begins. This models the non-wakeable
+    /// fallback path used by non-Unix stdin.
+    fn nonwakeable_h2c_quiet_c2h_pump() -> IoPump {
+        struct ForeverReader;
+        impl io::Read for ForeverReader {
+            fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+                loop {
+                    std::thread::park_timeout(Duration::from_secs(60));
+                }
+            }
+        }
+        struct DiscardWriter;
+        impl io::Write for DiscardWriter {
+            fn write(&mut self, b: &[u8]) -> io::Result<usize> {
+                Ok(b.len())
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+        let host_cancel = CancelHandle::new();
+        let host_to_child = spawn_cancellable_forwarder(
+            Direction::HostToChild,
+            CancellableReader::new(ForeverReader, host_cancel),
+            DiscardWriter,
+            false,
+        );
+        let c2h_in: Cursor<Vec<u8>> = Cursor::new(Vec::new());
+        let c2h_out: Vec<u8> = Vec::new();
+        let child_to_host = spawn_forwarder(Direction::ChildToHost, c2h_in, c2h_out);
+        IoPump {
+            host_to_child,
+            child_to_host,
+        }
     }
 
     /// Regression for chatgpt-codex/copilot reviewer finding
@@ -756,6 +803,30 @@ mod tests {
         assert!(
             elapsed < Duration::from_millis(500),
             "supervisor stalled on hung HostToChild: {elapsed:?}"
+        );
+    }
+
+    /// Regression for the accepted E-phase review on PR #125:
+    /// non-wakeable host stdin must retain the old zero-budget
+    /// detach path so non-Unix production builds do not wait the
+    /// short pollable-join budget and emit a spurious timeout
+    /// warning.
+    #[test]
+    fn production_deadlines_keep_zero_budget_for_nonwakeable_host_to_child() {
+        let mut deadlines = Deadlines::production();
+        deadlines.child_wait_deadline = Some(Duration::from_secs(2));
+        deadlines.wait_poll = Duration::from_millis(2);
+
+        let child = MockChild::new(ExitStatus::with_exit_code(0), 0);
+        let start = Instant::now();
+        let code = run_pump_session_with(child, nonwakeable_h2c_quiet_c2h_pump(), deadlines)
+            .expect("clean exit with non-wakeable h2c must still be Ok");
+        let elapsed = start.elapsed();
+
+        assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::SUCCESS));
+        assert!(
+            elapsed < Duration::from_millis(100),
+            "non-wakeable HostToChild should detach immediately: {elapsed:?}"
         );
     }
 


### PR DESCRIPTION
## Summary
- add a cancellable host-input reader and forwarder handle for the host->child PTY path
- poll unix host stdin before blocking reads and cancel that direction before the supervisor's post-exit join
- add unit and real-PTY regressions proving the cancelled host-input forwarder joins cleanly without the old detach warning

## Follow-up issues
- none

## Background
- The issue's real leak case is the unix TTY path where host stdin can sit in a blocking read after the child exits; this PR makes that production path pollable so cancellation can wake it.
- Non-unix and test-only generic readers keep the cooperative wrapper so existing seams stay intact without changing the generic forwarder API.

Closes #89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal sessions now support cancellable host→child (stdin) forwarding, including a pollable wake option on Unix to unblock blocked reads.

* **Bug Fixes**
  * More reliable shutdown: explicit cancellation plus a conditional short post-exit cleanup window prevents hangs while preserving immediate detach when wake-up isn’t available.

* **Tests**
  * Added unit and regression tests for cancellation behavior, pollable-stdin scenarios, and supervisor join-time budgets (including an integration regression).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/qorrection/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->