### PR TITLE
docs(readme): add demo section placeholder for usage GIF (#73)

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -44,6 +44,7 @@ words:
   # partial frame text can include these truncated word tails.
   - agen
   - aichat
+  - asciinema
   - clau
   - claudex
   - clauder

--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ animation, and signal handling are fully implemented and
 cross-platform tested (Linux, macOS, Windows ConPTY). See
 [the roadmap](#roadmap) for what's in scope and what comes next.
 
+## Demo
+
+<!-- Replace with an animated GIF or asciinema embed once recorded.
+     Suggested recording: `q9 claude` session → type `:q` → ambulance sweeps. -->
+
+*Screencast coming soon.*
+
 ## Why
 
 Modern AI coding agents (GitHub Copilot CLI, Claude Code, Codex


### PR DESCRIPTION
## Summary

- Adds a **Demo** section between Status and Why in the README.
- Contains an HTML comment describing the intended recording (`q9 claude` + `:q` → ambulance).
- Placeholder text (`Screencast coming soon.`) will be replaced with an animated GIF or asciinema embed once recorded.

## Test plan

- [ ] README renders correctly on GitHub with the new Demo section.
- [ ] All CI checks pass (no Rust changes).

Closes #73

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * README now includes a Demo section with a placeholder indicating an upcoming screencast.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/qorrection/pull/151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->