### PR TITLE
ci: add pty-e2e matrix job for linux and macos (#69)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,22 @@ jobs:
       - name: q9 -V
         run: q9 -V
 
+  pty-e2e:
+    name: PTY E2E (${{ matrix.os }})
+    needs: [fmt, clippy, deny]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo test (PTY E2E, unix only)
+        run: cargo test --locked --verbose --test pty_e2e
+
   test:
     name: Test (${{ matrix.os }})
     needs: [fmt, clippy, deny]


### PR DESCRIPTION
## Summary

- Adds a `pty-e2e` CI job that runs `cargo test --locked --verbose --test pty_e2e` on `ubuntu-latest` and `macos-latest`.
- Windows is intentionally excluded because `rexpect` is a Unix-only dev-dependency and the test bodies are gated with `#[cfg(unix)]`.
- Windows PTY smoke coverage is maintained by the existing `test` matrix job.
- Runs in parallel with the other jobs, gated on `[fmt, clippy, deny]`.

## Test plan

- [ ] CI `PTY E2E (ubuntu-latest)` job passes.
- [ ] CI `PTY E2E (macos-latest)` job passes.
- [ ] All existing tests still pass in the `test` matrix.

Closes #69

🤖 Generated with [Claude Code](https://claude.ai/claude-code)