### PR TITLE
[6/signals] sigwinch-forward-unix: Forward SIGWINCH to child PTY

### DIFF
--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -236,6 +236,38 @@ impl Drop for KillOnDropGuard {
 /// [`run_pump_session_with`].
 pub(crate) fn run_pump_session(session: SpawnedSession, pump: IoPump) -> Result<ExitCode> {
     let SpawnedSession { child, master } = session;
+    #[cfg(unix)]
+    {
+        run_pump_session_unix(child, master, pump)
+    }
+    #[cfg(not(unix))]
+    {
+        let child = PtyChild { child };
+        let _master = master;
+        run_pump_session_with(child, pump, Deadlines::production())
+    }
+}
+
+#[cfg(unix)]
+fn run_pump_session_unix(
+    child: Box<dyn portable_pty::Child + Send + Sync>,
+    master: Box<dyn MasterPty + Send>,
+    pump: IoPump,
+) -> Result<ExitCode> {
+    run_pump_session_unix_with_setup(child, master, pump, SignalGuard::install_resize_only)
+}
+
+#[cfg(unix)]
+fn run_pump_session_unix_with_setup<Setup>(
+    child: Box<dyn portable_pty::Child + Send + Sync>,
+    master: Box<dyn MasterPty + Send>,
+    pump: IoPump,
+    setup: Setup,
+) -> Result<ExitCode>
+where
+    Setup: FnOnce() -> Result<SignalGuard>,
+{
+    let mut kill_guard = KillOnDropGuard::armed(child.clone_killer());
     let child = PtyChild { child };
     // Bind the master to a named local so it stays alive for
     // the entire supervised session. A wildcard (`master: _`)
@@ -244,23 +276,16 @@ pub(crate) fn run_pump_session(session: SpawnedSession, pump: IoPump) -> Result<
     // forwarder threads. The named binding extends its lifetime
     // to the end of the function, so the master is dropped only
     // after the supervisor returns.
-    #[cfg(unix)]
-    {
-        let signal_guard = SignalGuard::install_resize_only()?;
-        run_pump_session_with_signals(
-            child,
-            master.as_ref(),
-            &signal_guard,
-            size::current_size,
-            pump,
-            Deadlines::production(),
-        )
-    }
-    #[cfg(not(unix))]
-    {
-        let _master = master;
-        run_pump_session_with(child, pump, Deadlines::production())
-    }
+    let signal_guard = setup()?;
+    kill_guard.disarm();
+    run_pump_session_with_signals(
+        child,
+        master.as_ref(),
+        &signal_guard,
+        size::current_size,
+        pump,
+        Deadlines::production(),
+    )
 }
 
 /// Lifecycle core, parameterised over the [`SupervisedChild`]
@@ -628,6 +653,7 @@ mod tests {
         state: Arc<Mutex<MockState>>,
     }
 
+    #[derive(Debug)]
     struct MockState {
         polls_remaining: usize,
         scheduled: ExitStatus,
@@ -1250,6 +1276,86 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[derive(Debug)]
+    struct PortableMockChild {
+        state: Arc<Mutex<MockState>>,
+    }
+
+    #[cfg(unix)]
+    impl portable_pty::ChildKiller for PortableMockChild {
+        fn kill(&mut self) -> io::Result<()> {
+            let mut s = self.state.lock().unwrap();
+            s.kills += 1;
+            s.scheduled = ExitStatus::with_signal("Signal 15");
+            s.polls_remaining = 0;
+            Ok(())
+        }
+
+        fn clone_killer(&self) -> Box<dyn ChildKiller + Send + Sync> {
+            Box::new(MockKiller {
+                state: Arc::clone(&self.state),
+            })
+        }
+    }
+
+    #[cfg(unix)]
+    impl portable_pty::Child for PortableMockChild {
+        fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
+            let mut s = self.state.lock().unwrap();
+            s.try_waits += 1;
+            if s.polls_remaining == 0 {
+                Ok(Some(s.scheduled.clone()))
+            } else {
+                s.polls_remaining -= 1;
+                Ok(None)
+            }
+        }
+
+        fn wait(&mut self) -> io::Result<ExitStatus> {
+            Ok(self.state.lock().unwrap().scheduled.clone())
+        }
+
+        fn process_id(&self) -> Option<u32> {
+            None
+        }
+    }
+
+    #[cfg(unix)]
+    #[derive(Debug)]
+    struct DummyMaster;
+
+    #[cfg(unix)]
+    impl MasterPty for DummyMaster {
+        fn resize(&self, _size: PtySize) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn get_size(&self) -> anyhow::Result<PtySize> {
+            Ok(pty_size(80, 24))
+        }
+
+        fn try_clone_reader(&self) -> anyhow::Result<Box<dyn io::Read + Send>> {
+            Ok(Box::new(Cursor::new(Vec::<u8>::new())))
+        }
+
+        fn take_writer(&self) -> anyhow::Result<Box<dyn io::Write + Send>> {
+            Ok(Box::new(Vec::<u8>::new()))
+        }
+
+        fn process_group_leader(&self) -> Option<libc::pid_t> {
+            None
+        }
+
+        fn as_raw_fd(&self) -> Option<std::os::fd::RawFd> {
+            None
+        }
+
+        fn tty_name(&self) -> Option<std::path::PathBuf> {
+            None
+        }
+    }
+
+    #[cfg(unix)]
     #[derive(Default)]
     struct MockSignalSource {
         batches: RefCell<VecDeque<Vec<SignalEvent>>>,
@@ -1403,6 +1509,37 @@ mod tests {
         assert!(
             handle.lock().unwrap().kills >= 1,
             "resize failure must kill the child on unwind"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn signal_setup_failure_kills_child_before_supervisor_handoff() {
+        let state = Arc::new(Mutex::new(MockState {
+            polls_remaining: 0,
+            scheduled: ExitStatus::with_exit_code(0),
+            kills: 0,
+            try_waits: 0,
+        }));
+
+        let err = run_pump_session_unix_with_setup(
+            Box::new(PortableMockChild {
+                state: Arc::clone(&state),
+            }),
+            Box::new(DummyMaster),
+            quiet_pump(),
+            || Err(io::Error::new(io::ErrorKind::AlreadyExists, "synthetic setup failure").into()),
+        )
+        .expect_err("setup failure must surface");
+
+        assert!(
+            matches!(&err, Error::Terminal(io_err) if io_err.kind() == io::ErrorKind::AlreadyExists),
+            "expected Terminal(AlreadyExists), got {err:?}"
+        );
+        assert_eq!(
+            state.lock().unwrap().kills,
+            1,
+            "outer setup guard must kill the child on setup failure"
         );
     }
 }

--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -1336,6 +1336,7 @@ mod tests {
         ]]);
         let resizer = MockResizer::default();
         let mut query_calls = 0usize;
+        let (pump, _exited) = cancellable_h2c_quiet_c2h_pump();
 
         let code = run_pump_session_with_signals(
             child,
@@ -1345,7 +1346,7 @@ mod tests {
                 query_calls += 1;
                 Some(pty_size(132, 44))
             },
-            quiet_pump(),
+            pump,
             fast_deadlines(),
         )
         .expect("clean exit with resize must be Ok");
@@ -1361,13 +1362,14 @@ mod tests {
         let child = MockChild::new(ExitStatus::with_exit_code(0), 1);
         let signals = MockSignalSource::new([vec![SignalEvent::Resize]]);
         let resizer = MockResizer::default();
+        let (pump, _exited) = cancellable_h2c_quiet_c2h_pump();
 
         let code = run_pump_session_with_signals(
             child,
             &resizer,
             &signals,
             || None,
-            quiet_pump(),
+            pump,
             fast_deadlines(),
         )
         .expect("clean exit with skipped resize must be Ok");

--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -68,11 +68,17 @@ use std::process::ExitCode;
 use std::time::{Duration, Instant};
 
 use portable_pty::{ChildKiller, ExitStatus};
+#[cfg(unix)]
+use portable_pty::{MasterPty, PtySize};
 
 use crate::pty::exit::map_exit_status;
 use crate::pty::forward::{Direction, ForwarderExit, ForwarderHandle};
 use crate::pty::pump::IoPump;
+#[cfg(unix)]
+use crate::pty::size;
 use crate::pty::spawn::SpawnedSession;
+#[cfg(unix)]
+use crate::signals::{Event as SignalEvent, SignalGuard};
 use crate::{Error, Result};
 
 /// Polling and join time budgets the supervisor honors.
@@ -165,6 +171,33 @@ impl SupervisedChild for PtyChild {
     }
 }
 
+#[cfg(unix)]
+trait ResizeTarget {
+    fn resize_pty(&self, size: PtySize) -> anyhow::Result<()>;
+}
+
+#[cfg(unix)]
+impl<T> ResizeTarget for T
+where
+    T: MasterPty + ?Sized,
+{
+    fn resize_pty(&self, size: PtySize) -> anyhow::Result<()> {
+        self.resize(size)
+    }
+}
+
+#[cfg(unix)]
+trait SignalSource {
+    fn drain_events(&self) -> io::Result<Vec<SignalEvent>>;
+}
+
+#[cfg(unix)]
+impl SignalSource for SignalGuard {
+    fn drain_events(&self) -> io::Result<Vec<SignalEvent>> {
+        self.drain()
+    }
+}
+
 /// RAII guard that best-effort `kill()`s the child unless
 /// disarmed. Documented invariant: armed until a successful
 /// wait returns and consumes a status. See module-level docs.
@@ -202,32 +235,79 @@ impl Drop for KillOnDropGuard {
 /// [`IoPump`] into the trait-seam form and delegates to
 /// [`run_pump_session_with`].
 pub(crate) fn run_pump_session(session: SpawnedSession, pump: IoPump) -> Result<ExitCode> {
+    let SpawnedSession { child, master } = session;
+    let child = PtyChild { child };
     // Bind the master to a named local so it stays alive for
     // the entire supervised session. A wildcard (`master: _`)
     // pattern would drop it immediately at the destructuring
     // point, EOF'ing the slave side and racing the child / the
     // forwarder threads. The named binding extends its lifetime
     // to the end of the function, so the master is dropped only
-    // after `run_pump_session_with` returns.
-    let SpawnedSession {
-        child,
-        master: _master,
-    } = session;
-    let child = PtyChild { child };
-    run_pump_session_with(child, pump, Deadlines::production())
+    // after the supervisor returns.
+    #[cfg(unix)]
+    {
+        let signal_guard = SignalGuard::install_resize_only()?;
+        run_pump_session_with_signals(
+            child,
+            master.as_ref(),
+            &signal_guard,
+            size::current_size,
+            pump,
+            Deadlines::production(),
+        )
+    }
+    #[cfg(not(unix))]
+    {
+        let _master = master;
+        run_pump_session_with(child, pump, Deadlines::production())
+    }
 }
 
 /// Lifecycle core, parameterised over the [`SupervisedChild`]
 /// implementation and the time [`Deadlines`]. Exists so unit
 /// tests can drive every branch of the state machine without a
 /// real PTY.
+#[cfg_attr(unix, allow(dead_code))]
 pub(crate) fn run_pump_session_with<C>(
-    mut child: C,
+    child: C,
     pump: IoPump,
     deadlines: Deadlines,
 ) -> Result<ExitCode>
 where
     C: SupervisedChild,
+{
+    run_pump_session_inner(child, pump, deadlines, || Ok(()))
+}
+
+#[cfg(unix)]
+fn run_pump_session_with_signals<C, R, S, Q>(
+    child: C,
+    resizer: &R,
+    signals: &S,
+    mut query_size: Q,
+    pump: IoPump,
+    deadlines: Deadlines,
+) -> Result<ExitCode>
+where
+    C: SupervisedChild,
+    R: ResizeTarget + ?Sized,
+    S: SignalSource + ?Sized,
+    Q: FnMut() -> Option<PtySize>,
+{
+    run_pump_session_inner(child, pump, deadlines, || {
+        handle_resize_events(signals, resizer, &mut query_size)
+    })
+}
+
+fn run_pump_session_inner<C, Tick>(
+    mut child: C,
+    pump: IoPump,
+    deadlines: Deadlines,
+    mut on_tick: Tick,
+) -> Result<ExitCode>
+where
+    C: SupervisedChild,
+    Tick: FnMut() -> Result<()>,
 {
     let mut guard = KillOnDropGuard::armed(child.clone_killer());
 
@@ -244,6 +324,7 @@ where
             Ok(None) => {}
             Err(e) => return Err(wrap_io("child try_wait", e)),
         }
+        on_tick()?;
 
         // Harvest finished forwarders so we can inspect their
         // results in subsequent ticks. This is a non-blocking
@@ -374,6 +455,33 @@ where
     log_forwarder_outcome(Direction::ChildToHost, c2h_result);
 
     map_exit_status(status)
+}
+
+#[cfg(unix)]
+fn handle_resize_events<S, R, Q>(signals: &S, resizer: &R, query_size: &mut Q) -> Result<()>
+where
+    S: SignalSource + ?Sized,
+    R: ResizeTarget + ?Sized,
+    Q: FnMut() -> Option<PtySize>,
+{
+    let saw_resize = signals
+        .drain_events()
+        .map_err(|e| wrap_io("signal drain", e))?
+        .into_iter()
+        .any(|event| matches!(event, SignalEvent::Resize));
+    if !saw_resize {
+        return Ok(());
+    }
+
+    let Some(size) = query_size() else {
+        tracing::debug!("supervisor: skipping SIGWINCH resize because host size was unavailable");
+        return Ok(());
+    };
+
+    resizer
+        .resize_pty(size)
+        .map_err(|e| Error::Pty(e.context("apply SIGWINCH PTY resize")))?;
+    Ok(())
 }
 
 fn wrap_io(context: &'static str, e: io::Error) -> Error {
@@ -508,6 +616,8 @@ mod tests {
     };
     use std::thread;
     use std::time::{Duration, Instant};
+    #[cfg(unix)]
+    use std::{cell::RefCell, collections::VecDeque};
 
     /// In-memory mock of a `portable_pty::Child` for unit tests.
     /// State machine: `try_wait` returns `None` `pending_polls`
@@ -1139,6 +1249,63 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
+    #[derive(Default)]
+    struct MockSignalSource {
+        batches: RefCell<VecDeque<Vec<SignalEvent>>>,
+    }
+
+    #[cfg(unix)]
+    impl MockSignalSource {
+        fn new(batches: impl IntoIterator<Item = Vec<SignalEvent>>) -> Self {
+            Self {
+                batches: RefCell::new(batches.into_iter().collect()),
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    impl SignalSource for MockSignalSource {
+        fn drain_events(&self) -> io::Result<Vec<SignalEvent>> {
+            Ok(self.batches.borrow_mut().pop_front().unwrap_or_default())
+        }
+    }
+
+    #[cfg(unix)]
+    #[derive(Default)]
+    struct MockResizer {
+        calls: Mutex<Vec<PtySize>>,
+        fail: bool,
+    }
+
+    #[cfg(unix)]
+    impl MockResizer {
+        fn calls(&self) -> Vec<PtySize> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[cfg(unix)]
+    impl ResizeTarget for MockResizer {
+        fn resize_pty(&self, size: PtySize) -> anyhow::Result<()> {
+            if self.fail {
+                anyhow::bail!("synthetic resize failure");
+            }
+            self.calls.lock().unwrap().push(size);
+            Ok(())
+        }
+    }
+
+    #[cfg(unix)]
+    fn pty_size(cols: u16, rows: u16) -> PtySize {
+        PtySize {
+            cols,
+            rows,
+            pixel_width: 0,
+            pixel_height: 0,
+        }
+    }
+
     /// Sanity check: harvest is non-blocking when the forwarder
     /// has not finished yet.
     #[test]
@@ -1156,6 +1323,85 @@ mod tests {
         drop(h2c);
         // Drop pump.child_to_host too.
         drop(pump.child_to_host);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resize_events_collapse_to_latest_host_size() {
+        let child = MockChild::new(ExitStatus::with_exit_code(0), 1);
+        let signals = MockSignalSource::new([vec![
+            SignalEvent::Resize,
+            SignalEvent::Resize,
+            SignalEvent::Resize,
+        ]]);
+        let resizer = MockResizer::default();
+        let mut query_calls = 0usize;
+
+        let code = run_pump_session_with_signals(
+            child,
+            &resizer,
+            &signals,
+            || {
+                query_calls += 1;
+                Some(pty_size(132, 44))
+            },
+            quiet_pump(),
+            fast_deadlines(),
+        )
+        .expect("clean exit with resize must be Ok");
+
+        assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::SUCCESS));
+        assert_eq!(query_calls, 1, "resize batch should query host size once");
+        assert_eq!(resizer.calls(), vec![pty_size(132, 44)]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resize_events_ignore_unusable_runtime_size() {
+        let child = MockChild::new(ExitStatus::with_exit_code(0), 1);
+        let signals = MockSignalSource::new([vec![SignalEvent::Resize]]);
+        let resizer = MockResizer::default();
+
+        let code = run_pump_session_with_signals(
+            child,
+            &resizer,
+            &signals,
+            || None,
+            quiet_pump(),
+            fast_deadlines(),
+        )
+        .expect("clean exit with skipped resize must be Ok");
+
+        assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::SUCCESS));
+        assert!(resizer.calls().is_empty(), "no resize should be applied");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resize_failure_surfaces_and_kills_child() {
+        let child = MockChild::new(ExitStatus::with_exit_code(0), 1_000_000);
+        let handle = child.handle();
+        let signals = MockSignalSource::new([vec![SignalEvent::Resize]]);
+        let resizer = MockResizer {
+            calls: Mutex::new(Vec::new()),
+            fail: true,
+        };
+
+        let err = run_pump_session_with_signals(
+            child,
+            &resizer,
+            &signals,
+            || Some(pty_size(100, 30)),
+            quiet_pump(),
+            fast_deadlines(),
+        )
+        .expect_err("resize failure must surface");
+
+        assert!(matches!(err, Error::Pty(_)), "got {err:?}");
+        assert!(
+            handle.lock().unwrap().kills >= 1,
+            "resize failure must kill the child on unwind"
+        );
     }
 }
 

--- a/src/pty/size.rs
+++ b/src/pty/size.rs
@@ -30,13 +30,32 @@ pub(crate) const FALLBACK_SIZE: PtySize = PtySize {
 /// Snapshot the host terminal's current size for a freshly
 /// spawned PTY child.
 pub(crate) fn initial_size() -> PtySize {
-    initial_size_with(crossterm::terminal::size)
+    current_size().unwrap_or(FALLBACK_SIZE)
 }
 
 /// Pure variant of [`initial_size`]: derives the size from an
 /// injected `query` instead of the real `crossterm` call. Used
 /// directly by unit tests; production code calls [`initial_size`].
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn initial_size_with<F>(query: F) -> PtySize
+where
+    F: FnOnce() -> std::io::Result<(u16, u16)>,
+{
+    current_size_with(query).unwrap_or(FALLBACK_SIZE)
+}
+
+/// Snapshot the host terminal's current size for a live resize.
+///
+/// Returns `None` when the query fails or reports a degenerate
+/// `(0, 0)` so callers can preserve the child's current size
+/// instead of forcing a fallback.
+pub(crate) fn current_size() -> Option<PtySize> {
+    current_size_with(crossterm::terminal::size)
+}
+
+/// Pure variant of [`current_size`]: derives the size from an
+/// injected `query` instead of the real `crossterm` call.
+pub(crate) fn current_size_with<F>(query: F) -> Option<PtySize>
 where
     F: FnOnce() -> std::io::Result<(u16, u16)>,
 {
@@ -46,8 +65,9 @@ where
             rows,
             pixel_width: 0,
             pixel_height: 0,
-        },
-        _ => FALLBACK_SIZE,
+        }
+        .into(),
+        _ => None,
     }
 }
 
@@ -83,6 +103,23 @@ mod tests {
                 (size.cols, size.rows),
                 (FALLBACK_SIZE.cols, FALLBACK_SIZE.rows),
                 "expected fallback for query={pair:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn current_size_returns_none_on_query_err() {
+        let size = current_size_with(|| Err(io::Error::other("no terminal")));
+        assert!(size.is_none());
+    }
+
+    #[test]
+    fn current_size_returns_none_when_query_returns_zero() {
+        for pair in [(0, 0), (0, 24), (80, 0)] {
+            let size = current_size_with(move || Ok(pair));
+            assert!(
+                size.is_none(),
+                "expected no runtime size for query={pair:?}"
             );
         }
     }

--- a/src/signals/mod.rs
+++ b/src/signals/mod.rs
@@ -70,7 +70,7 @@ static WRITE_FD: AtomicI32 = AtomicI32::new(-1);
 static CACHED_READ_FD: AtomicI32 = AtomicI32::new(-1);
 static CACHED_WRITE_FD: AtomicI32 = AtomicI32::new(-1);
 
-/// RAII handle for the installed SIGWINCH/SIGTERM handlers.
+/// RAII handle for the installed self-pipe-backed signal handlers.
 ///
 /// Drop restores the previous handlers but does **not** close
 /// the self-pipe FDs (see the comment on `Drop` for the
@@ -85,7 +85,19 @@ pub struct SignalGuard {
     read_fd: RawFd,
     write_fd: RawFd,
     old_winch: libc::sigaction,
-    old_term: libc::sigaction,
+    old_term: Option<libc::sigaction>,
+}
+
+#[derive(Clone, Copy)]
+enum InstallMode {
+    ResizeOnly,
+    ResizeAndShutdown,
+}
+
+impl InstallMode {
+    const fn captures_shutdown(self) -> bool {
+        matches!(self, Self::ResizeAndShutdown)
+    }
 }
 
 impl SignalGuard {
@@ -94,6 +106,19 @@ impl SignalGuard {
     /// Errors if a `SignalGuard` is already live in this
     /// process, or if `pipe2` / `sigaction` fail.
     pub fn install() -> Result<Self> {
+        Self::install_with_mode(InstallMode::ResizeAndShutdown)
+    }
+
+    /// Install only SIGWINCH handling and leave SIGTERM at its
+    /// previous disposition.
+    ///
+    /// This lets the Unix resize path start forwarding WINCH
+    /// without changing shutdown behavior before `#60` owns it.
+    pub fn install_resize_only() -> Result<Self> {
+        Self::install_with_mode(InstallMode::ResizeOnly)
+    }
+
+    fn install_with_mode(mode: InstallMode) -> Result<Self> {
         if INSTALLED
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
             .is_err()
@@ -157,6 +182,20 @@ impl SignalGuard {
                 return Err(e.into());
             }
         };
+
+        if !mode.captures_shutdown() {
+            if opened_new {
+                CACHED_READ_FD.store(read_fd, Ordering::Release);
+                CACHED_WRITE_FD.store(write_fd, Ordering::Release);
+            }
+            return Ok(Self {
+                read_fd,
+                write_fd,
+                old_winch,
+                old_term: None,
+            });
+        }
+
         let old_term = match install_handler(libc::SIGTERM) {
             Ok(prev) => prev,
             Err(e) => {
@@ -199,7 +238,7 @@ impl SignalGuard {
             read_fd,
             write_fd,
             old_winch,
-            old_term,
+            old_term: Some(old_term),
         })
     }
 
@@ -276,12 +315,18 @@ impl Drop for SignalGuard {
         // signal that arrives at this thread while we re-install
         // the previous handlers, which keeps the rollback path
         // out of any signal disposition surprise.
-        let _mask = BlockedSignals::block(&[libc::SIGWINCH, libc::SIGTERM]);
+        let _mask = if self.old_term.is_some() {
+            BlockedSignals::block(&[libc::SIGWINCH, libc::SIGTERM])
+        } else {
+            BlockedSignals::block(&[libc::SIGWINCH])
+        };
         // SAFETY: `old_winch`/`old_term` were obtained from the
         // matching sigaction calls in `install`.
         unsafe {
             libc::sigaction(libc::SIGWINCH, &self.old_winch, std::ptr::null_mut());
-            libc::sigaction(libc::SIGTERM, &self.old_term, std::ptr::null_mut());
+            if let Some(old_term) = &self.old_term {
+                libc::sigaction(libc::SIGTERM, old_term, std::ptr::null_mut());
+            }
         }
         WRITE_FD.store(-1, Ordering::Release);
         // FDs deliberately stay open and remain cached for any
@@ -533,6 +578,28 @@ mod tests {
             std::thread::sleep(std::time::Duration::from_millis(1));
         }
         assert_eq!(events, vec![Event::Shutdown]);
+    }
+
+    #[test]
+    fn resize_only_install_skips_sigterm_handler_setup() {
+        let _serial = SERIAL.lock().unwrap();
+        FAIL_INSTALL_FOR.store(libc::SIGTERM, Ordering::Release);
+        let guard = SignalGuard::install_resize_only();
+        FAIL_INSTALL_FOR.store(0, Ordering::Release);
+        let guard = guard.expect("resize-only install");
+
+        let rc = unsafe { libc::kill(libc::getpid(), libc::SIGWINCH) };
+        assert_eq!(rc, 0);
+
+        let mut events = Vec::new();
+        for _ in 0..100 {
+            events.extend(guard.drain().unwrap());
+            if !events.is_empty() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+        assert_eq!(events, vec![Event::Resize]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- install a SIGWINCH-only self-pipe path for the Unix PTY session so resize delivery starts without changing SIGTERM semantics ahead of `#60`
- coalesce pending resize wake bytes on the existing supervisor tick and forward only the latest valid host terminal size to `master.resize()`
- add focused tests for the new install mode, resize coalescing, unusable runtime sizes, and resize-failure cleanup

Closes #59

## Follow-ups
- `#61` will add rexpect coverage for real WINCH delivery into the child
- `#60` remains the owner of graceful SIGTERM shutdown and raw-mode restoration semantics


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * More efficient and reliable terminal resize handling: multiple queued resize signals collapse into a single host-size query and resize, and resizing is skipped when the runtime size is unavailable.
  * PTY size derivation improved to preserve existing child size when current runtime size is degenerate and to fall back only when needed.
* **Tests**
  * Added tests for batched resize signals, skipped resizes when size is unavailable, failure propagation during resize, and PTY size edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/qorrection/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->