### PR TITLE
[5/trigger] e2e-child-exits-during-animation: E2E: child dies mid-animation

### DIFF
--- a/src/anim/render.rs
+++ b/src/anim/render.rs
@@ -134,6 +134,29 @@ pub(crate) fn render_plan(outcome: Outcome, cols: u16) -> Option<RenderPlan> {
     }
 }
 
+pub(crate) fn render_frame_count(outcome: Outcome, cols: u16) -> Option<usize> {
+    let b = bucket(cols);
+    match outcome {
+        Outcome::None => None,
+        Outcome::Q => Some(match b {
+            WidthBucket::Tiny => 1,
+            WidthBucket::Small => scene::tiny_frame_count(cols),
+            WidthBucket::Medium | WidthBucket::Large => scene::q_frame_count(cols),
+        }),
+        Outcome::Wq => Some(match b {
+            WidthBucket::Tiny => 1,
+            WidthBucket::Small => scene::tiny_frame_count(cols),
+            WidthBucket::Medium => scene::q_frame_count(cols),
+            WidthBucket::Large => scene::wq_frame_count(cols),
+        }),
+        Outcome::QBang => Some(match b {
+            WidthBucket::Tiny => 1,
+            WidthBucket::Small => scene::tiny_bang_frame_count(cols),
+            WidthBucket::Medium | WidthBucket::Large => scene::bang_frame_count(cols),
+        }),
+    }
+}
+
 fn fallback_plan(trigger: fallback::Trigger) -> RenderPlan {
     RenderPlan {
         kind: PlanKind::Fallback,
@@ -187,6 +210,32 @@ mod tests {
     #[test]
     fn render_plan_returns_none_when_no_trigger_fired() {
         assert_eq!(render_plan(Outcome::None, 120), None);
+    }
+
+    #[test]
+    fn render_frame_count_matches_plan_lengths() {
+        for (outcome, cols) in [
+            (Outcome::Q, 39),
+            (Outcome::Q, 40),
+            (Outcome::Q, 80),
+            (Outcome::Q, 120),
+            (Outcome::Wq, 0),
+            (Outcome::Wq, 40),
+            (Outcome::Wq, 119),
+            (Outcome::Wq, 120),
+            (Outcome::QBang, 12),
+            (Outcome::QBang, 40),
+            (Outcome::QBang, 80),
+            (Outcome::QBang, 120),
+        ] {
+            let plan = render_plan(outcome, cols).expect("non-none outcomes must render");
+            let count = render_frame_count(outcome, cols).expect("non-none outcomes must count");
+            assert_eq!(
+                count,
+                plan.frames.len(),
+                "{outcome:?} at {cols} cols counted differently from its plan"
+            );
+        }
     }
 
     #[test]

--- a/src/anim/scene.rs
+++ b/src/anim/scene.rs
@@ -30,6 +30,10 @@ pub fn q(cols: u16) -> Vec<String> {
     sweep(car::STD, cols)
 }
 
+pub(crate) fn q_frame_count(cols: u16) -> usize {
+    sweep_frame_count(car::STD, cols)
+}
+
 /// Build the compact 40-79 column ambulance scene.
 ///
 /// This is the renderer's "small bucket" degrade path: when the
@@ -40,6 +44,10 @@ pub fn tiny(cols: u16) -> Vec<String> {
     sweep(car::TINY, cols)
 }
 
+pub(crate) fn tiny_frame_count(cols: u16) -> usize {
+    sweep_frame_count(car::TINY, cols)
+}
+
 /// Build the larger `:wq` ambulance scene.
 ///
 /// This timeline follows the same sweep / siren policy as [`q`]
@@ -48,6 +56,10 @@ pub fn tiny(cols: u16) -> Vec<String> {
 /// full asset is visible.
 pub fn wq(cols: u16) -> Vec<String> {
     sweep(car::BIG, cols)
+}
+
+pub(crate) fn wq_frame_count(cols: u16) -> usize {
+    sweep_frame_count(car::BIG, cols)
 }
 
 /// Build the `:q!` nine-car parade scene.
@@ -61,6 +73,10 @@ pub fn bang(cols: u16) -> Vec<String> {
     parade(car::STD, cols, BANG_CARS)
 }
 
+pub(crate) fn bang_frame_count(cols: u16) -> usize {
+    parade_frame_count(car::STD, cols, BANG_CARS)
+}
+
 /// Build the small-bucket `:q!` parade.
 ///
 /// The renderer uses this when `40 <= cols < 80`: the trigger keeps
@@ -68,6 +84,10 @@ pub fn bang(cols: u16) -> Vec<String> {
 /// narrow viewport still gets a recognisably animated convoy.
 pub fn tiny_bang(cols: u16) -> Vec<String> {
     parade(car::TINY, cols, BANG_CARS)
+}
+
+pub(crate) fn tiny_bang_frame_count(cols: u16) -> usize {
+    parade_frame_count(car::TINY, cols, BANG_CARS)
 }
 
 /// Sweep one ASCII asset across the visible width using the
@@ -90,6 +110,17 @@ fn sweep(car_asset: &str, cols: u16) -> Vec<String> {
     }
 
     frames
+}
+
+fn sweep_frame_count(car_asset: &str, cols: u16) -> usize {
+    if cols == 0 {
+        return 0;
+    }
+
+    let car_width = car::max_width(car_asset) as i32;
+    let start_x = 1 - car_width;
+    let end_x = i32::from(cols) - 1;
+    (end_x - start_x + 1) as usize
 }
 
 /// Move a multi-car convoy across the visible width.
@@ -117,6 +148,20 @@ fn parade(car_asset: &str, cols: u16, cars: usize) -> Vec<String> {
     }
 
     frames
+}
+
+fn parade_frame_count(car_asset: &str, cols: u16, cars: usize) -> usize {
+    if cols == 0 || cars == 0 {
+        return 0;
+    }
+
+    let car_width = car::max_width(car_asset);
+    let convoy_width = cars * car_width;
+    let car_lines = car::lines(car_asset);
+    let (car_left, car_right) = visible_bounds(&car_lines);
+    let start_x = -(((convoy_width - car_width) + car_right) as i32);
+    let end_x = i32::from(cols) - 1 - car_left as i32;
+    (end_x - start_x + 1) as usize
 }
 
 /// Find the leftmost and rightmost non-space columns in one asset.

--- a/src/pty/pump.rs
+++ b/src/pty/pump.rs
@@ -9,7 +9,11 @@
 //! by PR 4 (#33).
 
 use std::io::{self, Read, Write};
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc, Mutex, MutexGuard,
+};
+use std::time::Duration;
 
 #[cfg(unix)]
 use std::os::fd::RawFd;
@@ -21,11 +25,13 @@ use crate::pty::forward::{
 };
 use crate::pty::spawn::SpawnedSession;
 use crate::trigger::{
-    input::{shared_input_pump, InputInterceptor},
+    input::{shared_input_pump, shared_render_progress, InputInterceptor, SharedRenderProgress},
     output::OutputArbiter,
     parser::Outcome,
 };
 use crate::{Error, Result};
+
+const RENDER_JOIN_SLACK: Duration = Duration::from_millis(250);
 
 /// Owning bundle of the host↔child forwarder threads.
 ///
@@ -35,6 +41,43 @@ use crate::{Error, Result};
 pub(crate) struct IoPump {
     pub(crate) host_to_child: ForwarderHandle,
     pub(crate) child_to_host: ForwarderHandle,
+    pub(crate) host_to_child_render_progress: Option<SharedRenderProgress>,
+}
+
+impl IoPump {
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        ForwarderHandle,
+        ForwarderHandle,
+        Option<SharedRenderProgress>,
+    ) {
+        (
+            self.host_to_child,
+            self.child_to_host,
+            self.host_to_child_render_progress,
+        )
+    }
+
+    pub(crate) fn host_to_child_post_exit_budget(
+        render_progress: Option<&SharedRenderProgress>,
+        base: Duration,
+    ) -> Duration {
+        let Some(render_progress) = render_progress else {
+            return base;
+        };
+        let frames_remaining = render_progress.load(Ordering::SeqCst);
+        if frames_remaining == 0 {
+            return base;
+        }
+
+        let frames_remaining = u32::try_from(frames_remaining).unwrap_or(u32::MAX);
+        let render_budget = FRAME_DELAY
+            .checked_mul(frames_remaining)
+            .unwrap_or(Duration::from_secs(60))
+            + RENDER_JOIN_SLACK;
+        base.max(render_budget)
+    }
 }
 
 enum HostToChildWriter<W> {
@@ -172,7 +215,21 @@ fn render_cols() -> u16 {
     }
 }
 
-fn render_animation<W>(host_stdout: &SharedWriter<W>, outcome: Outcome) -> io::Result<()>
+struct RenderProgressGuard<'a> {
+    frames_remaining: &'a AtomicUsize,
+}
+
+impl Drop for RenderProgressGuard<'_> {
+    fn drop(&mut self) {
+        self.frames_remaining.store(0, Ordering::SeqCst);
+    }
+}
+
+fn render_animation<W>(
+    host_stdout: &SharedWriter<W>,
+    outcome: Outcome,
+    frames_remaining: &AtomicUsize,
+) -> io::Result<()>
 where
     W: Write,
 {
@@ -183,11 +240,14 @@ where
         return Ok(());
     }
 
