### PR TITLE
docs(readme): rewrite status and roadmap for v0.1.0 (#72)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,23 +9,20 @@
 > *other* CLI tools and answers them with a passing ambulance —
 > because experienced engineers reflexively type `:q` everywhere.
 
-`qorrection` (alias **`q9`** — *kyuukyuu*, the ambulance) is
-designed to wrap an arbitrary interactive command in a
-pseudo-terminal, watch what you type, and intercept Vim-style
-quit sequences (`:q`, `:wq`, `:q!`). Instead of being silently
-ignored by the wrapped program, those keystrokes will trigger a
-small ASCII-art ambulance animation sweeping across the screen,
-in the same spirit as the classic `sl` command. The wrap itself
-is not yet implemented (see [Status](#status)).
+`qorrection` (alias **`q9`** — *kyuukyuu*, the ambulance) wraps
+an arbitrary interactive command in a pseudo-terminal, watches
+what you type, and intercepts Vim-style quit sequences
+(`:q`, `:wq`, `:q!`). Instead of being silently ignored by the
+wrapped program, those keystrokes trigger a small ASCII-art
+ambulance animation sweeping across the screen, in the same
+spirit as the classic `sl` command.
 
 ## Status
 
-🚧 In progress. The CLI surface, usage screen, and version
-output are wired and tested end-to-end, but the PTY wrap itself
-still prints `qorrection: PTY wrap pending` (exit code 2)
-instead of running the child. Trigger detection lives as a
-standalone, unit-tested parser module; it does not yet observe
-real input. See [the roadmap](#roadmap) for what comes next.
+✅ v0.1.0 — The PTY wrapper, trigger detection, ambulance
+animation, and signal handling are fully implemented and
+cross-platform tested (Linux, macOS, Windows ConPTY). See
+[the roadmap](#roadmap) for what's in scope and what comes next.
 
 ## Why
 
@@ -36,9 +33,6 @@ turns that muscle-memory mistake into a small joke moment without
 changing the wrapped program at all.
 
 ## Install
-
-> Releases will appear once the wrapper ships its first working
-> version. Until then, install from source.
 
 ```sh
 # From source (requires a recent stable Rust toolchain)
@@ -55,17 +49,14 @@ Planned distribution channels:
 ## Usage
 
 ```sh
-# Once PTY plumbing lands, both `qorrection` and `q9` will wrap
-# any interactive command. Today these invocations enter the
-# wrap stub and exit with `qorrection: PTY wrap pending`.
 q9 copilot
 q9 claude
 ```
 
-Anything after the wrapped command's name is parsed as child
-arguments and will be forwarded verbatim — including flags — once
-PTY plumbing lands. With that in place, `q9 claude --help` will
-run `claude --help`; it will not show qorrection's own help.
+Anything after the wrapped command's name is forwarded verbatim
+as child arguments — including flags. For example,
+`q9 claude --help` runs `claude --help`; it does not show
+qorrection's own help.
 
 ### CLI surface
 
@@ -77,10 +68,6 @@ The v0.1 surface is intentionally minimal:
 | `q9 -h` / `q9 --help`    | Show the usage screen             |
 | `q9 -V` / `q9 --version` | Print `qorrection X.Y.Z` and exit |
 | `q9 <cmd> [args...]`     | Enter the wrap path (see below)   |
-
-The wrap path is the only entry that is not yet fully wired: it
-currently prints `qorrection: PTY wrap pending` on stderr and
-exits with code 2 until the PTY plumbing milestone lands.
 
 There are no other flags. Any unrecognized leading `-…` token
 (including the bare `--` separator) is rejected on stderr as
@@ -94,14 +81,13 @@ Detailed trigger edge policies, including bracketed paste, live in
 
 ### Triggers (locked policy)
 
-Once PTY plumbing lands, trigger interception will be active
-only when the wrapped command is one of the known AI coding
-agents: `copilot`, `codex`, `claude`, `aichat`, `gemini`,
-`qwen`, `ollama`. Matching is by command basename,
-case-insensitive, with `.exe` / `.cmd` / `.bat` stripped — so
-`/usr/bin/Claude` and `claude.exe` both arm. For any other
-command the wrapper will pass keystrokes through untouched, so
-editors such as Vim keep owning `:q`.
+Trigger interception is active only when the wrapped command is
+one of the known AI coding agents: `copilot`, `codex`, `claude`,
+`aichat`, `gemini`, `qwen`, `ollama`. Matching is by command
+basename, case-insensitive, with `.exe` / `.cmd` / `.bat`
+stripped — so `/usr/bin/Claude` and `claude.exe` both arm. For
+any other command the wrapper passes keystrokes through
+untouched, so editors such as Vim keep owning `:q`.
 
 | Trigger | Gag                                                          |
 | ------- | ------------------------------------------------------------ |
@@ -111,11 +97,11 @@ editors such as Vim keep owning `:q`.
 
 ## Roadmap
 
-1. PTY plumbing with `portable-pty` (Linux, macOS, Windows ConPTY)
-2. Trigger detection for `:q`, `:wq`, `:q!` (parser already landed;
-   wiring it to the live PTY input stream comes with PTY plumbing)
-3. Ambulance animation renderer (`crossterm`)
-4. Release pipeline (GitHub Releases + crates.io)
+- [x] PTY plumbing with `portable-pty` (Linux, macOS, Windows ConPTY)
+- [x] Trigger detection for `:q`, `:wq`, `:q!`
+- [x] Ambulance animation renderer (`crossterm`)
+- [x] Signal handling: SIGWINCH forwarding, SIGTERM graceful shutdown
+- [ ] Release pipeline (GitHub Releases + crates.io)
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- Removes all `PTY wrap pending` references from the README.
- Updates the **Status** section to reflect the fully implemented v0.1.0 feature set.
- Rewrites the **Roadmap** from a numbered list to a completed-items checklist.
- Updates the **Usage** section and **Triggers** section to present tense.

## Test plan

- [ ] README renders correctly on GitHub (no stale "pending" text).
- [ ] All CI checks pass (no Rust changes).

Closes #72

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to reflect completed v0.1 implementation status, including PTY wrapping, trigger detection, animation rendering, and signal handling features
  * Simplified usage examples with clearer command syntax and clarified that all arguments after the command name are forwarded verbatim to the child process
  * Converted roadmap from numbered to checkbox list format, marking implemented features as completed

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/qorrection/pull/145?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->