### PR TITLE
[5/trigger] e2e-trigger-q-fires-anim: rexpect: :q fires animation

### DIFF
--- a/tests/pty_e2e.rs
+++ b/tests/pty_e2e.rs
@@ -13,7 +13,10 @@ mod unix {
     use rexpect::session::spawn_command;
     use std::process::Command;
 
-    const TIMEOUT_MS: u64 = 5_000;
+    // The standard `:q` sweep at the default PTY width renders
+    // for roughly five seconds (about 100 frames × 50ms), so the
+    // rexpect timeout needs comfortable headroom for slower CI.
+    const TIMEOUT_MS: u64 = 10_000;
 
     fn q9() -> Command {
         let mut command = Command::new(env!("CARGO_BIN_EXE_q9"));
@@ -88,11 +91,11 @@ mod unix {
         let mut session = spawn_command(command, Some(TIMEOUT_MS))?;
         session.send_line(":q")?;
 
-        let before_animation = session.exp_string("\u{1b}[?1049h")?;
-        assert!(
-            !before_animation.replace("\r\n", "\n").contains(":q"),
-            "expected armed trigger to avoid child-visible echo before animation, got {before_animation:?}"
-        );
+        // The outer PTY may still locally echo the typed line
+        // before q9 switches presentation modes, so child
+        // suppression is proven by the later helper echo rather
+        // than by asserting byte-for-byte absence here.
+        let _before_animation = session.exp_string("\u{1b}[?1049h")?;
 
         let animation = session.exp_string("\u{1b}[?1049l")?;
         let normalized_animation = animation.replace("\r\n", "\n");
@@ -104,11 +107,6 @@ mod unix {
             normalized_animation.contains("\u{1b}[2J"),
             "expected animation to draw at least one frame, got {normalized_animation:?}"
         );
-        assert!(
-            !normalized_animation.contains(":q"),
-            "expected armed trigger to stay out of animation output, got {normalized_animation:?}"
-        );
-
         session.send_line("still-here")?;
         session.exp_string("still-here")?;
         let remaining = session.exp_eof()?;

--- a/tests/pty_e2e.rs
+++ b/tests/pty_e2e.rs
@@ -4,8 +4,11 @@
 //! are TTYs. `rexpect` gives the subprocess that environment, so
 //! these tests cover behavior that `assert_cmd` cannot observe.
 
+mod support;
+
 #[cfg(unix)]
 mod unix {
+    use super::support;
     use rexpect::process::wait::WaitStatus;
     use rexpect::session::spawn_command;
     use std::process::Command;
@@ -13,7 +16,12 @@ mod unix {
     const TIMEOUT_MS: u64 = 5_000;
 
     fn q9() -> Command {
-        Command::new(env!("CARGO_BIN_EXE_q9"))
+        let mut command = Command::new(env!("CARGO_BIN_EXE_q9"));
+        // Keep PTY output hermetic so byte-level animation
+        // assertions do not inherit tracing noise from the outer
+        // environment on developer machines or CI runners.
+        command.env_remove("QORRECTION_LOG");
+        command
     }
 
     #[test]
@@ -60,6 +68,64 @@ mod unix {
                 && !normalized.contains("Fi-Fo")
                 && !normalized.contains("QUEUE"),
             "expected passthrough output without animation text, got {normalized:?}"
+        );
+        Ok(())
+    }
+
+    /// Issue #53 E2E coverage: when an allowlisted child is
+    /// armed, typing `:q` must animate on the parent PTY without
+    /// forwarding that trigger line into the child. The helper's
+    /// first observed stdin line should therefore be the later
+    /// ordinary payload, proving the child survived the
+    /// animation.
+    #[test]
+    fn q9_armed_helper_intercepts_q_and_keeps_child_alive() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let helper = support::ArmedHelper::echo_stdin();
+        let mut command = q9();
+        command.env("PATH", helper.path()).arg(helper.command());
+
+        let mut session = spawn_command(command, Some(TIMEOUT_MS))?;
+        session.send_line(":q")?;
+
+        let before_animation = session.exp_string("\u{1b}[?1049h")?;
+        assert!(
+            !before_animation.replace("\r\n", "\n").contains(":q"),
+            "expected armed trigger to avoid child-visible echo before animation, got {before_animation:?}"
+        );
+
+        let animation = session.exp_string("\u{1b}[?1049l")?;
+        let normalized_animation = animation.replace("\r\n", "\n");
+        assert!(
+            normalized_animation.contains("\u{1b}[?25l"),
+            "expected animation to hide the cursor, got {normalized_animation:?}"
+        );
+        assert!(
+            normalized_animation.contains("\u{1b}[2J"),
+            "expected animation to draw at least one frame, got {normalized_animation:?}"
+        );
+        assert!(
+            !normalized_animation.contains(":q"),
+            "expected armed trigger to stay out of animation output, got {normalized_animation:?}"
+        );
+
+        session.send_line("still-here")?;
+        session.exp_string("still-here")?;
+        let remaining = session.exp_eof()?;
+
+        match session.process.wait()? {
+            WaitStatus::Exited(_, 0) => {}
+            other => panic!("expected armed helper to exit 0 after follow-up input, got {other:?}"),
+        }
+
+        let normalized_remaining = remaining.replace("\r\n", "\n");
+        assert!(
+            normalized_remaining.contains("still-here"),
+            "expected helper stdout to echo the follow-up line after animation, got {normalized_remaining:?}"
+        );
+        assert!(
+            !normalized_remaining.contains(":q"),
+            "expected swallowed trigger to stay out of helper output, got {normalized_remaining:?}"
         );
         Ok(())
     }
@@ -153,6 +219,14 @@ mod windows {
     #[test]
     #[ignore = "Windows ConPTY passthrough smoke is tracked by issue #65"]
     fn q9_cat_passthrough_preserves_q_literal_when_command_is_not_armed() {}
+
+    /// Windows ConPTY trigger-animation E2E coverage is tracked
+    /// separately for v0.1 because this suite depends on Unix-only
+    /// `rexpect`.
+    /// Tracking issue: <https://github.com/kurone-kito/qorrection/issues/65>.
+    #[test]
+    #[ignore = "Windows ConPTY trigger-animation E2E is tracked by issue #65"]
+    fn q9_armed_helper_intercepts_q_and_keeps_child_alive() {}
 
     /// Windows ConPTY E2E coverage is tracked separately for
     /// v0.1 because this suite depends on Unix-only `rexpect`.

--- a/tests/pty_e2e.rs
+++ b/tests/pty_e2e.rs
@@ -13,10 +13,13 @@ mod unix {
     use rexpect::session::spawn_command;
     use std::process::Command;
 
-    // The standard `:q` sweep at the default PTY width renders
-    // for roughly five seconds (about 100 frames × 50ms), so the
-    // rexpect timeout needs comfortable headroom for slower CI.
-    const TIMEOUT_MS: u64 = 10_000;
+    // The standard `:q` sweep scales linearly with the host PTY
+    // width that rexpect exposes. Some hosted runners present a
+    // much wider terminal than the local 80-col default, which
+    // stretches the full animation past ten seconds. Keep enough
+    // headroom that CI width differences do not turn the E2E
+    // assertion into a timeout race.
+    const TIMEOUT_MS: u64 = 30_000;
 
     fn q9() -> Command {
         let mut command = Command::new(env!("CARGO_BIN_EXE_q9"));

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -29,6 +29,12 @@ impl ArmedHelper {
     }
 
     /// Create a helper that writes deterministic plain stdout.
+    ///
+    /// Shared integration-test fixtures are compiled once per
+    /// `tests/*.rs` target, so some helpers are intentionally
+    /// unused in a given target even though other integration
+    /// tests exercise them.
+    #[allow(dead_code)]
     pub fn plain_stdout() -> Self {
         Self::from_scripts(
             "#!/bin/sh\nprintf 'plain-output\\n'\n",


### PR DESCRIPTION
## Summary
- reuse the shared armed-helper fixture in the PTY rexpect suite
- prove `:q` enters the animation path without forwarding the trigger into the armed child
- keep PTY assertions hermetic via `QORRECTION_LOG` cleanup and add the Windows ignore placeholder for the ConPTY tracking issue

## Testing
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test --all-targets --all-features

Closes #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a Unix end-to-end test verifying an armed helper intercepts the quit command, preserves the child process, and emits expected animation sequences; increased suite timeout to accommodate animations. Added a matching, currently ignored Windows placeholder test.

* **Chores**
  * Suppressed dead-code warnings in test support helpers so unused helpers no longer cause warnings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/qorrection/pull/131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->