### PR TITLE
[5/trigger] e2e-non-armed-passthrough: rexpect: non-armed passes :q

### DIFF
--- a/tests/pty_e2e.rs
+++ b/tests/pty_e2e.rs
@@ -34,6 +34,37 @@ mod unix {
     }
 
     #[test]
+    fn q9_cat_passthrough_preserves_q_literal_when_command_is_not_armed(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut command = q9();
+        command.arg("cat");
+
+        let mut session = spawn_command(command, Some(TIMEOUT_MS))?;
+        session.send_line(":q")?;
+        session.exp_string(":q")?;
+        session.send_control('d')?;
+        let remaining = session.exp_eof()?;
+
+        match session.process.wait()? {
+            WaitStatus::Exited(_, 0) => {}
+            other => panic!("expected q9 cat to exit 0, got {other:?}"),
+        }
+
+        let normalized = remaining.replace("\r\n", "\n");
+        assert!(
+            normalized.contains(":q"),
+            "expected cat itself to echo a second :q literal, got {normalized:?}"
+        );
+        assert!(
+            !normalized.contains("[QQ]")
+                && !normalized.contains("Fi-Fo")
+                && !normalized.contains("QUEUE"),
+            "expected passthrough output without animation text, got {normalized:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn q9_sh_nonzero_exit_is_propagated() -> Result<(), Box<dyn std::error::Error>> {
         let mut command = q9();
         command.args(["sh", "-c", "exit 7"]);
@@ -92,6 +123,13 @@ mod windows {
     #[test]
     #[ignore = "Windows ConPTY passthrough smoke is tracked by issue #65"]
     fn q9_cat_passthrough_echoes_input_and_exits_zero() {}
+
+    /// Windows ConPTY E2E coverage is tracked separately for
+    /// v0.1 because this suite depends on Unix-only `rexpect`.
+    /// Tracking issue: <https://github.com/kurone-kito/qorrection/issues/65>.
+    #[test]
+    #[ignore = "Windows ConPTY passthrough smoke is tracked by issue #65"]
+    fn q9_cat_passthrough_preserves_q_literal_when_command_is_not_armed() {}
 
     /// Windows ConPTY E2E coverage is tracked separately for
     /// v0.1 because this suite depends on Unix-only `rexpect`.


### PR DESCRIPTION
## Summary
- add a rexpect PTY E2E that sends `:q` through `q9 cat` when the wrapped command is not armed
- prove the literal reaches the child by requiring a second `:q` echo after the first terminal-side match
- keep the change local to `tests/pty_e2e.rs` and reuse the existing `q9 cat` harness

Closes #56

## Recommended follow-up
- #69 should still add the dedicated rexpect CI coverage once the remaining Phase 5 cases are in place

## Background
- the repo already covered the non-TTY bypass path for `:q`, but this issue specifically needed the interactive PTY regression guard where an unarmed command must not intercept the literal at all


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
- Added end-to-end test validating PTY passthrough correctly preserves literal input
- Updated Windows test stub to align with Unix coverage improvements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/qorrection/pull/128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->