### PR TITLE
ci: add cargo publish --dry-run gate (#79)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,18 @@ jobs:
       - name: cargo test (PTY E2E, unix only)
         run: cargo test --locked --verbose --test pty_e2e
 
+  publish-dry-run:
+    name: Publish dry-run (cargo publish --dry-run)
+    needs: [fmt, clippy, deny]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo publish --dry-run
+        run: cargo publish --dry-run --locked
+
   test:
     name: Test (${{ matrix.os }})
     needs: [fmt, clippy, deny]


### PR DESCRIPTION
## Summary

- Adds a `publish-dry-run` CI job to `ci.yml` that runs `cargo publish --dry-run` on `ubuntu-latest`.
- Verifies package metadata, `include` paths, and publish configuration before any crates.io release.
- Runs in parallel with the `test` matrix and `install-smoke`, gated on the same `[fmt, clippy, deny]` checks.

## Test plan

- [ ] CI `publish-dry-run` job passes on this PR.
- [ ] `cargo publish --dry-run` exits with code 0.

Closes #79

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline with automated verification step to validate release readiness before deployment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/qorrection/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->