### PR TITLE
docs(testing): document release build verification procedure (#76)

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -154,6 +154,31 @@ cargo test --tests                # integration + E2E
 cargo insta review                # review pending snapshots
 ```
 
+## Release build verification
+
+Before every release, trigger the `release.yml` workflow via
+`workflow_dispatch` to verify all five cross-compilation targets
+build successfully and produce artifacts:
+
+```sh
+gh workflow run release.yml --ref main
+```
+
+When run without a tag, the `verify-tag` job is skipped and the
+`build` matrix still runs, producing archives for all five targets:
+
+| Target                     | Platform      | Archive |
+| -------------------------- | ------------- | ------- |
+| `x86_64-unknown-linux-musl` | Linux x64    | tar.gz  |
+| `aarch64-unknown-linux-musl` | Linux arm64 | tar.gz  |
+| `x86_64-apple-darwin`       | macOS x64    | tar.gz  |
+| `aarch64-apple-darwin`      | macOS arm64  | tar.gz  |
+| `x86_64-pc-windows-msvc`    | Windows x64  | zip     |
+
+Artifacts are uploaded to the workflow run and available for 90 days.
+The `publish` job (GitHub Release creation) is gated on the tag path
+and does not run on `workflow_dispatch`.
+
 ## Adding a test
 
 1. Pick the lowest layer that can express the behavior. Pure


### PR DESCRIPTION
## Summary

- Adds a **Release build verification** section to `docs/testing.md`.
- Documents how to trigger `release.yml` via `workflow_dispatch` for a tagless dry-run.
- Lists all five cross-compilation targets and their archive formats.

## Evidence

Release workflow dry-run: https://github.com/kurone-kito/qorrection/actions/runs/25987147039

The `build` matrix runs for all 5 targets; the `publish` job is skipped (requires a tag).

## Test plan

- [ ] Release workflow run completes successfully (all 5 build targets pass).
- [ ] Artifacts are uploaded to the workflow run.
- [ ] All CI checks pass on this PR.

Closes #76

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added release build verification documentation describing the manual triggering process for release builds
* Documented cross-compilation targets and resulting archive formats
* Included information about artifact retention policies
* Clarified conditions for when publishing occurs during release workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/qorrection/pull/153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->