+    frames_remaining.store(plan.frames.len(), Ordering::SeqCst);
+    let _render_progress = RenderProgressGuard { frames_remaining };
     let mut presentation =
         LockedPresentation::acquire(host_stdout.lock()).map_err(io::Error::other)?;
     for frame in &plan.frames {
         draw_frame(presentation.writer(), frame).map_err(io::Error::other)?;
         std::thread::sleep(FRAME_DELAY);
+        frames_remaining.fetch_sub(1, Ordering::SeqCst);
     }
     Ok(())
 }
@@ -196,6 +256,7 @@ struct TriggerWiring<PtyW, HOut> {
     host_to_child: HostToChildWriter<PtyW>,
     child_to_host: ChildToHostWriter<SharedWriter<HOut>>,
     input: Option<crate::trigger::input::SharedInputPump>,
+    render_progress: Option<SharedRenderProgress>,
 }
 
 fn wire_trigger_io<PtyW, HOut>(
@@ -211,23 +272,29 @@ where
     if armed {
         let input = shared_input_pump();
         let render_stdout = shared_stdout.clone();
+        let render_progress = shared_render_progress();
+        let callback_render_progress = render_progress.clone();
         TriggerWiring {
             host_to_child: HostToChildWriter::Armed(InputInterceptor::new(
                 pty_writer,
                 input.clone(),
-                move |outcome| render_animation(&render_stdout, outcome),
+                move |outcome| {
+                    render_animation(&render_stdout, outcome, callback_render_progress.as_ref())
+                },
             )),
             child_to_host: ChildToHostWriter::Armed(OutputArbiter::new(
                 shared_stdout,
                 input.clone(),
             )),
             input: Some(input),
+            render_progress: Some(render_progress),
         }
     } else {
         TriggerWiring {
             host_to_child: HostToChildWriter::Passthrough(pty_writer),
             child_to_host: ChildToHostWriter::Passthrough(shared_stdout),
             input: None,
+            render_progress: None,
         }
     }
 }
