### PR TITLE
[5/trigger] pump-fire-animation: Fire animation on detect

### DIFF
--- a/src/anim/render.rs
+++ b/src/anim/render.rs
@@ -141,7 +141,7 @@ fn fallback_plan(trigger: fallback::Trigger) -> RenderPlan {
     }
 }
 
-fn draw_frame<W>(out: &mut W, frame: &str) -> Result<()>
+pub(crate) fn draw_frame<W>(out: &mut W, frame: &str) -> Result<()>
 where
     W: Write,
 {

--- a/src/pty/pump.rs
+++ b/src/pty/pump.rs
@@ -8,19 +8,22 @@
 //! supervisor that converges them with the child wait is owned
 //! by PR 4 (#33).
 
-use std::io::{Read, Write};
+use std::io::{self, Read, Write};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 #[cfg(unix)]
 use std::os::fd::RawFd;
 
+use crate::anim::render::{draw_frame, render_plan, FRAME_DELAY};
 use crate::pty::forward::{
     spawn_cancellable_forwarder, spawn_forwarder, CancelHandle, CancellableReader, Direction,
     ForwarderHandle,
 };
 use crate::pty::spawn::SpawnedSession;
 use crate::trigger::{
-    input::{shared_input_pump, InputDetector},
+    input::{shared_input_pump, InputInterceptor},
     output::OutputArbiter,
+    parser::Outcome,
 };
 use crate::{Error, Result};
 
@@ -35,7 +38,7 @@ pub(crate) struct IoPump {
 }
 
 enum HostToChildWriter<W> {
-    Armed(InputDetector<W>),
+    Armed(InputInterceptor<W>),
     Passthrough(W),
 }
 
@@ -82,9 +85,116 @@ where
     }
 }
 
+struct SharedWriter<W> {
+    inner: Arc<Mutex<W>>,
+}
+
+impl<W> Clone for SharedWriter<W> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl<W> SharedWriter<W> {
+    fn new(inner: W) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(inner)),
+        }
+    }
+
+    fn lock(&self) -> MutexGuard<'_, W> {
+        match self.inner.lock() {
+            Ok(guard) => guard,
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    "shared host stdout mutex was poisoned; recovering writer"
+                );
+                err.into_inner()
+            }
+        }
+    }
+}
+
+impl<W> Write for SharedWriter<W>
+where
+    W: Write,
+{
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut guard = self.lock();
+        guard.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        let mut guard = self.lock();
+        guard.flush()
+    }
+}
+
+struct LockedPresentation<'a, W: Write> {
+    out: MutexGuard<'a, W>,
+}
+
+impl<'a, W> LockedPresentation<'a, W>
+where
+    W: Write,
+{
+    fn acquire(mut out: MutexGuard<'a, W>) -> Result<Self> {
+        crossterm::execute!(&mut *out, crossterm::terminal::EnterAlternateScreen)?;
+        if let Err(err) = crossterm::execute!(&mut *out, crossterm::cursor::Hide) {
+            let _ = crossterm::execute!(&mut *out, crossterm::terminal::LeaveAlternateScreen);
+            return Err(err.into());
+        }
+        Ok(Self { out })
+    }
+
+    fn writer(&mut self) -> &mut W {
+        &mut self.out
+    }
+}
+
+impl<W> Drop for LockedPresentation<'_, W>
+where
+    W: Write,
+{
+    fn drop(&mut self) {
+        let _ = crossterm::execute!(&mut *self.out, crossterm::cursor::Show);
+        let _ = crossterm::execute!(&mut *self.out, crossterm::terminal::LeaveAlternateScreen);
+    }
+}
+
+fn render_cols() -> u16 {
+    match crossterm::terminal::size() {
+        Ok((cols, _)) if cols > 0 => cols,
+        _ => 80,
+    }
+}
+
+fn render_animation<W>(host_stdout: &SharedWriter<W>, outcome: Outcome) -> io::Result<()>
+where
+    W: Write,
+{
+    let Some(plan) = render_plan(outcome, render_cols()) else {
+        return Ok(());
+    };
+    if plan.frames.is_empty() {
+        return Ok(());
+    }
+
+    let mut presentation =
+        LockedPresentation::acquire(host_stdout.lock()).map_err(io::Error::other)?;
+    for frame in &plan.frames {
+        draw_frame(presentation.writer(), frame).map_err(io::Error::other)?;
+        std::thread::sleep(FRAME_DELAY);
+    }
+    Ok(())
+}
+
 struct TriggerWiring<PtyW, HOut> {
     host_to_child: HostToChildWriter<PtyW>,
-    child_to_host: ChildToHostWriter<HOut>,
+    child_to_host: ChildToHostWriter<SharedWriter<HOut>>,
     input: Option<crate::trigger::input::SharedInputPump>,
 }
 
