### PR TITLE
docs(test): document Windows PTY E2E ignore policy (#64)

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -50,13 +50,26 @@ a real pseudo-terminal:
 - Confirming raw mode is restored on cooperative SIGTERM.
 - Confirming SIGWINCH forwarding reaches the child PTY.
 
-**Windows policy (v0.1):** all PTY E2E tests are `#[ignore]` on
+**Windows policy (v0.1):** all PTY E2E tests are skipped on
 Windows. ConPTY behavior diverges from Unix PTYs in ways that
 demand a separate harness (no `rexpect` equivalent that we trust
 yet), and the v0.1 surface for Windows is best-effort polling
 (see plan §6 D-RESIZE). Snapshot + unit tests still run on
-Windows. Each ignored test must carry a doc comment with a
-tracking issue link so the ignore is auditable.
+Windows.
+
+Two skip mechanisms are in use; choose the one that fits the
+test's compilation constraints:
+
+- `#[cfg_attr(windows, ignore = "reason; tracking issue URL")]` —
+  use this when the test body can compile on Windows but should
+  not run. Every ignored test must carry the tracking issue URL
+  so the skip is auditable. See `tests/pty_smoke.rs` for an
+  example (tracking issue [#84](https://github.com/kurone-kito/qorrection/issues/84)).
+- `#[cfg(unix)]` — use this when the test body uses a Unix-only
+  dev-dependency (e.g. `rexpect`) that cannot compile on Windows.
+  The `pty_e2e.rs` module is excluded this way; see its module
+  comment for the rationale and tracking reference
+  ([#64](https://github.com/kurone-kito/qorrection/issues/64)).
 
 Mark a Unix test `#[ignore]` only if it is truly flaky in CI;
 document the reason in a doc comment above the test. Always

--- a/tests/pty_e2e.rs
+++ b/tests/pty_e2e.rs
@@ -3,6 +3,18 @@
 //! The real wrapper path only activates when both stdio streams
 //! are TTYs. `rexpect` gives the subprocess that environment, so
 //! these tests cover behavior that `assert_cmd` cannot observe.
+//!
+//! ## Windows policy (v0.1)
+//!
+//! All tests in this file are gated with `#[cfg(unix)]` rather
+//! than `#[cfg_attr(not(unix), ignore)]`. The distinction is
+//! intentional: `rexpect` is a Unix-only dev-dependency (see
+//! `[target.'cfg(unix)'.dev-dependencies]` in `Cargo.toml`), so
+//! the rexpect-based test bodies cannot compile on Windows at all.
+//! Using `#[cfg(unix)]` correctly excludes them from the Windows
+//! build rather than compiling them into ignored stubs.
+//!
+//! Tracking: <https://github.com/kurone-kito/qorrection/issues/64>
 
 mod support;
 


### PR DESCRIPTION
## Summary

- Adds a module-level comment to `tests/pty_e2e.rs` explaining why `#[cfg(unix)]` is used instead of `#[cfg_attr(not(unix), ignore)]`, with a tracking issue link (#64).
- Updates `docs/testing.md` to clearly distinguish the two skip mechanisms for Windows: `#[cfg_attr(windows, ignore)]` for tests that can compile on Windows, and `#[cfg(unix)]` for tests using Unix-only dev-dependencies like `rexpect`.

## Rationale

The `rexpect` crate is a `[target.'cfg(unix)'.dev-dependencies]` entry, so rexpect-based test bodies cannot compile on Windows at all. Using `#[cfg(unix)]` to exclude these tests is the correct mechanism, while `#[ignore]` is the right approach for tests that can compile but should not run (e.g. `tests/pty_smoke.rs`, which uses `portable-pty` available on all platforms).

Both mechanisms are documented with tracking issue references to make the skips auditable per the `docs/testing.md` policy.

Closes #64

🤖 Generated with [Claude Code](https://claude.ai/claude-code)