### PR TITLE
docs(readme): update install section for v0.1.0 release (#77)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,27 @@ changing the wrapped program at all.
 
 ## Install
 
+Download a self-contained binary from the
+[GitHub Releases page][releases] — no Rust toolchain required.
+Archives are available for:
+
+- Linux x86_64 and aarch64 (statically linked musl)
+- macOS x86_64 and Apple Silicon
+- Windows x86_64
+
+Extract the archive, then copy `q9` (or `q9.exe`) to a directory
+on your `PATH`.
+
+To build from source instead:
+
 ```sh
-# From source (requires a recent stable Rust toolchain)
 cargo install --git https://github.com/kurone-kito/qorrection
 ```
 
-Planned distribution channels:
+`cargo install qorrection` via [crates.io][crates] is coming soon.
 
-- GitHub Releases (self-contained `qorrection` and `q9` binaries
-  for Linux, macOS, Windows)
-- `cargo install qorrection` (crates.io)
-- Homebrew tap (future)
+[releases]: https://github.com/kurone-kito/qorrection/releases/latest
+[crates]: https://crates.io/crates/qorrection
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ on your `PATH`.
 To build from source instead:
 
 ```sh
-cargo install --git https://github.com/kurone-kito/qorrection
+cargo install --git https://github.com/kurone-kito/qorrection --tag v0.1.0
 ```
 
 `cargo install qorrection` via [crates.io][crates] is coming soon.


### PR DESCRIPTION
## Summary

- Replaces the "Planned distribution channels" list in README.md with actual
  install instructions pointing to the GitHub Releases page.
- Lists binary archives for all five targets (Linux x64/arm64, macOS x64/arm64, Windows x64).
- Adds `cargo install qorrection` via crates.io as "coming soon".
- After this PR merges, `git tag v0.1.0 && git push origin v0.1.0` will trigger
  the release workflow to publish the GitHub Release.

## Test plan

- [ ] CI checks pass.
- [ ] README Install section renders correctly on GitHub.
- [ ] After merge: tag `v0.1.0` is pushed and `release.yml` publishes GitHub Release with all 5 target binaries.

Closes #77

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions with clearer guidance on downloading prebuilt binaries from GitHub Releases for various operating systems and architectures.
  * Added information about upcoming `cargo install` availability via crates.io.
  * Included simplified setup instructions for adding the executable to system PATH.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/qorrection/pull/155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->