### PR TITLE
ci: add cargo install --path . smoke test (#80)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,20 @@ jobs:
       - name: cargo check on MSRV
         run: cargo +${{ steps.msrv.outputs.version }} check --locked --all-targets --all-features
 
+  install-smoke:
+    name: Install smoke (cargo install --path .)
+    needs: [fmt, clippy, deny]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo install --path .
+        run: cargo install --path . --locked
+      - name: q9 -V
+        run: q9 -V
+
   test:
     name: Test (${{ matrix.os }})
     needs: [fmt, clippy, deny]


### PR DESCRIPTION
## Summary

- Adds an `install-smoke` CI job to `ci.yml` that runs `cargo install --path . --locked` on `ubuntu-latest`.
- Verifies `q9 -V` exits successfully after installation.
- Runs in parallel with the `test` matrix, gated on the same `[fmt, clippy, deny]` checks.

## Test plan

- [ ] CI `install-smoke` job passes on this PR.
- [ ] `q9 -V` prints the installed version with exit code 0.

Closes #80

🤖 Generated with [Claude Code](https://claude.ai/claude-code)