### PR TITLE
ci(test): surface insta snapshot diffs on failure (#70)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,4 +104,24 @@ jobs:
         # `--all-features` matches the surface that fmt/clippy/deny
         # exercise, so feature-gated code cannot pass lint while
         # remaining untested.
+        # INSTA_UPDATE=no is insta's default when CI=true, but set it
+        # explicitly so intent is visible in the workflow log.
+        env:
+          INSTA_UPDATE: "no"
         run: cargo test --locked --verbose --all-targets --all-features
+      - name: Show pending snapshot diffs
+        if: failure()
+        shell: bash
+        run: |
+          find . -path '*/snapshots/*.snap.new' | while IFS= read -r f; do
+            echo "=== $f ==="
+            cat "$f"
+            echo ""
+          done
+      - name: Upload pending snapshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pending-snapshots-${{ matrix.os }}
+          path: "**/*.snap.new"
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

- Sets `INSTA_UPDATE: "no"` explicitly on the `cargo test` step (matches insta's CI-mode default; makes intent visible in the log).
- Adds "Show pending snapshot diffs" step (`if: failure`, `shell: bash`): finds `*.snap.new` files in snapshot directories and prints them to the CI log so reviewers can see what changed inline.
- Adds "Upload pending snapshots" step (`if: failure`, `upload-artifact@v4`): uploads pending snapshots as per-OS artifacts for local review with `cargo insta review`.

No code logic changes; CI-only.

Closes #70

🤖 Generated with [Claude Code](https://claude.ai/claude-code)