### PR TITLE
feat(signals): Windows resize via 250ms poll (#63)

### DIFF
--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -47,6 +47,8 @@ mod pump;
 mod session;
 mod size;
 mod spawn;
+#[cfg(windows)]
+mod winsize;
 
 use std::ffi::OsString;
 use std::process::{Command, ExitCode};

--- a/src/pty/session.rs
+++ b/src/pty/session.rs
@@ -68,15 +68,17 @@ use std::process::ExitCode;
 use std::time::{Duration, Instant};
 
 use portable_pty::{ChildKiller, ExitStatus};
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use portable_pty::{MasterPty, PtySize};
 
 use crate::pty::exit::map_exit_status;
 use crate::pty::forward::{Direction, ForwarderExit, ForwarderHandle};
 use crate::pty::pump::IoPump;
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use crate::pty::size;
 use crate::pty::spawn::SpawnedSession;
+#[cfg(windows)]
+use crate::pty::winsize::WindowsResizePoller;
 #[cfg(unix)]
 use crate::signals::{Event as SignalEvent, SignalGuard};
 use crate::trigger::input::SharedRenderProgress;
@@ -377,12 +379,51 @@ pub(crate) fn run_pump_session(session: SpawnedSession, pump: IoPump) -> Result<
     {
         run_pump_session_unix(child, master, pump)
     }
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    {
+        let code = run_pump_session_windows(child, master, pump)?;
+        Ok(SessionStatus::Exited(code))
+    }
+    #[cfg(all(not(unix), not(windows)))]
     {
         let child = PtyChild { child };
         let _master = master;
         let code = run_pump_session_with(child, pump, Deadlines::production())?;
         Ok(SessionStatus::Exited(code))
+    }
+}
+
+/// Windows session variant: forwards PTY resize events detected
+/// by a 250ms polling thread to the child PTY master.
+///
+/// No shutdown-signal source exists on Windows, so the session
+/// supervisor always exits via the normal child-wait path.
+#[cfg(windows)]
+fn run_pump_session_windows(
+    child: Box<dyn portable_pty::Child + Send + Sync>,
+    master: Box<dyn MasterPty + Send>,
+    pump: IoPump,
+) -> Result<ExitCode> {
+    let child = PtyChild { child };
+    let poller = WindowsResizePoller::start();
+    match run_pump_session_inner(child, pump, Deadlines::production(), || {
+        if poller.take_resize() {
+            if let Some(sz) = size::current_size() {
+                master
+                    .resize(sz)
+                    .map_err(|e| Error::Pty(e.context("apply Windows resize poll")))?;
+            } else {
+                tracing::debug!(
+                    "supervisor: skipping Windows resize poll because host size was unavailable"
+                );
+            }
+        }
+        Ok(TickAction::Continue)
+    })? {
+        SupervisorOutcome::Exited(code) => Ok(code),
+        SupervisorOutcome::Shutdown(_) => {
+            unreachable!("Windows on_tick never returns Shutdown")
+        }
     }
 }
 

--- a/src/pty/winsize.rs
+++ b/src/pty/winsize.rs
@@ -1,0 +1,111 @@
+//! Windows PTY resize poller.
+//!
+//! On Windows there is no `SIGWINCH`. This module polls
+//! `crossterm::terminal::size()` every 250 ms and sets an
+//! atomic flag when the terminal dimensions change. The session
+//! supervisor reads the flag on each tick and forwards a resize
+//! to the child PTY when set.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Polls the terminal size every 250 ms on a background thread
+/// and signals the caller via an atomic flag when the size changes.
+///
+/// The flag is edge-triggered: [`take_resize`] returns `true`
+/// once after each size change and then clears until the next.
+///
+/// Drop stops the background thread within one poll interval.
+///
+/// [`take_resize`]: WindowsResizePoller::take_resize
+pub(crate) struct WindowsResizePoller {
+    resized: Arc<AtomicBool>,
+    stop: Arc<AtomicBool>,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl WindowsResizePoller {
+    const POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+    /// Start the background polling thread.
+    pub(crate) fn start() -> Self {
+        let resized = Arc::new(AtomicBool::new(false));
+        let stop = Arc::new(AtomicBool::new(false));
+        let resized_t = Arc::clone(&resized);
+        let stop_t = Arc::clone(&stop);
+
+        let thread = std::thread::spawn(move || {
+            let mut last = crossterm::terminal::size().ok();
+            while !stop_t.load(Ordering::Acquire) {
+                std::thread::sleep(Self::POLL_INTERVAL);
+                if stop_t.load(Ordering::Acquire) {
+                    break;
+                }
+                let now = crossterm::terminal::size().ok();
+                if now != last {
+                    last = now;
+                    resized_t.store(true, Ordering::Release);
+                }
+            }
+        });
+
+        Self {
+            resized,
+            stop,
+            thread: Some(thread),
+        }
+    }
+
+    /// Returns `true` if the terminal was resized since the last
+    /// call. Atomically clears the flag so each resize fires once.
+    pub(crate) fn take_resize(&self) -> bool {
+        self.resized.swap(false, Ordering::AcqRel)
+    }
+}
+
+impl Drop for WindowsResizePoller {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Release);
+        // Detach — the thread observes the stop flag within one
+        // poll interval and exits cleanly without a join.
+        if let Some(t) = self.thread.take() {
+            drop(t);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    #[test]
+    fn starts_without_pending_resize() {
+        let poller = WindowsResizePoller::start();
+        assert!(
+            !poller.take_resize(),
+            "no resize expected immediately after construction"
+        );
+    }
+
+    #[test]
+    fn take_resize_clears_flag() {
+        let poller = WindowsResizePoller::start();
+        poller.resized.store(true, Ordering::Release);
+        assert!(poller.take_resize(), "flag should be set");
+        assert!(!poller.take_resize(), "flag should clear after take");
+    }
+
+    #[test]
+    fn drops_within_poll_interval() {
+        let start = Instant::now();
+        let poller = WindowsResizePoller::start();
+        drop(poller);
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "drop should not block: {:?}",
+            start.elapsed()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `src/pty/winsize.rs` (`#[cfg(windows)]`): `WindowsResizePoller` starts a background thread that polls `crossterm::terminal::size()` every 250 ms and sets an atomic edge-triggered flag on size change.
- Wires the poller into a new `run_pump_session_windows()` function whose `on_tick` closure reads the flag and forwards the new size to the child PTY via `master.resize()`.
- Routes `run_pump_session` on Windows to `run_pump_session_windows`; the original `#[cfg(not(unix))]` fallback is preserved for other non-Unix targets via `#[cfg(all(not(unix), not(windows)))]`.

## Background

On Unix, `SIGWINCH` is captured by the self-pipe in `src/signals/mod.rs` and forwarded to the session supervisor. No equivalent signal exists on Windows; the previous Windows path silently discarded `master` and never forwarded resize events. This PR implements the 250 ms poll alternative documented in the signals module comment.

## Non-goals

- No Windows CI job is added here (tracked by #64 and #65).
- No shutdown-event source for Windows (SIGTERM-equivalent); the Windows path has no deferred-shutdown path.

## Test plan

- [x] `cargo fmt --check` passes on Linux
- [x] `cargo clippy --all-targets -- -D warnings` passes on Linux
- [x] `cargo test --all-targets --all-features` passes on Linux
- [ ] Windows CI: `winsize` unit tests (`starts_without_pending_resize`, `take_resize_clears_flag`, `drops_within_poll_interval`) pass
- [ ] Windows CI: full test suite compiles and passes

Closes #63

🤖 Generated with [Claude Code](https://claude.ai/claude-code)