@@ -95,19 +205,28 @@ fn wire_trigger_io<PtyW, HOut>(
 ) -> TriggerWiring<PtyW, HOut>
 where
     PtyW: Write,
-    HOut: Write,
+    HOut: Write + Send + 'static,
 {
+    let shared_stdout = SharedWriter::new(host_stdout);
     if armed {
         let input = shared_input_pump();
+        let render_stdout = shared_stdout.clone();
         TriggerWiring {
-            host_to_child: HostToChildWriter::Armed(InputDetector::new(pty_writer, input.clone())),
-            child_to_host: ChildToHostWriter::Armed(OutputArbiter::new(host_stdout, input.clone())),
+            host_to_child: HostToChildWriter::Armed(InputInterceptor::new(
+                pty_writer,
+                input.clone(),
+                move |outcome| render_animation(&render_stdout, outcome),
+            )),
+            child_to_host: ChildToHostWriter::Armed(OutputArbiter::new(
+                shared_stdout,
+                input.clone(),
+            )),
             input: Some(input),
         }
     } else {
         TriggerWiring {
             host_to_child: HostToChildWriter::Passthrough(pty_writer),
-            child_to_host: ChildToHostWriter::Passthrough(host_stdout),
+            child_to_host: ChildToHostWriter::Passthrough(shared_stdout),
             input: None,
         }
     }
@@ -207,6 +326,7 @@ where
 mod tests {
     use super::*;
     use crate::trigger::parser::Outcome;
+    use std::{sync::mpsc, thread, time::Duration};
 
     const ENTER_ALT: &[u8] = b"\x1b[?1049h";
 
@@ -247,6 +367,32 @@ mod tests {
     }
 
     #[test]
+    fn armed_wiring_fires_animation_instead_of_forwarding_trigger_bytes() {
+        let mut wiring = wire_trigger_io(true, Vec::new(), Vec::new());
+
+        wiring.host_to_child.write_all(b":q\n").unwrap();
+
+        let HostToChildWriter::Armed(host) = &wiring.host_to_child else {
+            panic!("armed host path should use the trigger interceptor");
+        };
+        assert_eq!(
+            host.inner().as_slice(),
+            b"",
+            "fired trigger bytes must not reach the child PTY"
+        );
+
+        let ChildToHostWriter::Armed(child) = &wiring.child_to_host else {
+            panic!("armed child path should use the output arbiter");
+        };
+        let rendered = child.inner().lock();
+        let text = String::from_utf8_lossy(rendered.as_slice());
+        assert!(
+            text.contains("Fi-Fo") || text.contains("[QQ]") || text.contains("QUEUE"),
+            "expected renderer output on host stdout, got {text:?}"
+        );
+    }
+
+    #[test]
     fn disarmed_wiring_bypasses_trigger_state_entirely() {
         let mut wiring = wire_trigger_io(false, Vec::new(), Vec::new());
         assert!(matches!(
@@ -273,7 +419,37 @@ mod tests {
         let ChildToHostWriter::Passthrough(child_bytes) = wiring.child_to_host else {
             panic!("disarmed child path should remain a passthrough writer");
         };
-        assert_eq!(child_bytes, ENTER_ALT);
+        assert_eq!(child_bytes.lock().as_slice(), ENTER_ALT);
+    }
+
+    #[test]
+    fn shared_writer_blocks_other_handles_until_lock_is_released() {
+        let shared = SharedWriter::new(Vec::new());
+        let locked = shared.lock();
+        let mut writer = shared.clone();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (done_tx, done_rx) = mpsc::channel();
+
+        let join = thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            writer.write_all(b"child").unwrap();
+            done_tx.send(()).unwrap();
+        });
+
+        started_rx.recv().unwrap();
+        assert!(
+            done_rx.recv_timeout(Duration::from_millis(50)).is_err(),
+            "child output should block while the renderer owns the lock"
+        );
+
+        drop(locked);
+
+        done_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("child output should resume once the lock is released");
+        join.join().unwrap();
+
+        assert_eq!(shared.lock().as_slice(), b"child");
     }
 }
 

--- a/src/trigger/input.rs
+++ b/src/trigger/input.rs
@@ -16,7 +16,7 @@
 //! The type intentionally has no I/O side effects. Phase 3 can
 //! wire it in as detect-only logging while still forwarding bytes
 //! unchanged; later phases can use the same observations to route
-//! matching trigger bytes away from the child.
+//! matching trigger bytes away from the child and fire animation.
 
 use std::io::{self, Write};
 use std::sync::{Arc, Mutex};
@@ -66,6 +66,8 @@ pub fn shared_input_pump() -> SharedInputPump {
     Arc::new(Mutex::new(InputPump::new()))
 }
 
+type TriggerCallback = Box<dyn FnMut(Outcome) -> io::Result<()> + Send>;
+
 /// Host-input [`Write`] adapter for Phase 3 detect-only wiring.
 ///
 /// The adapter preserves the byte stream exactly as accepted by the
@@ -89,8 +91,82 @@ impl<W> InputDetector<W> {
     }
 
     #[cfg(test)]
-    fn inner(&self) -> &W {
+    pub(crate) fn inner(&self) -> &W {
         &self.inner
+    }
+}
+
+/// Host-input [`Write`] adapter that suppresses fired trigger
+/// lines from the child PTY and invokes a render callback.
+///
+/// Only bytes on a line that is still a possible trigger prefix
+/// are held back. As soon as a line becomes impossible to match,
+/// the adapter flushes the buffered prefix and returns to normal
+/// passthrough for the rest of that line.
+pub(crate) struct InputInterceptor<W> {
+    inner: W,
+    input: SharedInputPump,
+    on_trigger: TriggerCallback,
+    holdback: Parser,
+    pending: Vec<u8>,
+    line_dirty: bool,
+    suppress_next_lf: bool,
+    poison_warned: bool,
+}
+
+impl<W> std::fmt::Debug for InputInterceptor<W>
+where
+    W: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InputInterceptor")
+            .field("inner", &self.inner)
+            .field("holdback", &self.holdback)
+            .field("pending", &self.pending)
+            .field("line_dirty", &self.line_dirty)
+            .field("suppress_next_lf", &self.suppress_next_lf)
+            .field("poison_warned", &self.poison_warned)
+            .finish()
+    }
+}
+
+impl<W> InputInterceptor<W> {
+    pub(crate) fn new<R>(inner: W, input: SharedInputPump, on_trigger: R) -> Self
+    where
+        R: FnMut(Outcome) -> io::Result<()> + Send + 'static,
+    {
+        Self {
+            inner,
+            input,
+            on_trigger: Box::new(on_trigger),
+            holdback: Parser::new(),
+            pending: Vec::new(),
+            line_dirty: false,
+            suppress_next_lf: false,
+            poison_warned: false,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn inner(&self) -> &W {
+        &self.inner
+    }
+
+    fn forward_pending(&mut self) -> io::Result<()>
+    where
+        W: Write,
+    {
+        for b in std::mem::take(&mut self.pending) {
+            self.inner.write_all(&[b])?;
+        }
+        Ok(())
+    }
+
+    fn forward_byte(&mut self, b: u8) -> io::Result<()>
+    where
+        W: Write,
+    {
+        self.inner.write_all(&[b])
     }
 }
 
@@ -120,22 +196,81 @@ where
     }
 }
 
