### PR TITLE
test(signals): cover sigwinch forwarding in rexpect e2e

### DIFF
--- a/tests/pty_e2e.rs
+++ b/tests/pty_e2e.rs
@@ -25,6 +25,9 @@ mod unix {
     const BANG_CARS: usize = 9;
     const PARADE_MIN_VISIBLE_LABELS: usize = 3;
     const LONG_ANIMATION_COLS: u16 = 120;
+    const SIGWINCH_HOST_COLS: u16 = 120;
+    const SIGWINCH_CHILD_COLS: u16 = 80;
+    const SIGWINCH_CHILD_ROWS: u16 = 20;
     const PTY_ROWS: u16 = 24;
 
     fn q9() -> Command {
@@ -433,6 +436,47 @@ mod unix {
             "expected wrapper SIGTERM path to surface SIGTERM diagnostic, got {remaining:?}"
         );
         Ok(())
+    }
+
+    /// Issue #61 E2E coverage: when the wrapper receives
+    /// SIGWINCH, it must resize the child PTY back to the outer
+    /// host width and forward the signal so the child trap can
+    /// observe the restored terminal size.
+    #[test]
+    fn q9_wrapper_sigwinch_resizes_child_and_forwards_winch(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut command = q9_with_tty_size(SIGWINCH_HOST_COLS, PTY_ROWS);
+        let script = format!(
+            "stty cols {SIGWINCH_CHILD_COLS} rows {SIGWINCH_CHILD_ROWS}\n\
+             trap 'printf \"WINCH:%s:%s\\\\n\" \"$(tput cols)\" \"$(tput lines)\"; exit 0' WINCH\n\
+             printf 'READY:%s:%s\\\\n' \"$(tput cols)\" \"$(tput lines)\"\n\
+             while IFS= read -r line; do\n\
+               case \"$line\" in\n\
+                 print) printf 'NOW:%s:%s\\\\n' \"$(tput cols)\" \"$(tput lines)\" ;;\n\
+               esac\n\
+             done\n"
+        );
+        command.env("TERM", "xterm").arg("sh").arg("-c").arg(script);
+
+        let mut session = spawn_command(command, Some(TIMEOUT_MS))?;
+        let ready_marker = format!("READY:{SIGWINCH_CHILD_COLS}:{SIGWINCH_CHILD_ROWS}");
+        session.exp_string(&ready_marker)?;
+
+        session.send_line("print")?;
+        let before_signal = format!("NOW:{SIGWINCH_CHILD_COLS}:{SIGWINCH_CHILD_ROWS}");
+        session.exp_string(&before_signal)?;
+
+        session.process.signal(Signal::SIGWINCH)?;
+        let forwarded = format!("WINCH:{SIGWINCH_HOST_COLS}:{PTY_ROWS}");
+        session.exp_string(&forwarded)?;
+
+        let _remaining = session.exp_eof()?;
+        match session.process.wait()? {
+            WaitStatus::Exited(_, 0) => Ok(()),
+            other => {
+                panic!("expected q9 to exit 0 after forwarded SIGWINCH coverage, got {other:?}")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add a Unix `rexpect` E2E that shrinks the child PTY away from the host size before signaling
- assert the child observes both columns and rows before and after a forwarded `SIGWINCH`
- keep the resize setup portable on Linux and macOS by changing the `rexpect` shell TTY size from inside the shell

Closes #61

## Follow-up
- none

## Background
- the test intentionally shrinks the child PTY first so a synthetic `SIGWINCH` has an observable resize to restore, without relying on direct `TIOCSWINSZ` calls against `rexpect`'s master FD on hosted macOS runners

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test to validate proper handling of terminal window resize signals and dimension restoration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/qorrection/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->