### PR TITLE
[4/anim] anim-width-bucket-tests: Bucket boundary unit tests

### DIFF
--- a/src/anim/render.rs
+++ b/src/anim/render.rs
@@ -166,6 +166,24 @@ mod tests {
         },
     };
 
+    fn assert_render_plan(
+        outcome: Outcome,
+        cols: u16,
+        expected_kind: PlanKind,
+        expected_frames: Vec<String>,
+    ) {
+        let plan = render_plan(outcome, cols).unwrap();
+
+        assert_eq!(
+            plan.kind, expected_kind,
+            "{outcome:?} at {cols} cols chose an unexpected plan kind"
+        );
+        assert_eq!(
+            plan.frames, expected_frames,
+            "{outcome:?} at {cols} cols chose unexpected frames"
+        );
+    }
+
     #[test]
     fn render_plan_returns_none_when_no_trigger_fired() {
         assert_eq!(render_plan(Outcome::None, 120), None);
@@ -217,6 +235,54 @@ mod tests {
             render_plan(Outcome::QBang, 140).unwrap().kind,
             PlanKind::Bang
         );
+    }
+
+    #[test]
+    fn render_plan_covers_q_width_boundaries() {
+        assert_render_plan(
+            Outcome::Q,
+            39,
+            PlanKind::Fallback,
+            vec![fallback::fallback(fallback::Trigger::Q).to_string()],
+        );
+        assert_render_plan(Outcome::Q, 40, PlanKind::Tiny, scene::tiny(40));
+        assert_render_plan(Outcome::Q, 79, PlanKind::Tiny, scene::tiny(79));
+        assert_render_plan(Outcome::Q, 80, PlanKind::Q, scene::q(80));
+        assert_render_plan(Outcome::Q, 119, PlanKind::Q, scene::q(119));
+        assert_render_plan(Outcome::Q, 120, PlanKind::Q, scene::q(120));
+        assert_render_plan(Outcome::Q, 140, PlanKind::Q, scene::q(140));
+    }
+
+    #[test]
+    fn render_plan_covers_wq_width_boundaries() {
+        assert_render_plan(
+            Outcome::Wq,
+            39,
+            PlanKind::Fallback,
+            vec![fallback::fallback(fallback::Trigger::Wq).to_string()],
+        );
+        assert_render_plan(Outcome::Wq, 40, PlanKind::Tiny, scene::tiny(40));
+        assert_render_plan(Outcome::Wq, 79, PlanKind::Tiny, scene::tiny(79));
+        assert_render_plan(Outcome::Wq, 80, PlanKind::Q, scene::q(80));
+        assert_render_plan(Outcome::Wq, 119, PlanKind::Q, scene::q(119));
+        assert_render_plan(Outcome::Wq, 120, PlanKind::Wq, scene::wq(120));
+        assert_render_plan(Outcome::Wq, 140, PlanKind::Wq, scene::wq(140));
+    }
+
+    #[test]
+    fn render_plan_covers_bang_width_boundaries() {
+        assert_render_plan(
+            Outcome::QBang,
+            39,
+            PlanKind::Fallback,
+            vec![fallback::fallback(fallback::Trigger::Bang).to_string()],
+        );
+        assert_render_plan(Outcome::QBang, 40, PlanKind::TinyBang, scene::tiny_bang(40));
+        assert_render_plan(Outcome::QBang, 79, PlanKind::TinyBang, scene::tiny_bang(79));
+        assert_render_plan(Outcome::QBang, 80, PlanKind::Bang, scene::bang(80));
+        assert_render_plan(Outcome::QBang, 119, PlanKind::Bang, scene::bang(119));
+        assert_render_plan(Outcome::QBang, 120, PlanKind::Bang, scene::bang(120));
+        assert_render_plan(Outcome::QBang, 140, PlanKind::Bang, scene::bang(140));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add width-boundary unit tests for `render_plan` at `39/40/79/80/119/120/140` columns across `:q`, `:wq`, and `:q!`
- assert both the selected `PlanKind` and the representative frame source so each boundary proves the intended scene swap
- keep the change inside the existing `src/anim/render.rs` test module without widening the production API

Closes #49

## Recommended follow-up
- #76 should still validate these boundaries in the release dry run after the remaining trigger wiring lands

## Background
- `render_plan` already had spot checks for a few buckets, but this PR closes the exact boundary matrix called out by the issue so regressions at the width cutovers fail fast and locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for rendering width-boundary behavior validation and plan output verification across different display scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/qorrection/pull/127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->