@@ -263,6 +330,7 @@ where
         host_to_child: pty_writer,
         child_to_host: host_stdout,
         input: _input,
+        render_progress,
     } = wire_trigger_io(armed, pty_writer, host_stdout);
 
     let host_to_child = spawn_cancellable_forwarder(
@@ -276,6 +344,7 @@ where
     Ok(IoPump {
         host_to_child,
         child_to_host,
+        host_to_child_render_progress: render_progress,
     })
 }
 

--- a/src/pty/pump.rs
+++ b/src/pty/pump.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 #[cfg(unix)]
 use std::os::fd::RawFd;
 
-use crate::anim::render::{draw_frame, render_plan, FRAME_DELAY};
+use crate::anim::render::{draw_frame, render_frame_count, render_plan, FRAME_DELAY};
 use crate::pty::forward::{
     spawn_cancellable_forwarder, spawn_forwarder, CancelHandle, CancellableReader, Direction,
     ForwarderHandle,
@@ -244,15 +244,31 @@ fn render_animation<W>(
 where
     W: Write,
 {
-    let Some(plan) = render_plan(outcome, render_cols()) else {
+    let cols = render_cols();
+    let Some(frame_count) = render_frame_count(outcome, cols) else {
+        return Ok(());
+    };
+    if frame_count == 0 {
+        return Ok(());
+    }
+
+    // Reserve one final progress unit for the terminal-guard
+    // drop so the supervisor keeps waiting until the primary
+    // screen and cursor are restored.
+    frames_remaining.store(frame_count.saturating_add(1), Ordering::SeqCst);
+    let _render_progress = RenderProgressGuard { frames_remaining };
+
+    let Some(plan) = render_plan(outcome, cols) else {
         return Ok(());
     };
     if plan.frames.is_empty() {
         return Ok(());
     }
-
-    frames_remaining.store(plan.frames.len(), Ordering::SeqCst);
-    let _render_progress = RenderProgressGuard { frames_remaining };
+    debug_assert_eq!(
+        plan.frames.len(),
+        frame_count,
+        "render frame count drifted from the actual plan"
+    );
     let mut presentation =
         LockedPresentation::acquire(host_stdout.lock()).map_err(io::Error::other)?;
     for frame in &plan.frames {

--- a/src/pty/pump.rs
+++ b/src/pty/pump.rs
@@ -31,7 +31,11 @@ use crate::trigger::{
 };
 use crate::{Error, Result};
 
-const RENDER_JOIN_SLACK: Duration = Duration::from_millis(250);
+// Hosted macOS runners spend noticeably longer than the nominal
+// 50 ms/frame on flush + scheduling overhead, so the post-exit
+// join budget needs extra slack to let an in-flight animation
+// restore the primary screen before the process tears down.
+const RENDER_JOIN_SLACK: Duration = Duration::from_secs(2);
 
 /// Owning bundle of the host↔child forwarder threads.
 ///

--- a/src/pty/pump.rs
+++ b/src/pty/pump.rs
@@ -31,10 +31,15 @@ use crate::trigger::{
 };
 use crate::{Error, Result};
 
-// Hosted macOS runners spend noticeably longer than the nominal
-// 50 ms/frame on flush + scheduling overhead, so the post-exit
-// join budget needs extra slack to let an in-flight animation
-// restore the primary screen before the process tears down.
+// Hosted macOS runners can spend roughly one extra 50 ms tick
+// per frame on draw/flush scheduling beyond the nominal hold
+// delay, so budget each remaining frame as "draw + hold" rather
+// than "hold only" when the supervisor waits for an in-flight
+// animation to restore the primary screen.
+const RENDER_FRAME_BUDGET_MULTIPLIER: u32 = 2;
+// Even after the last frame draw returns, give the renderer a
+// little extra wall-clock slack to run the terminal-guard drop
+// and flush the leave-alt-screen sequence on contended CI hosts.
 const RENDER_JOIN_SLACK: Duration = Duration::from_secs(2);
 
 /// Owning bundle of the host↔child forwarder threads.
@@ -75,9 +80,11 @@ impl IoPump {
             return base;
         }
 
-        let frames_remaining = u32::try_from(frames_remaining).unwrap_or(u32::MAX);
+        let frame_budget_units =
+            frames_remaining.saturating_mul(RENDER_FRAME_BUDGET_MULTIPLIER as usize);
+        let frame_budget_units = u32::try_from(frame_budget_units).unwrap_or(u32::MAX);
         let render_budget = FRAME_DELAY
-            .checked_mul(frames_remaining)
+            .checked_mul(frame_budget_units)
             .unwrap_or(Duration::from_secs(60))
             + RENDER_JOIN_SLACK;
         base.max(render_budget)
@@ -493,6 +500,21 @@ mod tests {
             panic!("disarmed child path should remain a passthrough writer");
         };
         assert_eq!(child_bytes.lock().as_slice(), ENTER_ALT);
+    }
+
+    #[test]
+    fn render_progress_budget_uses_frame_overhead_from_zero_base() {
+        let progress = Arc::new(AtomicUsize::new(3));
+
+        let budget = IoPump::host_to_child_post_exit_budget(Some(&progress), Duration::ZERO);
+
+        assert_eq!(
+            budget,
+            FRAME_DELAY
+                .checked_mul(3 * RENDER_FRAME_BUDGET_MULTIPLIER)
+                .expect("small test multiplier should fit")
+                + RENDER_JOIN_SLACK
+        );
     }
 
     #[test]

--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -228,8 +228,9 @@ where
 {
     let mut guard = KillOnDropGuard::armed(child.clone_killer());
 
-    let mut h2c = Some(pump.host_to_child);
-    let mut c2h = Some(pump.child_to_host);
+    let (host_to_child, child_to_host, host_to_child_render_progress) = pump.into_parts();
+    let mut h2c = Some(host_to_child);
+    let mut c2h = Some(child_to_host);
     let mut h2c_result: Option<io::Result<ForwarderExit>> = None;
     let mut c2h_result: Option<io::Result<ForwarderExit>> = None;
 
@@ -353,7 +354,10 @@ where
     if let Some(h) = h2c.take() {
         h.cancel();
         let budget = if h.cancel_wakes_read() {
-            deadlines.host_to_child_post_exit_budget
+            IoPump::host_to_child_post_exit_budget(
+                host_to_child_render_progress.as_ref(),
+                deadlines.host_to_child_post_exit_budget,
+            )
         } else {
             Duration::ZERO
         };
@@ -603,6 +607,7 @@ mod tests {
         IoPump {
             host_to_child,
             child_to_host,
+            host_to_child_render_progress: None,
         }
     }
 
@@ -633,6 +638,7 @@ mod tests {
         IoPump {
             host_to_child,
             child_to_host,
+            host_to_child_render_progress: None,
         }
     }
 
@@ -697,6 +703,7 @@ mod tests {
             IoPump {
                 host_to_child,
                 child_to_host,
+                host_to_child_render_progress: None,
             },
             exited,
         )
@@ -736,6 +743,7 @@ mod tests {
         IoPump {
             host_to_child,
             child_to_host,
+            host_to_child_render_progress: None,
         }
     }
 
@@ -958,6 +966,7 @@ mod tests {
         let pump = IoPump {
             host_to_child: h2c,
             child_to_host: c2h,
+            host_to_child_render_progress: None,
         };
 
         // Child takes many polls so the forwarder error

--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -52,15 +52,16 @@
 //!   parent process termination clean it up.
 //! - [`Deadlines::host_to_child_post_exit_budget`] is a short
 //!   bounded join window for the cancelled `HostToChild`
-//!   direction, but only when cancellation is known to wake the
-//!   blocked read (the unix pollable stdin path, or a test seam
-//!   that models the same behavior). Once cancellation is
-//!   signalled there is no useful user input left to deliver, so
-//!   the budget only needs to be long enough for the poll loop to
-//!   observe the cancel bit and exit cleanly instead of
-//!   detaching immediately. Non-wakeable readers retain the old
-//!   zero-budget detach path to avoid reintroducing a post-exit
-//!   delay or warning.
+//!   direction when cancellation is known to wake the blocked
+//!   read (the unix pollable stdin path, or a test seam that
+//!   models the same behavior). Once cancellation is signalled
+//!   there is no useful user input left to deliver, so the budget
+//!   only needs to be long enough for the poll loop to observe
+//!   the cancel bit and exit cleanly instead of detaching
+//!   immediately. Non-wakeable readers still detach with a zero
+//!   base budget once no trigger animation is in flight, but an
+//!   in-progress render now extends the join window long enough
+//!   to restore the primary screen before teardown.
 
 use std::io;
 use std::process::ExitCode;
@@ -99,7 +100,9 @@ pub(crate) struct Deadlines {
     /// has exited the host->child forwarder has no useful work
     /// left, so the budget only needs to cover one or two poll
     /// intervals of the wakeable cancel loop. Non-wakeable
-    /// readers still detach with a zero budget.
+    /// readers still use a zero base budget unless the shared
+    /// render-progress counter says the forwarder is finishing an
+    /// in-flight trigger animation.
     pub host_to_child_post_exit_budget: Duration,
     /// Sleep between successive `try_wait` ticks. Keeps the
     /// supervisor from busy-looping; small enough that signal
@@ -353,14 +356,15 @@ where
     // Phase 2: drain remaining forwarders within budget.
     if let Some(h) = h2c.take() {
         h.cancel();
-        let budget = if h.cancel_wakes_read() {
-            IoPump::host_to_child_post_exit_budget(
-                host_to_child_render_progress.as_ref(),
-                deadlines.host_to_child_post_exit_budget,
-            )
+        let base_budget = if h.cancel_wakes_read() {
+            deadlines.host_to_child_post_exit_budget
         } else {
             Duration::ZERO
         };
+        let budget = IoPump::host_to_child_post_exit_budget(
+            host_to_child_render_progress.as_ref(),
+            base_budget,
+        );
         h2c_result = Some(join_with_budget(h, budget));
     }
     if let Some(h) = c2h.take() {
@@ -816,9 +820,9 @@ mod tests {
 
     /// Regression for the accepted E-phase review on PR #125:
     /// non-wakeable host stdin must retain the old zero-budget
-    /// detach path so non-Unix production builds do not wait the
-    /// short pollable-join budget and emit a spurious timeout
-    /// warning.
+    /// detach path when no render is in flight so non-Unix
+    /// production builds do not wait the short pollable-join
+    /// budget and emit a spurious timeout warning.
     #[test]
     fn production_deadlines_keep_zero_budget_for_nonwakeable_host_to_child() {
         let mut deadlines = Deadlines::production();
@@ -835,6 +839,97 @@ mod tests {
         assert!(
             elapsed < Duration::from_millis(100),
             "non-wakeable HostToChild should detach immediately: {elapsed:?}"
+        );
+    }
+
+    /// Regression for PR #134 / issue #57: a non-wakeable
+    /// HostToChild reader may already be inside `read()` while
+    /// also presenting a trigger animation. Even though
+    /// cancellation cannot wake that read, the supervisor still
+    /// needs to honor the render-progress budget long enough for
+    /// the in-flight animation to restore the primary screen
+    /// before returning.
+    #[test]
+    fn production_deadlines_wait_for_inflight_nonwakeable_render() {
+        struct DelayedReader {
+            delay: Duration,
+            started: Arc<AtomicBool>,
+            exited: Arc<AtomicBool>,
+        }
+        impl io::Read for DelayedReader {
+            fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+                self.started.store(true, Ordering::SeqCst);
+                std::thread::sleep(self.delay);
+                self.exited.store(true, Ordering::SeqCst);
+                Ok(0)
+            }
+        }
+        struct DiscardWriter;
+        impl io::Write for DiscardWriter {
+            fn write(&mut self, b: &[u8]) -> io::Result<usize> {
+                Ok(b.len())
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let mut deadlines = Deadlines::production();
+        deadlines.child_wait_deadline = Some(Duration::from_secs(2));
+        deadlines.wait_poll = Duration::from_millis(2);
+
+        let host_cancel = CancelHandle::new();
+        let started = Arc::new(AtomicBool::new(false));
+        let exited = Arc::new(AtomicBool::new(false));
+        let host_to_child = spawn_cancellable_forwarder(
+            Direction::HostToChild,
+            CancellableReader::new(
+                DelayedReader {
+                    delay: Duration::from_millis(100),
+                    started: Arc::clone(&started),
+                    exited: Arc::clone(&exited),
+                },
+                host_cancel,
+            ),
+            DiscardWriter,
+            false,
+        );
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !started.load(Ordering::SeqCst) && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            started.load(Ordering::SeqCst),
+            "host->child forwarder did not enter read() within the wait budget"
+        );
+
+        let c2h_in: Cursor<Vec<u8>> = Cursor::new(Vec::new());
+        let c2h_out: Vec<u8> = Vec::new();
+        let child_to_host = spawn_forwarder(Direction::ChildToHost, c2h_in, c2h_out);
+        let pump = IoPump {
+            host_to_child,
+            child_to_host,
+            host_to_child_render_progress: Some(Arc::new(AtomicUsize::new(1))),
+        };
+
+        let child = MockChild::new(ExitStatus::with_exit_code(0), 0);
+        let start = Instant::now();
+        let code = run_pump_session_with(child, pump, deadlines)
+            .expect("clean exit with in-flight non-wakeable render must still be Ok");
+        let elapsed = start.elapsed();
+
+        assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::SUCCESS));
+        assert!(
+            exited.load(Ordering::SeqCst),
+            "supervisor should wait for the in-flight non-wakeable render to finish"
+        );
+        assert!(
+            elapsed >= Duration::from_millis(80),
+            "supervisor detached before the in-flight render finished: {elapsed:?}"
+        );
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "supervisor should wait only for the in-flight render, not the full budget: {elapsed:?}"
         );
     }
 

--- a/src/trigger/input.rs
+++ b/src/trigger/input.rs
@@ -19,7 +19,7 @@
 //! matching trigger bytes away from the child and fire animation.
 
 use std::io::{self, Write};
-use std::sync::{Arc, Mutex};
+use std::sync::{atomic::AtomicUsize, Arc, Mutex};
 
 use super::{
     altscreen::AltScreenTracker,
@@ -62,8 +62,16 @@ impl InputObservation {
 /// pump halves.
 pub type SharedInputPump = Arc<Mutex<InputPump>>;
 
+/// Shared countdown of animation frames still in flight on the
+/// host->child path.
+pub(crate) type SharedRenderProgress = Arc<AtomicUsize>;
+
 pub fn shared_input_pump() -> SharedInputPump {
     Arc::new(Mutex::new(InputPump::new()))
+}
+
+pub(crate) fn shared_render_progress() -> SharedRenderProgress {
+    Arc::new(AtomicUsize::new(0))
 }
 
 type TriggerCallback = Box<dyn FnMut(Outcome) -> io::Result<()> + Send>;

--- a/tests/pty_e2e.rs
+++ b/tests/pty_e2e.rs
@@ -23,6 +23,7 @@ mod unix {
     const LARGE_WQ_COLS: u16 = 120;
     const BANG_CARS: usize = 9;
     const PARADE_MIN_VISIBLE_LABELS: usize = 3;
+    const LONG_ANIMATION_COLS: u16 = 120;
     const PTY_ROWS: u16 = 24;
 
     fn q9() -> Command {
@@ -287,6 +288,42 @@ mod unix {
         Ok(())
     }
 
+    /// Issue #57 E2E coverage: an armed child may exit while the
+    /// parent is still animating `:q`, and q9 must still leave
+    /// the alt screen, avoid hanging, and propagate the child's
+    /// eventual non-zero exit status.
+    #[test]
+    fn q9_armed_child_exit_during_animation_exits_nonzero_without_hanging(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let helper = support::ArmedHelper::ready_then_exit_seven();
+        let mut command = q9_with_tty_size(LONG_ANIMATION_COLS, PTY_ROWS);
+        command.env("PATH", helper.path()).arg(helper.command());
+
+        let mut session = spawn_command(command, Some(TIMEOUT_MS))?;
+        assert_eq!(session.read_line()?, "READY");
+        session.send_line(":q")?;
+
+        let _before_animation = session.exp_string("\u{1b}[?1049h")?;
+        let animation = session.exp_string("\u{1b}[?1049l")?;
+        let normalized_animation = animation.replace("\r\n", "\n");
+        assert!(
+            normalized_animation.contains("\u{1b}[?25l"),
+            "expected animation to hide the cursor, got {normalized_animation:?}"
+        );
+        assert!(
+            normalized_animation.contains("\u{1b}[2J"),
+            "expected animation to draw at least one frame, got {normalized_animation:?}"
+        );
+
+        let _remaining = session.exp_eof()?;
+        match session.process.wait()? {
+            WaitStatus::Exited(_, 7) => Ok(()),
+            other => {
+                panic!("expected armed helper exit 7 to propagate after animation, got {other:?}")
+            }
+        }
+    }
+
     #[test]
     fn q9_cat_typed_ctrl_c_reaches_child_and_exits_130() -> Result<(), Box<dyn std::error::Error>> {
         let mut command = q9();
@@ -400,6 +437,14 @@ mod windows {
     #[test]
     #[ignore = "Windows ConPTY trigger-animation E2E is tracked by issue #65"]
     fn q9_armed_helper_q_bang_shows_nine_car_parade() {}
+
+    /// Windows ConPTY trigger-animation E2E for a child exiting
+    /// mid-animation is tracked separately for v0.1 because
+    /// this suite depends on Unix-only `rexpect`.
+    /// Tracking issue: <https://github.com/kurone-kito/qorrection/issues/65>.
+    #[test]
+    #[ignore = "Windows ConPTY trigger-animation E2E is tracked by issue #65"]
+    fn q9_armed_child_exit_during_animation_exits_nonzero_without_hanging() {}
 
     /// Windows ConPTY E2E coverage is tracked separately for
     /// v0.1 because this suite depends on Unix-only `rexpect`.

--- a/tests/pty_e2e.rs
+++ b/tests/pty_e2e.rs
@@ -296,14 +296,26 @@ mod unix {
     fn q9_armed_child_exit_during_animation_exits_nonzero_without_hanging(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let helper = support::ArmedHelper::ready_then_exit_seven();
+        let release_dir = tempfile::tempdir()?;
+        let release_file = release_dir.path().join("release");
         let mut command = q9_with_tty_size(LONG_ANIMATION_COLS, PTY_ROWS);
-        command.env("PATH", helper.path()).arg(helper.command());
+        command
+            .env("PATH", helper.path())
+            .env(
+                support::READY_THEN_EXIT_RELEASE_FILE_ENV,
+                release_file.as_os_str(),
+            )
+            .arg(helper.command());
 
         let mut session = spawn_command(command, Some(TIMEOUT_MS))?;
         assert_eq!(session.read_line()?, "READY");
         session.send_line(":q")?;
 
         let _before_animation = session.exp_string("\u{1b}[?1049h")?;
+        // Release the helper only after q9 has entered the alt
+        // screen so the child exit deterministically lands during
+        // the live animation instead of racing the test driver.
+        std::fs::write(&release_file, b"release")?;
         let animation = session.exp_string("\u{1b}[?1049l")?;
         let normalized_animation = animation.replace("\r\n", "\n");
         assert!(

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -42,6 +42,20 @@ impl ArmedHelper {
         )
     }
 
+    /// Create a helper that announces readiness, then exits 7
+    /// after a short delay.
+    ///
+    /// The delay lets trigger-animation tests prove that q9
+    /// recovers cleanly even when the child dies mid-render
+    /// rather than before the trigger is fired.
+    #[allow(dead_code)]
+    pub fn ready_then_exit_seven() -> Self {
+        Self::from_scripts(
+            "#!/bin/sh\nprintf 'READY\\n'\nsleep 1\nexit 7\n",
+            "@echo off\r\necho READY\r\npowershell -NoProfile -Command \"Start-Sleep -Seconds 1; exit 7\"\r\nexit /b %ERRORLEVEL%\r\n",
+        )
+    }
+
     /// Command name to pass to `q9`.
     pub fn command(&self) -> &OsStr {
         &self.command

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -3,6 +3,9 @@
 use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
 
+#[allow(dead_code)]
+pub const READY_THEN_EXIT_RELEASE_FILE_ENV: &str = "QORRECTION_HELPER_RELEASE_FILE";
+
 /// Tempdir-backed helper named like an armed AI CLI.
 ///
 /// The helper lives at the front of a synthetic PATH so tests
@@ -43,16 +46,18 @@ impl ArmedHelper {
     }
 
     /// Create a helper that announces readiness, then exits 7
-    /// after a short delay.
+    /// after the driving test releases it through a file path in
+    /// [`READY_THEN_EXIT_RELEASE_FILE_ENV`].
     ///
-    /// The delay lets trigger-animation tests prove that q9
-    /// recovers cleanly even when the child dies mid-render
-    /// rather than before the trigger is fired.
+    /// The out-of-band release file makes the mid-animation exit
+    /// deterministic relative to the parent PTY entering the
+    /// alternate screen, avoiding short wall-clock races on
+    /// loaded CI hosts.
     #[allow(dead_code)]
     pub fn ready_then_exit_seven() -> Self {
         Self::from_scripts(
-            "#!/bin/sh\nprintf 'READY\\n'\nsleep 1\nexit 7\n",
-            "@echo off\r\necho READY\r\npowershell -NoProfile -Command \"Start-Sleep -Seconds 1; exit 7\"\r\nexit /b %ERRORLEVEL%\r\n",
+            "#!/bin/sh\nprintf 'READY\\n'\nrelease_file=${QORRECTION_HELPER_RELEASE_FILE:?}\nwhile [ ! -f \"$release_file\" ]; do\n  sleep 0.05\ndone\nexit 7\n",
+            "@echo off\r\necho READY\r\npowershell -NoProfile -Command \"$path=$env:QORRECTION_HELPER_RELEASE_FILE; if (-not $path) { exit 7 }; while (-not (Test-Path -LiteralPath $path)) { Start-Sleep -Milliseconds 50 }; exit 7\"\r\nexit /b %ERRORLEVEL%\r\n",
         )
     }
 


### PR DESCRIPTION
## Summary
- add a helper-backed PTY E2E that proves `:q` still restores the primary screen when the armed child exits 7 mid-animation
- keep the host->child forwarder join alive for the remaining animation frames so in-flight renders can leave the alt screen cleanly after child exit
- cover the new Unix path plus the Windows tracking placeholder

## Validation
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test --all-targets --all-features

Closes #57


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Animation progress tracking so the system waits for in-flight frames before closing the animation path.

* **Bug Fixes**
  * Supervisor now extends join/drain windows to avoid premature cancellation or hangs when a child exits during active rendering.

* **Tests**
  * Added end-to-end tests for child-exit-mid-animation, widened-animation timing scenario, and a test helper that signals readiness then exits with status 7.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/qorrection/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->