-fn observe_detected_input<F>(
-    input: &SharedInputPump,
-    bytes: &[u8],
-    warned: &mut bool,
-    mut on_detect: F,
-) -> io::Result<()>
+impl<W> Write for InputInterceptor<W>
 where
-    F: FnMut(Outcome),
+    W: Write,
 {
-    let mut detected = Vec::new();
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut consumed = 0;
+
+        for &b in buf {
+            if self.suppress_next_lf {
+                self.suppress_next_lf = false;
+                if b == b'\n' {
+                    consumed += 1;
+                    continue;
+                }
+            }
+
+            let observation = observe_input_byte(&self.input, b, &mut self.poison_warned);
+            match observation {
+                InputObservation::Bypassed(_) => {
+                    self.holdback.reset();
+                    self.line_dirty = false;
+                    self.forward_pending()?;
+                    self.forward_byte(b)?;
+                }
+                InputObservation::Parsed(observed) => {
+                    if self.line_dirty {
+                        self.forward_byte(b)?;
+                        if matches!(b, b'\r' | b'\n') {
+                            self.line_dirty = false;
+                            self.holdback.reset();
+                        }
+                        consumed += 1;
+                        continue;
+                    }
+
+                    let held = self.holdback.feed(b);
+                    debug_assert_eq!(
+                        held, observed,
+                        "holdback parser must mirror the shared input pump while armed"
+                    );
+
+                    if held != Outcome::None {
+                        self.pending.clear();
+                        if b == b'\r' {
+                            self.suppress_next_lf = true;
+                        }
+                        (self.on_trigger)(held)?;
+                    } else if matches!(b, b'\r' | b'\n') {
+                        self.forward_pending()?;
+                        self.forward_byte(b)?;
+                    } else if self.holdback.can_still_match() {
+                        self.pending.push(b);
+                    } else {
+                        self.forward_pending()?;
+                        self.forward_byte(b)?;
+                        self.line_dirty = true;
+                    }
+                }
+            }
+
+            consumed += 1;
+        }
+
+        Ok(consumed)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+fn observe_input_byte(input: &SharedInputPump, b: u8, warned: &mut bool) -> InputObservation {
     let mut input = match input.lock() {
         Ok(guard) => guard,
         Err(err) => {
-            // The mutex was poisoned by a panic in another thread.  Recover
-            // the inner value so trigger detection continues; the poisoned
-            // state remains but does not affect correctness of the pump itself.
             if !*warned {
                 tracing::warn!(
                     error = %err,
@@ -146,13 +281,25 @@ where
             err.into_inner()
         }
     };
+    input.feed_input_byte(b)
+}
+
+fn observe_detected_input<F>(
+    input: &SharedInputPump,
+    bytes: &[u8],
+    warned: &mut bool,
+    mut on_detect: F,
+) -> io::Result<()>
+where
+    F: FnMut(Outcome),
+{
+    let mut detected = Vec::new();
     for &b in bytes {
-        let outcome = input.feed_input_byte(b).outcome();
+        let outcome = observe_input_byte(input, b, warned).outcome();
         if outcome != Outcome::None {
             detected.push(outcome);
         }
     }
-    drop(input);
 
     for outcome in detected {
         on_detect(outcome);
@@ -232,6 +379,7 @@ impl InputPump {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Arc, Mutex};
 
     const BEGIN_PASTE: &[u8] = b"\x1b[200~";
     const END_PASTE: &[u8] = b"\x1b[201~";
@@ -472,6 +620,104 @@ mod tests {
             "trigger detection must survive mutex poison recovery"
         );
         assert!(warned, "poison_warned must be set after first recovery");
+    }
+
+    #[test]
+    fn input_interceptor_swallows_trigger_and_fires_callback() {
+        let input = shared_input_pump();
+        let fired = Arc::new(Mutex::new(Vec::new()));
+        let fired_probe = Arc::clone(&fired);
+        let mut interceptor = InputInterceptor::new(Vec::new(), input, move |outcome| {
+            fired_probe.lock().unwrap().push(outcome);
+            Ok(())
+        });
+
+        interceptor.write_all(b":q\n").unwrap();
+
+        assert_eq!(interceptor.inner().as_slice(), b"");
+        assert_eq!(fired.lock().unwrap().as_slice(), [Outcome::Q]);
+    }
+
+    #[test]
+    fn input_interceptor_preserves_cross_write_trigger_state() {
+        let input = shared_input_pump();
+        let fired = Arc::new(Mutex::new(Vec::new()));
+        let fired_probe = Arc::clone(&fired);
+        let mut interceptor = InputInterceptor::new(Vec::new(), input, move |outcome| {
+            fired_probe.lock().unwrap().push(outcome);
+            Ok(())
+        });
+
+        assert_eq!(interceptor.write(b":").unwrap(), 1);
+        assert_eq!(interceptor.write(b"q").unwrap(), 1);
+        assert_eq!(interceptor.write(b"\n").unwrap(), 1);
+
+        assert_eq!(interceptor.inner().as_slice(), b"");
+        assert_eq!(fired.lock().unwrap().as_slice(), [Outcome::Q]);
+    }
+
+    #[test]
+    fn input_interceptor_flushes_nonmatching_lines_to_the_child() {
+        let input = shared_input_pump();
+        let fired = Arc::new(Mutex::new(Vec::new()));
+        let fired_probe = Arc::clone(&fired);
+        let mut interceptor = InputInterceptor::new(Vec::new(), input, move |outcome| {
+            fired_probe.lock().unwrap().push(outcome);
+            Ok(())
+        });
+
+        interceptor.write_all(b":qq\n").unwrap();
+
+        assert_eq!(interceptor.inner().as_slice(), b":qq\n");
+        assert!(fired.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn input_interceptor_swallows_crlf_second_byte_after_fire() {
+        let input = shared_input_pump();
+        let fired = Arc::new(Mutex::new(Vec::new()));
+        let fired_probe = Arc::clone(&fired);
+        let mut interceptor = InputInterceptor::new(Vec::new(), input, move |outcome| {
+            fired_probe.lock().unwrap().push(outcome);
+            Ok(())
+        });
+
+        interceptor.write_all(b":wq\r\n").unwrap();
+
+        assert_eq!(interceptor.inner().as_slice(), b"");
+        assert_eq!(fired.lock().unwrap().as_slice(), [Outcome::Wq]);
+    }
+
+    #[test]
+    fn input_interceptor_flushes_buffered_prefix_when_alt_screen_disarms() {
+        let input = shared_input_pump();
+        let fired = Arc::new(Mutex::new(Vec::new()));
+        let fired_probe = Arc::clone(&fired);
+        let mut interceptor = InputInterceptor::new(Vec::new(), input.clone(), move |outcome| {
+            fired_probe.lock().unwrap().push(outcome);
+            Ok(())
+        });
+
+        assert_eq!(interceptor.write(b":").unwrap(), 1);
+        input.lock().unwrap().feed_child_output_slice(ENTER_ALT);
+        interceptor.write_all(b"q\n").unwrap();
+
+        assert_eq!(interceptor.inner().as_slice(), b":q\n");
+        assert!(fired.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn input_interceptor_releases_input_lock_before_render_callback() {
+        let input = shared_input_pump();
+        let input_for_callback = input.clone();
+        let mut interceptor = InputInterceptor::new(Vec::new(), input, move |_outcome| {
+            let _guard = input_for_callback
+                .try_lock()
+                .expect("render callback must not run while the input mutex is held");
+            Ok(())
+        });
+
+        interceptor.write_all(b":q\n").unwrap();
     }
 
     #[test]

--- a/src/trigger/output.rs
+++ b/src/trigger/output.rs
@@ -54,7 +54,7 @@ impl<W> OutputArbiter<W> {
     }
 
     #[cfg(test)]
-    fn inner(&self) -> &W {
+    pub(crate) fn inner(&self) -> &W {
         &self.inner
     }
 

--- a/src/trigger/parser.rs
+++ b/src/trigger/parser.rs
@@ -155,6 +155,16 @@ impl Parser {
         self.reset_line();
     }
 
+    /// Whether the current line is still a possible trigger
+    /// prefix if more bytes arrive before the terminator.
+    pub(crate) fn can_still_match(&self) -> bool {
+        !self.dirty
+            && matches!(
+                self.buf.as_slice(),
+                b"" | b":" | b":q" | b":q!" | b":w" | b":wq"
+            )
+    }
+
     /// Test/diagnostic helper: feed a slice and return the
     /// sequence of non-`None` outcomes in order.
     pub fn feed_all(&mut self, bytes: &[u8]) -> Vec<Outcome> {


### PR DESCRIPTION
## Summary
- intercept still-matchable quit prefixes on the armed host-input path and suppress fired `:q` / `:wq` / `:q!` lines from the child PTY
- render the matching animation while holding a shared host-stdout lock so child output backs up and drains after the animation instead of interleaving between frames
- add unit coverage for swallowed triggers, CRLF suppression, bypass flush behavior, shared-writer blocking, and the armed wiring seam

## Testing
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test --all-targets --all-features

Closes #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal trigger handling and rendering coordination to ensure trigger sequences are properly intercepted and animation output displays correctly when triggers are armed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/qorrection/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->