### PR TITLE
fix(signals): handle sigterm shutdown gracefully

### DIFF
--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -59,6 +59,18 @@ use crate::{
     Error, Result,
 };
 
+pub(crate) enum BodyResult {
+    Complete(ExitCode),
+    #[cfg(unix)]
+    Deferred(Box<dyn FnOnce() -> Result<ExitCode>>),
+}
+
+impl From<ExitCode> for BodyResult {
+    fn from(code: ExitCode) -> Self {
+        Self::Complete(code)
+    }
+}
+
 fn trigger_armed(command: &OsString) -> bool {
     crate::cli::arming::is_armed(command.as_os_str())
 }
@@ -108,7 +120,7 @@ pub(crate) fn run_session_with<Arm, A, B, P>(
 where
     Arm: FnOnce(&OsString) -> bool,
     A: FnOnce(&TerminalCaps) -> Result<RawGuard>,
-    B: FnOnce(bool, &OsString, &[OsString]) -> Result<ExitCode>,
+    B: FnOnce(bool, &OsString, &[OsString]) -> Result<BodyResult>,
     P: FnOnce(&OsString, &[OsString]) -> Result<ExitCode>,
 {
     let armed = arm(&command);
@@ -121,8 +133,14 @@ where
     // Bind the guard to a named local so it lives until the end
     // of the function. `let _ = ...` would drop it immediately
     // and defeat the purpose.
-    let _raw = acquire(&caps)?;
-    body(armed, &command, &args)
+    let raw = acquire(&caps)?;
+    let result = body(armed, &command, &args)?;
+    drop(raw);
+    match result {
+        BodyResult::Complete(code) => Ok(code),
+        #[cfg(unix)]
+        BodyResult::Deferred(complete) => complete(),
+    }
 }
 
 /// Non-TTY bypass body. Spawns `command` + `args` with stdio
@@ -146,7 +164,7 @@ fn non_tty_passthrough(command: &OsString, args: &[OsString]) -> Result<ExitCode
 /// supervisor surfaces the child's exit status through the
 /// returned [`ExitCode`]; nothing in this body writes to host
 /// stdout directly.
-fn default_body(armed: bool, command: &OsString, args: &[OsString]) -> Result<ExitCode> {
+fn default_body(armed: bool, command: &OsString, args: &[OsString]) -> Result<BodyResult> {
     let size = size::initial_size();
     tracing::info!(
         program = %command.to_string_lossy(),
@@ -179,7 +197,13 @@ fn default_body(armed: bool, command: &OsString, args: &[OsString]) -> Result<Ex
     #[cfg(not(unix))]
     let pump = pump::start_io_pump(&mut session, std::io::stdin(), std::io::stdout(), armed)?;
     kill_guard.disarm();
-    session::run_pump_session(session, pump)
+    match session::run_pump_session(session, pump)? {
+        session::SessionStatus::Exited(code) => Ok(BodyResult::Complete(code)),
+        #[cfg(unix)]
+        session::SessionStatus::DeferredShutdown(shutdown) => {
+            Ok(BodyResult::Deferred(Box::new(move || shutdown.complete())))
+        }
+    }
 }
 
 #[cfg(test)]
@@ -216,7 +240,7 @@ mod tests {
     fn no_acquire(_caps: &TerminalCaps) -> Result<RawGuard> {
         panic!("acquire must not run on the non-TTY bypass path");
     }
-    fn no_body(_armed: bool, _cmd: &OsString, _args: &[OsString]) -> Result<ExitCode> {
+    fn no_body(_armed: bool, _cmd: &OsString, _args: &[OsString]) -> Result<BodyResult> {
         panic!("body must not run on the non-TTY bypass path");
     }
 
@@ -249,7 +273,7 @@ mod tests {
                     acquired_for_body.load(Ordering::SeqCst),
                     "body ran before acquire"
                 );
-                Ok(ExitCode::SUCCESS)
+                Ok(ExitCode::SUCCESS.into())
             },
             no_passthrough,
         )
@@ -274,7 +298,7 @@ mod tests {
                 acquire_observed.fetch_add(1, Ordering::SeqCst);
                 Ok(RawGuard::noop())
             },
-            |_armed, _cmd, _args| Ok(ExitCode::SUCCESS),
+            |_armed, _cmd, _args| Ok(ExitCode::SUCCESS.into()),
             no_passthrough,
         )
         .unwrap();
@@ -293,7 +317,7 @@ mod tests {
             Vec::new(),
             |_| true,
             move |_caps| Ok(observed_guard(counter_for_acquire)),
-            |_armed, _cmd, _args| Ok(ExitCode::SUCCESS),
+            |_armed, _cmd, _args| Ok(ExitCode::SUCCESS.into()),
             no_passthrough,
         )
         .unwrap();
@@ -337,7 +361,7 @@ mod tests {
                 Vec::new(),
                 |_| true,
                 move |_caps| Ok(observed_guard(counter_for_call)),
-                |_armed, _cmd, _args| -> Result<ExitCode> {
+                |_armed, _cmd, _args| -> Result<BodyResult> {
                     panic!("body boom");
                 },
                 no_passthrough,
@@ -365,7 +389,7 @@ mod tests {
             },
             move |_armed, _cmd, _args| {
                 body_observed.store(true, Ordering::SeqCst);
-                Ok(ExitCode::SUCCESS)
+                Ok(ExitCode::SUCCESS.into())
             },
             no_passthrough,
         );
@@ -375,6 +399,44 @@ mod tests {
             !body_ran.load(Ordering::SeqCst),
             "body ran after acquire failure"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_session_with_drops_guard_before_deferred_body_action() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let counter_for_acquire = Arc::clone(&counter);
+        let counter_for_body = Arc::clone(&counter);
+        let deferred_ran = Arc::new(AtomicBool::new(false));
+        let deferred_observed = Arc::clone(&deferred_ran);
+
+        let code = run_session_with(
+            caps(),
+            OsString::from("dummy"),
+            Vec::new(),
+            |_| true,
+            move |_caps| Ok(observed_guard(counter_for_acquire)),
+            move |_armed, _cmd, _args| {
+                Ok(BodyResult::Deferred(Box::new(move || {
+                    assert_eq!(
+                        counter_for_body.load(Ordering::SeqCst),
+                        1,
+                        "raw guard must drop before deferred shutdown action runs"
+                    );
+                    deferred_observed.store(true, Ordering::SeqCst);
+                    Ok(ExitCode::SUCCESS)
+                })))
+            },
+            no_passthrough,
+        )
+        .expect("deferred action should complete successfully");
+
+        let _ = code;
+        assert!(
+            deferred_ran.load(Ordering::SeqCst),
+            "deferred action should run after raw guard drop"
+        );
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
     }
 
     /// Non-TTY bypass routing — when stdin is not a TTY, the
@@ -479,7 +541,7 @@ mod tests {
             |_caps| Ok(RawGuard::noop()),
             move |armed, _cmd, _args| {
                 observed_for_body.store(armed, Ordering::SeqCst);
-                Ok(ExitCode::SUCCESS)
+                Ok(ExitCode::SUCCESS.into())
             },
             no_passthrough,
         )
@@ -507,7 +569,7 @@ mod tests {
             |_caps| Ok(RawGuard::noop()),
             move |armed, _cmd, _args| {
                 observed_for_body.store(armed, Ordering::SeqCst);
-                Ok(ExitCode::SUCCESS)
+                Ok(ExitCode::SUCCESS.into())
             },
             no_passthrough,
         )

--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -196,8 +196,8 @@ impl ShutdownTarget {
 #[cfg(unix)]
 pub(crate) struct DeferredShutdown<C> {
     child: C,
-    _master: Box<dyn MasterPty + Send>,
-    shutdown_target: Option<ShutdownTarget>,
+    master: Box<dyn MasterPty + Send>,
+    signal_guard: Option<SignalGuard>,
     host_to_child: Option<ForwarderHandle>,
     child_to_host: Option<ForwarderHandle>,
     host_to_child_render_progress: Option<SharedRenderProgress>,
@@ -211,9 +211,29 @@ impl<C> DeferredShutdown<C>
 where
     C: SupervisedChild,
 {
+    fn resolve_shutdown_target(&self) -> Option<ShutdownTarget> {
+        ShutdownTarget::from_parts(self.master.process_group_leader(), self.child.process_id())
+    }
+
     pub(crate) fn complete(mut self) -> Result<ExitCode> {
         let mut guard = KillOnDropGuard::armed(self.child.clone_killer());
-        let target = self.shutdown_target.ok_or_else(|| {
+        if let Some(status) = self
+            .child
+            .try_wait()
+            .map_err(|e| wrap_io("child try_wait before forwarded SIGTERM", e))?
+        {
+            guard.disarm();
+            return finish_after_child_exit(
+                status,
+                self.host_to_child.take(),
+                self.child_to_host.take(),
+                self.host_to_child_render_progress.take(),
+                self.h2c_result.take(),
+                self.c2h_result.take(),
+                self.deadlines,
+            );
+        }
+        let target = self.resolve_shutdown_target().ok_or_else(|| {
             wrap_io(
                 "forward SIGTERM to PTY child",
                 io::Error::new(
@@ -396,14 +416,20 @@ where
     // after the supervisor returns.
     let signal_guard = setup()?;
     kill_guard.disarm();
-    run_pump_session_with_signals(
+    match run_pump_session_with_signals(
         child,
         master,
         &signal_guard,
         size::current_size,
         pump,
         Deadlines::production(),
-    )
+    )? {
+        SessionStatus::Exited(code) => Ok(SessionStatus::Exited(code)),
+        SessionStatus::DeferredShutdown(mut shutdown) => {
+            shutdown.signal_guard = Some(signal_guard);
+            Ok(SessionStatus::DeferredShutdown(shutdown))
+        }
+    }
 }
 
 /// Lifecycle core, parameterised over the [`SupervisedChild`]
@@ -439,8 +465,6 @@ where
     S: SignalSource + ?Sized,
     Q: FnMut() -> Option<PtySize>,
 {
-    let shutdown_target =
-        ShutdownTarget::from_parts(master.process_group_leader(), child.process_id());
     match run_pump_session_inner(child, pump, deadlines, || {
         handle_signal_events(signals, master.as_ref(), &mut query_size)
     })? {
@@ -448,8 +472,8 @@ where
         SupervisorOutcome::Shutdown(pending) => Ok(SessionStatus::DeferredShutdown(Box::new(
             DeferredShutdown {
                 child: pending.child,
-                _master: master,
-                shutdown_target,
+                master,
+                signal_guard: None,
                 host_to_child: pending.host_to_child,
                 child_to_host: pending.child_to_host,
                 host_to_child_render_progress: pending.host_to_child_render_progress,
@@ -691,10 +715,20 @@ fn wait_with_budget<C: SupervisedChild>(
 #[cfg(unix)]
 fn signal_shutdown_target(target: ShutdownTarget) -> io::Result<()> {
     let rc = match target {
-        ShutdownTarget::ProcessGroup(process_group_leader) => unsafe {
-            libc::killpg(process_group_leader, libc::SIGTERM)
-        },
-        ShutdownTarget::Process(process_id) => unsafe { libc::kill(process_id, libc::SIGTERM) },
+        ShutdownTarget::ProcessGroup(process_group_leader) => {
+            // SAFETY: `ShutdownTarget::from_parts()` constructs this variant only
+            // from positive `pid_t` values, so the group leader id is well-formed
+            // for libc. Sending SIGTERM is intentional, and errno handling is
+            // preserved below.
+            unsafe { libc::killpg(process_group_leader, libc::SIGTERM) }
+        }
+        ShutdownTarget::Process(process_id) => {
+            // SAFETY: `ShutdownTarget::from_parts()` constructs this variant only
+            // from positive `pid_t` values converted from the child pid, so the
+            // process id is well-formed for libc. Sending SIGTERM is intentional,
+            // and errno handling is preserved below.
+            unsafe { libc::kill(process_id, libc::SIGTERM) }
+        }
     };
     if rc == 0 {
         return Ok(());
@@ -730,13 +764,10 @@ fn finish_after_child_exit(
         } else {
             Duration::ZERO
         };
-        #[cfg(unix)]
         let budget = IoPump::host_to_child_post_exit_budget(
             host_to_child_render_progress.as_ref(),
             base_budget,
         );
-        #[cfg(not(unix))]
-        let budget = base_budget;
         h2c_result = Some(join_with_budget(h, budget));
     }
     if let Some(h) = child_to_host.take() {
@@ -837,7 +868,11 @@ mod tests {
     use crate::pty::forward::{
         spawn_cancellable_forwarder, spawn_forwarder, CancelHandle, CancellableReader, Direction,
     };
+    #[cfg(unix)]
+    use crate::signals::TEST_SERIAL;
     use std::io::{self, Cursor};
+    #[cfg(unix)]
+    use std::sync::atomic::AtomicI32;
     use std::sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc, Mutex,
@@ -1588,7 +1623,7 @@ mod tests {
     struct MockMasterState {
         calls: Mutex<Vec<PtySize>>,
         fail: bool,
-        process_group_leader: Option<libc::pid_t>,
+        process_group_leader: AtomicI32,
     }
 
     #[cfg(unix)]
@@ -1605,7 +1640,7 @@ mod tests {
             let state = Arc::new(MockMasterState {
                 calls: Mutex::new(Vec::new()),
                 fail,
-                process_group_leader,
+                process_group_leader: AtomicI32::new(process_group_leader.unwrap_or_default()),
             });
             (
                 Self {
@@ -1613,6 +1648,15 @@ mod tests {
                 },
                 state,
             )
+        }
+
+        fn set_process_group_leader(
+            state: &MockMasterState,
+            process_group_leader: Option<libc::pid_t>,
+        ) {
+            state
+                .process_group_leader
+                .store(process_group_leader.unwrap_or_default(), Ordering::SeqCst);
         }
     }
 
@@ -1639,7 +1683,8 @@ mod tests {
         }
 
         fn process_group_leader(&self) -> Option<libc::pid_t> {
-            self.state.process_group_leader
+            let pid = self.state.process_group_leader.load(Ordering::SeqCst);
+            (pid > 0).then_some(pid)
         }
 
         fn as_raw_fd(&self) -> Option<std::os::fd::RawFd> {
@@ -1811,14 +1856,108 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn deferred_shutdown_rechecks_child_exit_before_forwarding_sigterm() {
+        let child = MockChild::new(ExitStatus::with_exit_code(0), 0);
+        let handle = child.handle();
+
+        let code = DeferredShutdown {
+            child,
+            master: Box::new(DummyMaster),
+            signal_guard: None,
+            host_to_child: None,
+            child_to_host: None,
+            host_to_child_render_progress: None,
+            h2c_result: None,
+            c2h_result: None,
+            deadlines: fast_deadlines(),
+        }
+        .complete()
+        .expect("already-exited child should bypass SIGTERM forwarding");
+
+        assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::SUCCESS));
+        assert_eq!(
+            handle.lock().unwrap().kills,
+            0,
+            "already-exited child should not be killed during deferred completion"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn deferred_shutdown_resolves_shutdown_target_from_live_master_state() {
+        let child = MockChild::new(ExitStatus::with_exit_code(0), 1_000_000);
+        let (master, state) = MockMaster::shared(false, Some(7));
+        let shutdown = DeferredShutdown {
+            child,
+            master: Box::new(master),
+            signal_guard: None,
+            host_to_child: None,
+            child_to_host: None,
+            host_to_child_render_progress: None,
+            h2c_result: None,
+            c2h_result: None,
+            deadlines: fast_deadlines(),
+        };
+
+        assert!(matches!(
+            shutdown.resolve_shutdown_target(),
+            Some(ShutdownTarget::ProcessGroup(7))
+        ));
+        MockMaster::set_process_group_leader(state.as_ref(), Some(54_054));
+        assert!(matches!(
+            shutdown.resolve_shutdown_target(),
+            Some(ShutdownTarget::ProcessGroup(54_054))
+        ));
+        MockMaster::set_process_group_leader(state.as_ref(), None);
+        assert!(matches!(
+            shutdown.resolve_shutdown_target(),
+            Some(ShutdownTarget::Process(42_042))
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn deferred_shutdown_keeps_signal_guard_installed_until_completion() {
+        let _serial = TEST_SERIAL.lock().unwrap();
+        let child = MockChild::new(ExitStatus::with_exit_code(0), 0);
+        let guard = SignalGuard::install().expect("install signal guard");
+        let shutdown = DeferredShutdown {
+            child,
+            master: Box::new(DummyMaster),
+            signal_guard: Some(guard),
+            host_to_child: None,
+            child_to_host: None,
+            host_to_child_render_progress: None,
+            h2c_result: None,
+            c2h_result: None,
+            deadlines: fast_deadlines(),
+        };
+
+        let err = SignalGuard::install().expect_err("deferred shutdown should retain the guard");
+        assert!(
+            matches!(&err, Error::Terminal(io_err) if io_err.kind() == io::ErrorKind::AlreadyExists),
+            "expected Terminal(AlreadyExists), got {err:?}"
+        );
+
+        let code = shutdown
+            .complete()
+            .expect("already-exited child should release the retained signal guard cleanly");
+        assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::SUCCESS));
+
+        let guard = SignalGuard::install().expect("signal guard should drop after completion");
+        drop(guard);
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn deferred_shutdown_kills_child_on_completion_error() {
         let child = MockChild::new(ExitStatus::with_exit_code(0), 1_000_000);
         let handle = child.handle();
 
         let err = DeferredShutdown {
             child,
-            _master: Box::new(DummyMaster),
-            shutdown_target: None,
+            master: Box::new(DummyMaster),
+            signal_guard: None,
             host_to_child: None,
             child_to_host: None,
             host_to_child_render_progress: None,

--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -79,6 +79,7 @@ use crate::pty::size;
 use crate::pty::spawn::SpawnedSession;
 #[cfg(unix)]
 use crate::signals::{Event as SignalEvent, SignalGuard};
+use crate::trigger::input::SharedRenderProgress;
 use crate::{Error, Result};
 
 /// Polling and join time budgets the supervisor honors.
@@ -142,6 +143,117 @@ impl Deadlines {
     }
 }
 
+#[cfg(unix)]
+pub(crate) enum SessionStatus<C = PtyChild> {
+    Exited(ExitCode),
+    DeferredShutdown(Box<DeferredShutdown<C>>),
+}
+
+#[cfg(not(unix))]
+pub(crate) enum SessionStatus {
+    Exited(ExitCode),
+}
+
+enum SupervisorOutcome<C> {
+    Exited(ExitCode),
+    Shutdown(PendingShutdown<C>),
+}
+
+struct PendingShutdown<C> {
+    child: C,
+    host_to_child: Option<ForwarderHandle>,
+    child_to_host: Option<ForwarderHandle>,
+    host_to_child_render_progress: Option<SharedRenderProgress>,
+    h2c_result: Option<io::Result<ForwarderExit>>,
+    c2h_result: Option<io::Result<ForwarderExit>>,
+    deadlines: Deadlines,
+}
+
+#[cfg(unix)]
+#[derive(Debug, Clone, Copy)]
+enum ShutdownTarget {
+    ProcessGroup(libc::pid_t),
+    Process(libc::pid_t),
+}
+
+#[cfg(unix)]
+impl ShutdownTarget {
+    fn from_parts(
+        process_group_leader: Option<libc::pid_t>,
+        process_id: Option<u32>,
+    ) -> Option<Self> {
+        if let Some(process_group_leader) = process_group_leader.filter(|pid| *pid > 0) {
+            return Some(Self::ProcessGroup(process_group_leader));
+        }
+
+        process_id
+            .and_then(|pid| libc::pid_t::try_from(pid).ok())
+            .filter(|pid| *pid > 0)
+            .map(Self::Process)
+    }
+}
+
+#[cfg(unix)]
+pub(crate) struct DeferredShutdown<C> {
+    child: C,
+    _master: Box<dyn MasterPty + Send>,
+    shutdown_target: Option<ShutdownTarget>,
+    host_to_child: Option<ForwarderHandle>,
+    child_to_host: Option<ForwarderHandle>,
+    host_to_child_render_progress: Option<SharedRenderProgress>,
+    h2c_result: Option<io::Result<ForwarderExit>>,
+    c2h_result: Option<io::Result<ForwarderExit>>,
+    deadlines: Deadlines,
+}
+
+#[cfg(unix)]
+impl<C> DeferredShutdown<C>
+where
+    C: SupervisedChild,
+{
+    pub(crate) fn complete(mut self) -> Result<ExitCode> {
+        let mut guard = KillOnDropGuard::armed(self.child.clone_killer());
+        let target = self.shutdown_target.ok_or_else(|| {
+            wrap_io(
+                "forward SIGTERM to PTY child",
+                io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "no PTY process group leader or child pid was available",
+                ),
+            )
+        })?;
+        signal_shutdown_target(target).map_err(|e| wrap_io("forward SIGTERM to PTY child", e))?;
+        let status = wait_with_budget(
+            &mut self.child,
+            self.deadlines.post_kill_wait_budget,
+            self.deadlines.wait_poll,
+        )?
+        .ok_or_else(|| {
+            wrap_io(
+                "wait for PTY child after forwarded SIGTERM",
+                io::Error::new(io::ErrorKind::TimedOut, "post-SIGTERM wait budget exceeded"),
+            )
+        })?;
+        guard.disarm();
+
+        finish_after_child_exit(
+            status,
+            self.host_to_child.take(),
+            self.child_to_host.take(),
+            self.host_to_child_render_progress.take(),
+            self.h2c_result.take(),
+            self.c2h_result.take(),
+            self.deadlines,
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TickAction {
+    Continue,
+    Shutdown,
+}
+
 /// Trait-level seam for the wrapped child.
 ///
 /// Production binds [`PtyChild`] (a thin wrapper over a
@@ -155,6 +267,8 @@ pub(crate) trait SupervisedChild {
     /// Produce a fresh killer handle. Wraps
     /// `portable_pty::Child::clone_killer`.
     fn clone_killer(&mut self) -> Box<dyn ChildKiller + Send + Sync>;
+    /// Report the child pid when the backend exposes one.
+    fn process_id(&self) -> Option<u32>;
 }
 
 /// Production [`SupervisedChild`] over a `portable-pty` child.
@@ -168,6 +282,9 @@ impl SupervisedChild for PtyChild {
     }
     fn clone_killer(&mut self) -> Box<dyn ChildKiller + Send + Sync> {
         self.child.clone_killer()
+    }
+    fn process_id(&self) -> Option<u32> {
+        self.child.process_id()
     }
 }
 
@@ -234,7 +351,7 @@ impl Drop for KillOnDropGuard {
 /// Production entry point. Wraps [`SpawnedSession`] +
 /// [`IoPump`] into the trait-seam form and delegates to
 /// [`run_pump_session_with`].
-pub(crate) fn run_pump_session(session: SpawnedSession, pump: IoPump) -> Result<ExitCode> {
+pub(crate) fn run_pump_session(session: SpawnedSession, pump: IoPump) -> Result<SessionStatus> {
     let SpawnedSession { child, master } = session;
     #[cfg(unix)]
     {
@@ -244,7 +361,8 @@ pub(crate) fn run_pump_session(session: SpawnedSession, pump: IoPump) -> Result<
     {
         let child = PtyChild { child };
         let _master = master;
-        run_pump_session_with(child, pump, Deadlines::production())
+        let code = run_pump_session_with(child, pump, Deadlines::production())?;
+        Ok(SessionStatus::Exited(code))
     }
 }
 
@@ -253,8 +371,8 @@ fn run_pump_session_unix(
     child: Box<dyn portable_pty::Child + Send + Sync>,
     master: Box<dyn MasterPty + Send>,
     pump: IoPump,
-) -> Result<ExitCode> {
-    run_pump_session_unix_with_setup(child, master, pump, SignalGuard::install_resize_only)
+) -> Result<SessionStatus<PtyChild>> {
+    run_pump_session_unix_with_setup(child, master, pump, SignalGuard::install)
 }
 
 #[cfg(unix)]
@@ -263,7 +381,7 @@ fn run_pump_session_unix_with_setup<Setup>(
     master: Box<dyn MasterPty + Send>,
     pump: IoPump,
     setup: Setup,
-) -> Result<ExitCode>
+) -> Result<SessionStatus<PtyChild>>
 where
     Setup: FnOnce() -> Result<SignalGuard>,
 {
@@ -280,7 +398,7 @@ where
     kill_guard.disarm();
     run_pump_session_with_signals(
         child,
-        master.as_ref(),
+        master,
         &signal_guard,
         size::current_size,
         pump,
@@ -301,27 +419,46 @@ pub(crate) fn run_pump_session_with<C>(
 where
     C: SupervisedChild,
 {
-    run_pump_session_inner(child, pump, deadlines, || Ok(()))
+    match run_pump_session_inner(child, pump, deadlines, || Ok(TickAction::Continue))? {
+        SupervisorOutcome::Exited(code) => Ok(code),
+        SupervisorOutcome::Shutdown(_) => unreachable!("shutdown requires a signal source"),
+    }
 }
 
 #[cfg(unix)]
-fn run_pump_session_with_signals<C, R, S, Q>(
+fn run_pump_session_with_signals<C, S, Q>(
     child: C,
-    resizer: &R,
+    master: Box<dyn MasterPty + Send>,
     signals: &S,
     mut query_size: Q,
     pump: IoPump,
     deadlines: Deadlines,
-) -> Result<ExitCode>
+) -> Result<SessionStatus<C>>
 where
     C: SupervisedChild,
-    R: ResizeTarget + ?Sized,
     S: SignalSource + ?Sized,
     Q: FnMut() -> Option<PtySize>,
 {
-    run_pump_session_inner(child, pump, deadlines, || {
-        handle_resize_events(signals, resizer, &mut query_size)
-    })
+    let shutdown_target =
+        ShutdownTarget::from_parts(master.process_group_leader(), child.process_id());
+    match run_pump_session_inner(child, pump, deadlines, || {
+        handle_signal_events(signals, master.as_ref(), &mut query_size)
+    })? {
+        SupervisorOutcome::Exited(code) => Ok(SessionStatus::Exited(code)),
+        SupervisorOutcome::Shutdown(pending) => Ok(SessionStatus::DeferredShutdown(Box::new(
+            DeferredShutdown {
+                child: pending.child,
+                _master: master,
+                shutdown_target,
+                host_to_child: pending.host_to_child,
+                child_to_host: pending.child_to_host,
+                host_to_child_render_progress: pending.host_to_child_render_progress,
+                h2c_result: pending.h2c_result,
+                c2h_result: pending.c2h_result,
+                deadlines: pending.deadlines,
+            },
+        ))),
+    }
 }
 
 fn run_pump_session_inner<C, Tick>(
@@ -329,10 +466,10 @@ fn run_pump_session_inner<C, Tick>(
     pump: IoPump,
     deadlines: Deadlines,
     mut on_tick: Tick,
-) -> Result<ExitCode>
+) -> Result<SupervisorOutcome<C>>
 where
     C: SupervisedChild,
-    Tick: FnMut() -> Result<()>,
+    Tick: FnMut() -> Result<TickAction>,
 {
     let mut guard = KillOnDropGuard::armed(child.clone_killer());
 
@@ -349,7 +486,18 @@ where
             Ok(None) => {}
             Err(e) => return Err(wrap_io("child try_wait", e)),
         }
-        on_tick()?;
+        if matches!(on_tick()?, TickAction::Shutdown) {
+            guard.disarm();
+            return Ok(SupervisorOutcome::Shutdown(PendingShutdown {
+                child,
+                host_to_child: h2c,
+                child_to_host: c2h,
+                host_to_child_render_progress,
+                h2c_result,
+                c2h_result,
+                deadlines,
+            }));
+        }
 
         // Harvest finished forwarders so we can inspect their
         // results in subsequent ticks. This is a non-blocking
@@ -459,54 +607,49 @@ where
     // Wait consumed a status → guard's job is done.
     guard.disarm();
 
-    // Phase 2: drain remaining forwarders within budget.
-    if let Some(h) = h2c.take() {
-        h.cancel();
-        let base_budget = if h.cancel_wakes_read() {
-            deadlines.host_to_child_post_exit_budget
-        } else {
-            Duration::ZERO
-        };
-        let budget = IoPump::host_to_child_post_exit_budget(
-            host_to_child_render_progress.as_ref(),
-            base_budget,
-        );
-        h2c_result = Some(join_with_budget(h, budget));
-    }
-    if let Some(h) = c2h.take() {
-        c2h_result = Some(join_with_budget(h, deadlines.forwarder_join_budget));
-    }
-    log_forwarder_outcome(Direction::HostToChild, h2c_result);
-    log_forwarder_outcome(Direction::ChildToHost, c2h_result);
-
-    map_exit_status(status)
+    let code = finish_after_child_exit(
+        status,
+        h2c.take(),
+        c2h.take(),
+        host_to_child_render_progress,
+        h2c_result,
+        c2h_result,
+        deadlines,
+    )?;
+    Ok(SupervisorOutcome::Exited(code))
 }
 
 #[cfg(unix)]
-fn handle_resize_events<S, R, Q>(signals: &S, resizer: &R, query_size: &mut Q) -> Result<()>
+fn handle_signal_events<S, R, Q>(signals: &S, resizer: &R, query_size: &mut Q) -> Result<TickAction>
 where
     S: SignalSource + ?Sized,
     R: ResizeTarget + ?Sized,
     Q: FnMut() -> Option<PtySize>,
 {
-    let saw_resize = signals
+    let mut saw_resize = false;
+    for event in signals
         .drain_events()
         .map_err(|e| wrap_io("signal drain", e))?
-        .into_iter()
-        .any(|event| matches!(event, SignalEvent::Resize));
+    {
+        match event {
+            SignalEvent::Resize => saw_resize = true,
+            SignalEvent::Shutdown => return Ok(TickAction::Shutdown),
+        }
+    }
+
     if !saw_resize {
-        return Ok(());
+        return Ok(TickAction::Continue);
     }
 
     let Some(size) = query_size() else {
         tracing::debug!("supervisor: skipping SIGWINCH resize because host size was unavailable");
-        return Ok(());
+        return Ok(TickAction::Continue);
     };
 
     resizer
         .resize_pty(size)
         .map_err(|e| Error::Pty(e.context("apply SIGWINCH PTY resize")))?;
-    Ok(())
+    Ok(TickAction::Continue)
 }
 
 fn wrap_io(context: &'static str, e: io::Error) -> Error {
@@ -543,6 +686,66 @@ fn wait_with_budget<C: SupervisedChild>(
         }
         std::thread::sleep(poll);
     }
+}
+
+#[cfg(unix)]
+fn signal_shutdown_target(target: ShutdownTarget) -> io::Result<()> {
+    let rc = match target {
+        ShutdownTarget::ProcessGroup(process_group_leader) => unsafe {
+            libc::killpg(process_group_leader, libc::SIGTERM)
+        },
+        ShutdownTarget::Process(process_id) => unsafe { libc::kill(process_id, libc::SIGTERM) },
+    };
+    if rc == 0 {
+        return Ok(());
+    }
+
+    let err = io::Error::last_os_error();
+    if matches!(err.raw_os_error(), Some(code) if code == libc::ESRCH) {
+        tracing::debug!(
+            ?target,
+            error = %err,
+            "supervisor: shutdown target exited before SIGTERM forward"
+        );
+        return Ok(());
+    }
+
+    Err(err)
+}
+
+fn finish_after_child_exit(
+    status: ExitStatus,
+    mut host_to_child: Option<ForwarderHandle>,
+    mut child_to_host: Option<ForwarderHandle>,
+    host_to_child_render_progress: Option<SharedRenderProgress>,
+    mut h2c_result: Option<io::Result<ForwarderExit>>,
+    mut c2h_result: Option<io::Result<ForwarderExit>>,
+    deadlines: Deadlines,
+) -> Result<ExitCode> {
+    // Phase 2: drain remaining forwarders within budget.
+    if let Some(h) = host_to_child.take() {
+        h.cancel();
+        let base_budget = if h.cancel_wakes_read() {
+            deadlines.host_to_child_post_exit_budget
+        } else {
+            Duration::ZERO
+        };
+        #[cfg(unix)]
+        let budget = IoPump::host_to_child_post_exit_budget(
+            host_to_child_render_progress.as_ref(),
+            base_budget,
+        );
+        #[cfg(not(unix))]
+        let budget = base_budget;
+        h2c_result = Some(join_with_budget(h, budget));
+    }
+    if let Some(h) = child_to_host.take() {
+        c2h_result = Some(join_with_budget(h, deadlines.forwarder_join_budget));
+    }
+    log_forwarder_outcome(Direction::HostToChild, h2c_result);
+    log_forwarder_outcome(Direction::ChildToHost, c2h_result);
+
+    map_exit_status(status)
 }
 
 /// Non-blocking peek + extract. If the handle is finished, join
@@ -693,6 +896,9 @@ mod tests {
             Box::new(MockKiller {
                 state: Arc::clone(&self.state),
             })
+        }
+        fn process_id(&self) -> Option<u32> {
+            Some(42_042)
         }
     }
 
@@ -1379,26 +1585,69 @@ mod tests {
 
     #[cfg(unix)]
     #[derive(Default)]
-    struct MockResizer {
+    struct MockMasterState {
         calls: Mutex<Vec<PtySize>>,
         fail: bool,
+        process_group_leader: Option<libc::pid_t>,
     }
 
     #[cfg(unix)]
-    impl MockResizer {
-        fn calls(&self) -> Vec<PtySize> {
-            self.calls.lock().unwrap().clone()
+    struct MockMaster {
+        state: Arc<MockMasterState>,
+    }
+
+    #[cfg(unix)]
+    impl MockMaster {
+        fn shared(
+            fail: bool,
+            process_group_leader: Option<libc::pid_t>,
+        ) -> (Self, Arc<MockMasterState>) {
+            let state = Arc::new(MockMasterState {
+                calls: Mutex::new(Vec::new()),
+                fail,
+                process_group_leader,
+            });
+            (
+                Self {
+                    state: Arc::clone(&state),
+                },
+                state,
+            )
         }
     }
 
     #[cfg(unix)]
-    impl ResizeTarget for MockResizer {
-        fn resize_pty(&self, size: PtySize) -> anyhow::Result<()> {
-            if self.fail {
+    impl MasterPty for MockMaster {
+        fn resize(&self, size: PtySize) -> anyhow::Result<()> {
+            if self.state.fail {
                 anyhow::bail!("synthetic resize failure");
             }
-            self.calls.lock().unwrap().push(size);
+            self.state.calls.lock().unwrap().push(size);
             Ok(())
+        }
+
+        fn get_size(&self) -> anyhow::Result<PtySize> {
+            Ok(pty_size(80, 24))
+        }
+
+        fn try_clone_reader(&self) -> anyhow::Result<Box<dyn io::Read + Send>> {
+            Ok(Box::new(Cursor::new(Vec::<u8>::new())))
+        }
+
+        fn take_writer(&self) -> anyhow::Result<Box<dyn io::Write + Send>> {
+            Ok(Box::new(Vec::<u8>::new()))
+        }
+
+        fn process_group_leader(&self) -> Option<libc::pid_t> {
+            self.state.process_group_leader
+        }
+
+        fn as_raw_fd(&self) -> Option<std::os::fd::RawFd> {
+            None
+        }
+
+        fn tty_name(&self) -> Option<std::path::PathBuf> {
+            None
         }
     }
 
@@ -1409,6 +1658,16 @@ mod tests {
             rows,
             pixel_width: 0,
             pixel_height: 0,
+        }
+    }
+
+    #[cfg(unix)]
+    fn expect_exited<C>(status: SessionStatus<C>) -> ExitCode {
+        match status {
+            SessionStatus::Exited(code) => code,
+            SessionStatus::DeferredShutdown(_) => {
+                panic!("signal-free resize path should not defer shutdown")
+            }
         }
     }
 
@@ -1440,26 +1699,28 @@ mod tests {
             SignalEvent::Resize,
             SignalEvent::Resize,
         ]]);
-        let resizer = MockResizer::default();
+        let (master, state) = MockMaster::shared(false, None);
         let mut query_calls = 0usize;
         let (pump, _exited) = cancellable_h2c_quiet_c2h_pump();
 
-        let code = run_pump_session_with_signals(
-            child,
-            &resizer,
-            &signals,
-            || {
-                query_calls += 1;
-                Some(pty_size(132, 44))
-            },
-            pump,
-            fast_deadlines(),
-        )
-        .expect("clean exit with resize must be Ok");
+        let code = expect_exited(
+            run_pump_session_with_signals(
+                child,
+                Box::new(master),
+                &signals,
+                || {
+                    query_calls += 1;
+                    Some(pty_size(132, 44))
+                },
+                pump,
+                fast_deadlines(),
+            )
+            .expect("clean exit with resize must be Ok"),
+        );
 
         assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::SUCCESS));
         assert_eq!(query_calls, 1, "resize batch should query host size once");
-        assert_eq!(resizer.calls(), vec![pty_size(132, 44)]);
+        assert_eq!(state.calls.lock().unwrap().clone(), vec![pty_size(132, 44)]);
     }
 
     #[cfg(unix)]
@@ -1467,21 +1728,26 @@ mod tests {
     fn resize_events_ignore_unusable_runtime_size() {
         let child = MockChild::new(ExitStatus::with_exit_code(0), 1);
         let signals = MockSignalSource::new([vec![SignalEvent::Resize]]);
-        let resizer = MockResizer::default();
+        let (master, state) = MockMaster::shared(false, None);
         let (pump, _exited) = cancellable_h2c_quiet_c2h_pump();
 
-        let code = run_pump_session_with_signals(
-            child,
-            &resizer,
-            &signals,
-            || None,
-            pump,
-            fast_deadlines(),
-        )
-        .expect("clean exit with skipped resize must be Ok");
+        let code = expect_exited(
+            run_pump_session_with_signals(
+                child,
+                Box::new(master),
+                &signals,
+                || None,
+                pump,
+                fast_deadlines(),
+            )
+            .expect("clean exit with skipped resize must be Ok"),
+        );
 
         assert_eq!(format!("{code:?}"), format!("{:?}", ExitCode::SUCCESS));
-        assert!(resizer.calls().is_empty(), "no resize should be applied");
+        assert!(
+            state.calls.lock().unwrap().is_empty(),
+            "no resize should be applied"
+        );
     }
 
     #[cfg(unix)]
@@ -1490,25 +1756,84 @@ mod tests {
         let child = MockChild::new(ExitStatus::with_exit_code(0), 1_000_000);
         let handle = child.handle();
         let signals = MockSignalSource::new([vec![SignalEvent::Resize]]);
-        let resizer = MockResizer {
-            calls: Mutex::new(Vec::new()),
-            fail: true,
-        };
+        let (master, _state) = MockMaster::shared(true, None);
 
         let err = run_pump_session_with_signals(
             child,
-            &resizer,
+            Box::new(master),
             &signals,
             || Some(pty_size(100, 30)),
             quiet_pump(),
             fast_deadlines(),
-        )
-        .expect_err("resize failure must surface");
+        );
+        let err = match err {
+            Ok(_) => panic!("resize failure must surface"),
+            Err(err) => err,
+        };
 
         assert!(matches!(err, Error::Pty(_)), "got {err:?}");
         assert!(
             handle.lock().unwrap().kills >= 1,
             "resize failure must kill the child on unwind"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shutdown_event_returns_deferred_shutdown() {
+        let child = MockChild::new(ExitStatus::with_exit_code(0), 1_000_000);
+        let handle = child.handle();
+        let signals = MockSignalSource::new([vec![SignalEvent::Shutdown]]);
+        let (master, _state) = MockMaster::shared(false, Some(42_042));
+
+        let status = run_pump_session_with_signals(
+            child,
+            Box::new(master),
+            &signals,
+            || Some(pty_size(100, 30)),
+            quiet_pump(),
+            fast_deadlines(),
+        )
+        .expect("shutdown event should defer completion");
+
+        match status {
+            SessionStatus::Exited(code) => {
+                panic!("shutdown event should defer, got immediate exit {code:?}")
+            }
+            SessionStatus::DeferredShutdown(_) => {}
+        }
+        assert_eq!(
+            handle.lock().unwrap().kills,
+            0,
+            "deferred shutdown must not trigger the SIGHUP kill guard on return"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn deferred_shutdown_kills_child_on_completion_error() {
+        let child = MockChild::new(ExitStatus::with_exit_code(0), 1_000_000);
+        let handle = child.handle();
+
+        let err = DeferredShutdown {
+            child,
+            _master: Box::new(DummyMaster),
+            shutdown_target: None,
+            host_to_child: None,
+            child_to_host: None,
+            host_to_child_render_progress: None,
+            h2c_result: None,
+            c2h_result: None,
+            deadlines: fast_deadlines(),
+        }
+        .complete()
+        .expect_err("missing shutdown target must surface");
+
+        assert!(matches!(err, Error::Pty(_)), "got {err:?}");
+        assert_eq!(
+            handle.lock().unwrap().kills,
+            1,
+            "completion failure must still best-effort kill the child on drop"
         );
     }
 
@@ -1529,8 +1854,11 @@ mod tests {
             Box::new(DummyMaster),
             quiet_pump(),
             || Err(io::Error::new(io::ErrorKind::AlreadyExists, "synthetic setup failure").into()),
-        )
-        .expect_err("setup failure must surface");
+        );
+        let err = match err {
+            Ok(_) => panic!("setup failure must surface"),
+            Err(err) => err,
+        };
 
         assert!(
             matches!(&err, Error::Terminal(io_err) if io_err.kind() == io::ErrorKind::AlreadyExists),

--- a/src/signals/mod.rs
+++ b/src/signals/mod.rs
@@ -502,13 +502,11 @@ extern "C" fn handler(sig: libc::c_int) {
 }
 
 #[cfg(test)]
+pub(crate) static TEST_SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    // Singleton install means tests cannot run in parallel.
-    // One mutex serializes any test that touches the guard.
-    static SERIAL: Mutex<()> = Mutex::new(());
 
     /// Test-only injection point: when set to a non-zero signal
     /// number, the next `install_handler` call for that signal
@@ -531,7 +529,7 @@ mod tests {
 
     #[test]
     fn install_and_drain_winch() {
-        let _serial = SERIAL.lock().unwrap();
+        let _serial = TEST_SERIAL.lock().unwrap();
         let guard = SignalGuard::install().expect("install");
         // SAFETY: kill on our own pid with SIGWINCH (default
         // action: ignore) is safe even without a handler.
@@ -558,7 +556,7 @@ mod tests {
         // handler install or decode regression for SIGTERM would
         // otherwise slip past the SIGWINCH-only delivery test
         // and the install-failure injection tests.
-        let _serial = SERIAL.lock().unwrap();
+        let _serial = TEST_SERIAL.lock().unwrap();
         let guard = SignalGuard::install().expect("install");
         // SAFETY: SIGTERM's default action is to terminate, but
         // our handler is installed by `install()` above and
@@ -582,7 +580,7 @@ mod tests {
 
     #[test]
     fn resize_only_install_skips_sigterm_handler_setup() {
-        let _serial = SERIAL.lock().unwrap();
+        let _serial = TEST_SERIAL.lock().unwrap();
         FAIL_INSTALL_FOR.store(libc::SIGTERM, Ordering::Release);
         let guard = SignalGuard::install_resize_only();
         FAIL_INSTALL_FOR.store(0, Ordering::Release);
@@ -604,7 +602,7 @@ mod tests {
 
     #[test]
     fn double_install_is_rejected() {
-        let _serial = SERIAL.lock().unwrap();
+        let _serial = TEST_SERIAL.lock().unwrap();
         let _g = SignalGuard::install().expect("first install");
         let err = SignalGuard::install().expect_err("second install must fail");
         assert!(err.to_string().contains("already installed"), "{err}");
@@ -612,7 +610,7 @@ mod tests {
 
     #[test]
     fn drop_restores_previous_handler() {
-        let _serial = SERIAL.lock().unwrap();
+        let _serial = TEST_SERIAL.lock().unwrap();
         // Install + drop, then verify SIGWINCH no longer writes
         // to a (now-closed) pipe by re-installing and confirming
         // it succeeds -- a stale handler would be using the old
@@ -632,7 +630,7 @@ mod tests {
         // install opens the pipe and caches both ends; every
         // subsequent install in this process must reuse those
         // exact descriptors.
-        let _serial = SERIAL.lock().unwrap();
+        let _serial = TEST_SERIAL.lock().unwrap();
         let (first_r, first_w) = {
             let g = SignalGuard::install().expect("first install");
             (g.read_fd, g.write_fd)
@@ -653,7 +651,7 @@ mod tests {
         // leftovers; otherwise the new session's first `drain`
         // would surface a Resize/Shutdown that no longer maps
         // to anything in this lifetime.
-        let _serial = SERIAL.lock().unwrap();
+        let _serial = TEST_SERIAL.lock().unwrap();
         let cached_w = {
             let g = SignalGuard::install().expect("first install");
             g.write_fd
@@ -691,7 +689,7 @@ mod tests {
         // *new* pipe (or reuse a pre-existing valid cached one)
         // rather than handing the OS-recycled FD numbers to the
         // I/O loop.
-        let _serial = SERIAL.lock().unwrap();
+        let _serial = TEST_SERIAL.lock().unwrap();
         // Drain any cache populated by an earlier test.
         CACHED_READ_FD.store(-1, Ordering::Release);
         CACHED_WRITE_FD.store(-1, Ordering::Release);
@@ -724,7 +722,7 @@ mod tests {
         // succeeded, the pipe must stay open (in-flight handler
         // safety) AND must be cached, so the next install
         // reuses that exact pair instead of leaking another.
-        let _serial = SERIAL.lock().unwrap();
+        let _serial = TEST_SERIAL.lock().unwrap();
         CACHED_READ_FD.store(-1, Ordering::Release);
         CACHED_WRITE_FD.store(-1, Ordering::Release);
 

--- a/tests/pty_e2e.rs
+++ b/tests/pty_e2e.rs
@@ -9,6 +9,7 @@ mod support;
 #[cfg(unix)]
 mod unix {
     use super::support;
+    use rexpect::process::signal::Signal;
     use rexpect::process::wait::WaitStatus;
     use rexpect::session::spawn_command;
     use std::process::Command;
@@ -405,6 +406,31 @@ mod unix {
         assert!(
             remaining.contains("child terminated by signal 15"),
             "expected SIGTERM diagnostic on PTY output, got {remaining:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn q9_wrapper_sigterm_gracefully_terminates_child_and_exits_143(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut command = q9();
+        command.args(["sh", "-c", "printf 'READY\\n'; exec sleep 30"]);
+
+        let mut session = spawn_command(command, Some(TIMEOUT_MS))?;
+        let _ready = session.exp_string("READY")?;
+        session.process.signal(Signal::SIGTERM)?;
+        let remaining = session.exp_eof()?;
+
+        match session.process.wait()? {
+            WaitStatus::Exited(_, 143) => {}
+            other => {
+                panic!("expected q9 to exit 143 after wrapper SIGTERM, got {other:?}")
+            }
+        }
+
+        assert!(
+            remaining.contains("child terminated by signal 15"),
+            "expected wrapper SIGTERM path to surface SIGTERM diagnostic, got {remaining:?}"
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary
- detect SIGTERM self-pipe events in the Unix PTY supervisor and return a deferred shutdown outcome instead of treating wrapper shutdown like an in-band child exit
- drop `RawGuard` before forwarding SIGTERM to the PTY child process group, then reuse the existing bounded wait and forwarder-drain logic for the final exit mapping
- add unit coverage for deferred shutdown routing and error-path cleanup, plus a PTY E2E that sends SIGTERM to `q9` itself and expects exit 143

Closes #60

## Follow-up
- #62 will validate host terminal raw-mode restoration end-to-end at the terminal boundary.

## Background
- `portable-pty`'s Unix `ChildKiller` sends `SIGHUP`, so the normal shutdown path now targets the PTY process group explicitly and keeps the existing kill-on-drop guard only as an error-path cleanup backstop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured terminal raw-mode is released before running deferred shutdown actions, preventing cleanup from running while raw mode is held.
  * Improved SIGTERM handling and shutdown semantics so wrapper exits and reports termination status more reliably.
  * Enhanced post-exit drain and process-group signaling on Unix to treat already-dead targets gracefully.

* **Tests**
  * Added Unix PTY e2e test for SIGTERM behavior and unit tests for deferred-shutdown semantics and signal-guard serialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/qorrection/pull/136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->