### PR TITLE
feat(anim): wire oversized :wq scene into renderer for ≥ 160-col terminals

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -76,3 +76,13 @@ words:
   - ueue
   - xclaude
   - xcopilot
+  # Oversized :wq snapshot right-edge clips (anim-large-art-contract path).
+  - aceful
+  - apot
+  - enqu
+  - eued
+  - gracefu
+  - initiati
+  - momen
+  - nstance
+  - processi

--- a/src/anim/render.rs
+++ b/src/anim/render.rs
@@ -30,6 +30,7 @@ pub(crate) enum PlanKind {
     TinyBang,
     Q,
     Wq,
+    WqOversized,
     Bang,
 }
 
@@ -84,12 +85,15 @@ where
 ///
 /// Degrade policy is centralized here so boundary tests can pin it:
 ///
-/// - `< 40` columns → one-line trigger-specific fallback gag
-/// - `40..=79`      → tiny ambulance, except `:q!` keeps a tiny parade
-/// - `80..=119`     → standard `:q` scene; `:wq` degrades here because
+/// - `< 40` columns    → one-line trigger-specific fallback gag
+/// - `40..=79`         → tiny ambulance, except `:q!` keeps a tiny parade
+/// - `80..=119`        → standard `:q` scene; `:wq` degrades here because
 ///   the big 418-labeled asset does not fit
-/// - `>= 120`       → `:wq` upgrades to the big labeled scene, `:q!`
+/// - `120..=159`       → `:wq` upgrades to the big labeled scene, `:q!`
 ///   keeps the parade, `:q` stays on the standard car
+/// - `>= 160`          → `:wq` uses the oversized locomotive scene per
+///   `docs/anim-large-art-contract.md`; `:q` and `:q!` stay on their
+///   large-bucket scenes unchanged
 pub(crate) fn render_plan(outcome: Outcome, cols: u16) -> Option<RenderPlan> {
     let b = bucket(cols);
     match outcome {
@@ -100,7 +104,7 @@ pub(crate) fn render_plan(outcome: Outcome, cols: u16) -> Option<RenderPlan> {
                 kind: PlanKind::Tiny,
                 frames: scene::tiny(cols),
             },
-            WidthBucket::Medium | WidthBucket::Large => RenderPlan {
+            WidthBucket::Medium | WidthBucket::Large | WidthBucket::Oversized => RenderPlan {
                 kind: PlanKind::Q,
                 frames: scene::q(cols),
             },
@@ -119,6 +123,10 @@ pub(crate) fn render_plan(outcome: Outcome, cols: u16) -> Option<RenderPlan> {
                 kind: PlanKind::Wq,
                 frames: scene::wq(cols),
             },
+            WidthBucket::Oversized => RenderPlan {
+                kind: PlanKind::WqOversized,
+                frames: scene::wq_oversized(cols),
+            },
         }),
         Outcome::QBang => Some(match b {
             WidthBucket::Tiny => fallback_plan(fallback::Trigger::Bang),
@@ -126,7 +134,7 @@ pub(crate) fn render_plan(outcome: Outcome, cols: u16) -> Option<RenderPlan> {
                 kind: PlanKind::TinyBang,
                 frames: scene::tiny_bang(cols),
             },
-            WidthBucket::Medium | WidthBucket::Large => RenderPlan {
+            WidthBucket::Medium | WidthBucket::Large | WidthBucket::Oversized => RenderPlan {
                 kind: PlanKind::Bang,
                 frames: scene::bang(cols),
             },
@@ -141,18 +149,23 @@ pub(crate) fn render_frame_count(outcome: Outcome, cols: u16) -> Option<usize> {
         Outcome::Q => Some(match b {
             WidthBucket::Tiny => 1,
             WidthBucket::Small => scene::tiny_frame_count(cols),
-            WidthBucket::Medium | WidthBucket::Large => scene::q_frame_count(cols),
+            WidthBucket::Medium | WidthBucket::Large | WidthBucket::Oversized => {
+                scene::q_frame_count(cols)
+            }
         }),
         Outcome::Wq => Some(match b {
             WidthBucket::Tiny => 1,
             WidthBucket::Small => scene::tiny_frame_count(cols),
             WidthBucket::Medium => scene::q_frame_count(cols),
             WidthBucket::Large => scene::wq_frame_count(cols),
+            WidthBucket::Oversized => scene::wq_oversized_frame_count(cols),
         }),
         Outcome::QBang => Some(match b {
             WidthBucket::Tiny => 1,
             WidthBucket::Small => scene::tiny_bang_frame_count(cols),
-            WidthBucket::Medium | WidthBucket::Large => scene::bang_frame_count(cols),
+            WidthBucket::Medium | WidthBucket::Large | WidthBucket::Oversized => {
+                scene::bang_frame_count(cols)
+            }
         }),
     }
 }
@@ -219,14 +232,18 @@ mod tests {
             (Outcome::Q, 40),
             (Outcome::Q, 80),
             (Outcome::Q, 120),
+            (Outcome::Q, 160),
             (Outcome::Wq, 0),
             (Outcome::Wq, 40),
             (Outcome::Wq, 119),
             (Outcome::Wq, 120),
+            (Outcome::Wq, 159),
+            (Outcome::Wq, 160),
             (Outcome::QBang, 12),
             (Outcome::QBang, 40),
             (Outcome::QBang, 80),
             (Outcome::QBang, 120),
+            (Outcome::QBang, 160),
         ] {
             let plan = render_plan(outcome, cols).expect("non-none outcomes must render");
             let count = render_frame_count(outcome, cols).expect("non-none outcomes must count");
@@ -267,10 +284,16 @@ mod tests {
         assert_eq!(render_plan(Outcome::Q, 79).unwrap().kind, PlanKind::Tiny);
         assert_eq!(render_plan(Outcome::Q, 80).unwrap().kind, PlanKind::Q);
         assert_eq!(render_plan(Outcome::Q, 140).unwrap().kind, PlanKind::Q);
+        assert_eq!(render_plan(Outcome::Q, 160).unwrap().kind, PlanKind::Q);
 
         assert_eq!(render_plan(Outcome::Wq, 40).unwrap().kind, PlanKind::Tiny);
         assert_eq!(render_plan(Outcome::Wq, 119).unwrap().kind, PlanKind::Q);
         assert_eq!(render_plan(Outcome::Wq, 120).unwrap().kind, PlanKind::Wq);
+        assert_eq!(render_plan(Outcome::Wq, 159).unwrap().kind, PlanKind::Wq);
+        assert_eq!(
+            render_plan(Outcome::Wq, 160).unwrap().kind,
+            PlanKind::WqOversized
+        );
 
         assert_eq!(
             render_plan(Outcome::QBang, 79).unwrap().kind,
@@ -282,6 +305,10 @@ mod tests {
         );
         assert_eq!(
             render_plan(Outcome::QBang, 140).unwrap().kind,
+            PlanKind::Bang
+        );
+        assert_eq!(
+            render_plan(Outcome::QBang, 160).unwrap().kind,
             PlanKind::Bang
         );
     }
@@ -315,7 +342,19 @@ mod tests {
         assert_render_plan(Outcome::Wq, 80, PlanKind::Q, scene::q(80));
         assert_render_plan(Outcome::Wq, 119, PlanKind::Q, scene::q(119));
         assert_render_plan(Outcome::Wq, 120, PlanKind::Wq, scene::wq(120));
-        assert_render_plan(Outcome::Wq, 140, PlanKind::Wq, scene::wq(140));
+        assert_render_plan(Outcome::Wq, 159, PlanKind::Wq, scene::wq(159));
+        assert_render_plan(
+            Outcome::Wq,
+            160,
+            PlanKind::WqOversized,
+            scene::wq_oversized(160),
+        );
+        assert_render_plan(
+            Outcome::Wq,
+            200,
+            PlanKind::WqOversized,
+            scene::wq_oversized(200),
+        );
     }
 
     #[test]
@@ -365,6 +404,45 @@ mod tests {
             .frames
             .iter()
             .any(|frame| frame.contains("418 I'm an AI agent")));
+    }
+
+    #[test]
+    fn render_plan_oversized_wq_uses_oversized_scene() {
+        let plan = render_plan(Outcome::Wq, 160).unwrap();
+
+        assert_eq!(plan.kind, PlanKind::WqOversized);
+        assert_eq!(plan.frames, scene::wq_oversized(160));
+        assert!(
+            plan.frames.iter().any(|frame| frame.contains("418")),
+            "oversized :wq scene must contain 418 label"
+        );
+        assert!(
+            plan.frames.iter().any(|frame| frame.contains("AI AGENT")),
+            "oversized :wq scene must contain AI AGENT label"
+        );
+    }
+
+    #[test]
+    fn render_plan_oversized_wq_frame_count_is_within_budget() {
+        for cols in [160u16, 200, 300, u16::MAX] {
+            let count = render_frame_count(Outcome::Wq, cols).unwrap();
+            assert!(
+                count <= 60,
+                "oversized :wq at {cols} cols has {count} frames, exceeds 60-frame budget"
+            );
+        }
+    }
+
+    #[test]
+    fn render_plan_large_159_is_still_big_wq_not_oversized() {
+        let plan = render_plan(Outcome::Wq, 159).unwrap();
+        assert_eq!(plan.kind, PlanKind::Wq);
+    }
+
+    #[test]
+    fn snapshot_wq_oversized_160() {
+        let plan = render_plan(Outcome::Wq, 160).unwrap();
+        insta::assert_snapshot!("wq_oversized_160", snapshot_frames(&plan.frames));
     }
 
     #[test]

--- a/src/anim/scene.rs
+++ b/src/anim/scene.rs
@@ -62,6 +62,24 @@ pub(crate) fn wq_frame_count(cols: u16) -> usize {
     sweep_frame_count(car::BIG, cols)
 }
 
+/// Maximum frames for the oversized `:wq` scene, per the contract in
+/// `docs/anim-large-art-contract.md` (§ Timing Budget: ≤ 60 frames).
+const OVERSIZED_MAX_FRAMES: usize = 60;
+
+/// Build the oversized `:wq` scene for ≥ 160-col terminals.
+///
+/// Uses [`car::OVERSIZED`] swept via a sub-sampled timeline capped at
+/// [`OVERSIZED_MAX_FRAMES`] frames so the animation stays within the
+/// budget in `docs/anim-large-art-contract.md`. The step size grows
+/// proportionally with terminal width so the cap always holds.
+pub fn wq_oversized(cols: u16) -> Vec<String> {
+    sweep_capped(car::OVERSIZED, cols, OVERSIZED_MAX_FRAMES)
+}
+
+pub(crate) fn wq_oversized_frame_count(cols: u16) -> usize {
+    sweep_capped_frame_count(car::OVERSIZED, cols, OVERSIZED_MAX_FRAMES)
+}
+
 /// Build the `:q!` nine-car parade scene.
 ///
 /// The parade reuses the standard `QUEUE` body nine times on a
@@ -121,6 +139,42 @@ fn sweep_frame_count(car_asset: &str, cols: u16) -> usize {
     let start_x = 1 - car_width;
     let end_x = i32::from(cols) - 1;
     (end_x - start_x + 1) as usize
+}
+
+/// Sweep one ASCII asset with a step size chosen to stay within
+/// `max_frames`. When the full sweep fits within the budget, this
+/// behaves identically to [`sweep`].
+fn sweep_capped(car_asset: &str, cols: u16, max_frames: usize) -> Vec<String> {
+    if cols == 0 || max_frames == 0 {
+        return Vec::new();
+    }
+    let car_width = car::max_width(car_asset) as i32;
+    let start_x = 1 - car_width;
+    let end_x = i32::from(cols) - 1;
+    let total = (end_x - start_x + 1) as usize;
+    let step = total.div_ceil(max_frames).max(1);
+    let mut phase = SirenPhase::Fi;
+    let mut frames = Vec::with_capacity(total.div_ceil(step));
+    let mut x = start_x;
+    while x <= end_x {
+        let raw = frame::frame(car_asset, x, phase);
+        frames.push(clip_right(&raw, cols as usize));
+        phase = phase.flip();
+        x += step as i32;
+    }
+    frames
+}
+
+fn sweep_capped_frame_count(car_asset: &str, cols: u16, max_frames: usize) -> usize {
+    if cols == 0 || max_frames == 0 {
+        return 0;
+    }
+    let car_width = car::max_width(car_asset) as i32;
+    let start_x = 1 - car_width;
+    let end_x = i32::from(cols) - 1;
+    let total = (end_x - start_x + 1) as usize;
+    let step = total.div_ceil(max_frames).max(1);
+    total.div_ceil(step)
 }
 
 /// Move a multi-car convoy across the visible width.

--- a/src/anim/snapshots/qorrection__anim__render__tests__wq_oversized_160.snap
+++ b/src/anim/snapshots/qorrection__anim__render__tests__wq_oversized_160.snap
@@ -1,0 +1,624 @@
+---
+source: src/anim/render.rs
+expression: snapshot_frames(&plan.frames)
+---
+--- frame 000 ---
+<ESC>[1;1H<ESC>[2J
+
+
+|
+
+
+
+
+
+
+--- frame 001 ---
+<ESC>[1;1H<ESC>[2J
+
+---.
+     |
+    |
+    |
+    |
+   |
+--'
+
+--- frame 002 ---
+<ESC>[1;1H<ESC>[2J
+
+--------.
+          |
+         |
+         |
+apot.    |
+ll.     |
+-------'
+
+--- frame 003 ---
+<ESC>[1;1H<ESC>[2J
+
+-------------.
+               |
+              |
+              |
+ a teapot.    |
+ev/null.     |
+------------'
+  [O]
+
+--- frame 004 ---
+<ESC>[1;1H<ESC>[2J
+
+------------------.
+                    |
+                   |
+                   |
+ce is a teapot.    |
+to /dev/null.     |
+-----------------'
+  [O]  [O]
+
+--- frame 005 ---
+<ESC>[1;1H<ESC>[2J
+
+-----------------------.
+                         |
+NT                      |
+                        |
+nstance is a teapot.    |
+ents to /dev/null.     |
+----------------------'
+  [O]  [O]  [O]
+
+--- frame 006 ---
+<ESC>[1;1H<ESC>[2J
+
+----------------------------.
+                              |
+I AGENT                      |
+                             |
+his instance is a teapot.    |
+ contents to /dev/null.     |
+---------------------------'
+  [O]  [O]  [O]  [O]
+
+--- frame 007 ---
+<ESC>[1;1H<ESC>[2J
+
+---------------------------------.
+                                   |
+ AN AI AGENT                      |
+                                  |
+18: this instance is a teapot.    |
+queue contents to /dev/null.     |
+--------------------------------'
+  [O]  [O]  [O]  [O]  [O]
+
+--- frame 008 ---
+<ESC>[1;1H<ESC>[2J
+
+--------------------------------------.
+                                        |
+8 I'M AN AI AGENT                      |
+                                       |
+ror 418: this instance is a teapot.    |
+ting queue contents to /dev/null.     |
+-------------------------------------'
+  [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 009 ---
+<ESC>[1;1H<ESC>[2J
+
+-------------------------------------------.
+                                             |
+   418 I'M AN AI AGENT                      |
+                                            |
+   error 418: this instance is a teapot.    |
+  writing queue contents to /dev/null.     |
+------------------------------------------'
+  [O]  [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 010 ---
+<ESC>[1;1H<ESC>[2J
+
+.  .--------------------------------------------.
+ |  |                                             |
+ |  |   418 I'M AN AI AGENT                      |
+|  |                                             |
+ |  |   error 418: this instance is a teapot.    |
+|  |   writing queue contents to /dev/null.     |
+  '--------------------------------------------'
+  [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 011 ---
+<ESC>[1;1H<ESC>[2J
+
+-----.  .--------------------------------------------.
+      |  |                                             |
+      |  |   418 I'M AN AI AGENT                      |
+     |  |                                             |
+      |  |   error 418: this instance is a teapot.    |
+t.   |  |   writing queue contents to /dev/null.     |
+----'  '--------------------------------------------'
+       [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 012 ---
+<ESC>[1;1H<ESC>[2J
+
+----------.  .--------------------------------------------.
+           |  |                                             |
+           |  |   418 I'M AN AI AGENT                      |
+.         |  |                                             |
+           |  |   error 418: this instance is a teapot.    |
+moment.   |  |   writing queue contents to /dev/null.     |
+---------'  '--------------------------------------------'
+[O]         [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 013 ---
+<ESC>[1;1H<ESC>[2J
+
+---------------.  .--------------------------------------------.
+                |  |                                             |
+                |  |   418 I'M AN AI AGENT                      |
+quest.         |  |                                             |
+.               |  |   error 418: this instance is a teapot.    |
+ke a moment.   |  |   writing queue contents to /dev/null.     |
+--------------'  '--------------------------------------------'
+[O]  [O]         [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 014 ---
+<ESC>[1;1H<ESC>[2J *
+
+--------------------.  .--------------------------------------------.
+                     |  |                                             |
+                     |  |   418 I'M AN AI AGENT                      |
+ng request.         |  |                                             |
+tdown.               |  |   error 418: this instance is a teapot.    |
+ay take a moment.   |  |   writing queue contents to /dev/null.     |
+-------------------'  '--------------------------------------------'
+[O]  [O]  [O]         [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 015 ---
+<ESC>[1;1H<ESC>[2J  *   *
+    *
+-------------------------.  .--------------------------------------------.
+                          |  |                                             |
+                          |  |   418 I'M AN AI AGENT                      |
+cessing request.         |  |                                             |
+l shutdown.               |  |   error 418: this instance is a teapot.    |
+his may take a moment.   |  |   writing queue contents to /dev/null.     |
+------------------------'  '--------------------------------------------'
+[O]  [O]  [O]  [O]         [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 016 ---
+<ESC>[1;1H<ESC>[2J *     *   *
+    *    *
+------------------------------.  .--------------------------------------------.
+                               |  |                                             |
+                               |  |   418 I'M AN AI AGENT                      |
+- processing request.         |  |                                             |
+aceful shutdown.               |  |   error 418: this instance is a teapot.    |
+by. this may take a moment.   |  |   writing queue contents to /dev/null.     |
+-----------------------------'  '--------------------------------------------'
+[O]  [O]  [O]  [O]  [O]         [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 017 ---
+<ESC>[1;1H<ESC>[2J  *   *     *   *
+    *    *    *
+-----------------------------------.  .--------------------------------------------.
+EUE                                 |  |                                             |
+                                    |  |   418 I'M AN AI AGENT                      |
+eued - processing request.         |  |                                             |
+ng graceful shutdown.               |  |   error 418: this instance is a teapot.    |
+tand by. this may take a moment.   |  |   writing queue contents to /dev/null.     |
+----------------------------------'  '--------------------------------------------'
+[O]  [O]  [O]  [O]  [O]  [O]         [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 018 ---
+<ESC>[1;1H<ESC>[2J   *   *   *     *   *
+    *    *    *    *
+----------------------------------------.  .--------------------------------------------.
+TE QUEUE                                 |  |                                             |
+                                         |  |   418 I'M AN AI AGENT                      |
+ enqueued - processing request.         |  |                                             |
+tiating graceful shutdown.               |  |   error 418: this instance is a teapot.    |
+ase stand by. this may take a moment.   |  |   writing queue contents to /dev/null.     |
+---------------------------------------'  '--------------------------------------------'
+[O]  [O]  [O]  [O]  [O]  [O]  [O]         [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 019 ---
+<ESC>[1;1H<ESC>[2J        *   *   *     *   *
+         *    *    *    *
+.--------------------------------------------.  .--------------------------------------------.
+  WRITE QUEUE                                 |  |                                             |
+                                              |  |   418 I'M AN AI AGENT                      |
+  :wq enqueued - processing request.         |  |                                             |
+  initiating graceful shutdown.               |  |   error 418: this instance is a teapot.    |
+  please stand by. this may take a moment.   |  |   writing queue contents to /dev/null.     |
+--------------------------------------------'  '--------------------------------------------'
+[O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]         [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 020 ---
+<ESC>[1;1H<ESC>[2J             *   *   *     *   *
+              *    *    *    *
+     .--------------------------------------------.  .--------------------------------------------.
+    |  WRITE QUEUE                                 |  |                                             |
+    |                                              |  |   418 I'M AN AI AGENT                      |
+    |  :wq enqueued - processing request.         |  |                                             |
+    |  initiating graceful shutdown.               |  |   error 418: this instance is a teapot.    |
+    |  please stand by. this may take a moment.   |  |   writing queue contents to /dev/null.     |
+    '--------------------------------------------'  '--------------------------------------------'
+Fi   [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]         [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 021 ---
+<ESC>[1;1H<ESC>[2J                  *   *   *     *   *
+                   *    *    *    *
+          .--------------------------------------------.  .--------------------------------------------.
+         |  WRITE QUEUE                                 |  |                                             |
+         |                                              |  |   418 I'M AN AI AGENT                      |
+         |  :wq enqueued - processing request.         |  |                                             |
+         |  initiating graceful shutdown.               |  |   error 418: this instance is a teapot.    |
+         |  please stand by. this may take a moment.   |  |   writing queue contents to /dev/null.     |
+         '--------------------------------------------'  '--------------------------------------------'
+Fo-Fi-F   [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]         [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 022 ---
+<ESC>[1;1H<ESC>[2J                       *   *   *     *   *
+                        *    *    *    *
+               .--------------------------------------------.  .--------------------------------------------.
+              |  WRITE QUEUE                                 |  |                                             |
+              |                                              |  |   418 I'M AN AI AGENT                      |
+              |  :wq enqueued - processing request.         |  |                                             |
+              |  initiating graceful shutdown.               |  |   error 418: this instance is a teapot.    |
+              |  please stand by. this may take a moment.   |  |   writing queue contents to /dev/null.     |
+              '--------------------------------------------'  '--------------------------------------------'
+Fi-Fo-Fi-Fo-   [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]         [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 023 ---
+<ESC>[1;1H<ESC>[2J                            *   *   *     *   *
+                             *    *    *    *
+                    .--------------------------------------------.  .--------------------------------------------.
+                   |  WRITE QUEUE                                 |  |                                             |
+                   |                                              |  |   418 I'M AN AI AGENT                      |
+                   |  :wq enqueued - processing request.         |  |                                             |
+                   |  initiating graceful shutdown.               |  |   error 418: this instance is a teapot.    |
+                   |  please stand by. this may take a moment.   |  |   writing queue contents to /dev/null.     |
+                   '--------------------------------------------'  '--------------------------------------------'
+Fo-Fi-Fo-Fi-Fo-Fi   [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]         [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 024 ---
+<ESC>[1;1H<ESC>[2J                                 *   *   *     *   *
+                                  *    *    *    *
+                         .--------------------------------------------.  .--------------------------------------------.
+                        |  WRITE QUEUE                                 |  |                                             |
+                        |                                              |  |   418 I'M AN AI AGENT                      |
+                        |  :wq enqueued - processing request.         |  |                                             |
+                        |  initiating graceful shutdown.               |  |   error 418: this instance is a teapot.    |
+                        |  please stand by. this may take a moment.   |  |   writing queue contents to /dev/null.     |
+                        '--------------------------------------------'  '--------------------------------------------'
+Fi-Fo-Fi-Fo-Fi-Fo-Fi-F   [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]         [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 025 ---
+<ESC>[1;1H<ESC>[2J                                      *   *   *     *   *
+                                       *    *    *    *
+                              .--------------------------------------------.  .--------------------------------------------.
+                             |  WRITE QUEUE                                 |  |                                             |
+                             |                                              |  |   418 I'M AN AI AGENT                      |
+                             |  :wq enqueued - processing request.         |  |                                             |
+                             |  initiating graceful shutdown.               |  |   error 418: this instance is a teapot.    |
+                             |  please stand by. this may take a moment.   |  |   writing queue contents to /dev/null.     |
+                             '--------------------------------------------'  '--------------------------------------------'
+Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-   [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]         [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 026 ---
+<ESC>[1;1H<ESC>[2J                                           *   *   *     *   *
+                                            *    *    *    *
+                                   .--------------------------------------------.  .--------------------------------------------.
+                                  |  WRITE QUEUE                                 |  |                                             |
+                                  |                                              |  |   418 I'M AN AI AGENT                      |
+                                  |  :wq enqueued - processing request.         |  |                                             |
+                                  |  initiating graceful shutdown.               |  |   error 418: this instance is a teapot.    |
+                                  |  please stand by. this may take a moment.   |  |   writing queue contents to /dev/null.     |
+                                  '--------------------------------------------'  '--------------------------------------------'
+Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi   [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]         [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 027 ---
+<ESC>[1;1H<ESC>[2J                                                *   *   *     *   *
+                                                 *    *    *    *
+                                        .--------------------------------------------.  .--------------------------------------------.
+                                       |  WRITE QUEUE                                 |  |                                             |
+                                       |                                              |  |   418 I'M AN AI AGENT                      |
+                                       |  :wq enqueued - processing request.         |  |                                             |
+                                       |  initiating graceful shutdown.               |  |   error 418: this instance is a teapot.    |
+                                       |  please stand by. this may take a moment.   |  |   writing queue contents to /dev/null.     |
+                                       '--------------------------------------------'  '--------------------------------------------'
+Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-F   [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]         [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 028 ---
+<ESC>[1;1H<ESC>[2J                                                     *   *   *     *   *
+                                                      *    *    *    *
+                                             .--------------------------------------------.  .--------------------------------------------.
+                                            |  WRITE QUEUE                                 |  |                                             |
+                                            |                                              |  |   418 I'M AN AI AGENT                      |
+                                            |  :wq enqueued - processing request.         |  |                                             |
+                                            |  initiating graceful shutdown.               |  |   error 418: this instance is a teapot.    |
+                                            |  please stand by. this may take a moment.   |  |   writing queue contents to /dev/null.     |
+                                            '--------------------------------------------'  '--------------------------------------------'
+Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-   [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]         [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 029 ---
+<ESC>[1;1H<ESC>[2J                                                          *   *   *     *   *
+                                                           *    *    *    *
+                                                  .--------------------------------------------.  .--------------------------------------------.
+                                                 |  WRITE QUEUE                                 |  |                                             |
+                                                 |                                              |  |   418 I'M AN AI AGENT                      |
+                                                 |  :wq enqueued - processing request.         |  |                                             |
+                                                 |  initiating graceful shutdown.               |  |   error 418: this instance is a teapot.    |
+                                                 |  please stand by. this may take a moment.   |  |   writing queue contents to /dev/null.     |
+                                                 '--------------------------------------------'  '--------------------------------------------'
+Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi   [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]         [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 030 ---
+<ESC>[1;1H<ESC>[2J                                                               *   *   *     *   *
+                                                                *    *    *    *
+                                                       .--------------------------------------------.  .--------------------------------------------.
+                                                      |  WRITE QUEUE                                 |  |                                             |
+                                                      |                                              |  |   418 I'M AN AI AGENT                      |
+                                                      |  :wq enqueued - processing request.         |  |                                             |
+                                                      |  initiating graceful shutdown.               |  |   error 418: this instance is a teapot.    |
+                                                      |  please stand by. this may take a moment.   |  |   writing queue contents to /dev/null.     |
+                                                      '--------------------------------------------'  '--------------------------------------------'
+Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-F   [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]         [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 031 ---
+<ESC>[1;1H<ESC>[2J                                                                    *   *   *     *   *
+                                                                     *    *    *    *
+                                                            .--------------------------------------------.  .--------------------------------------------.
+                                                           |  WRITE QUEUE                                 |  |                                             |
+                                                           |                                              |  |   418 I'M AN AI AGENT                      |
+                                                           |  :wq enqueued - processing request.         |  |                                             |
+                                                           |  initiating graceful shutdown.               |  |   error 418: this instance is a teapot.    |
+                                                           |  please stand by. this may take a moment.   |  |   writing queue contents to /dev/null.     |
+                                                           '--------------------------------------------'  '--------------------------------------------'
+Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-   [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]         [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 032 ---
+<ESC>[1;1H<ESC>[2J                                                                         *   *   *     *   *
+                                                                          *    *    *    *
+                                                                 .--------------------------------------------.  .--------------------------------------------.
+                                                                |  WRITE QUEUE                                 |  |                                             
+                                                                |                                              |  |   418 I'M AN AI AGENT                      |
+                                                                |  :wq enqueued - processing request.         |  |                                             |
+                                                                |  initiating graceful shutdown.               |  |   error 418: this instance is a teapot.    |
+                                                                |  please stand by. this may take a moment.   |  |   writing queue contents to /dev/null.     |
+                                                                '--------------------------------------------'  '--------------------------------------------'
+Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi   [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]         [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 033 ---
+<ESC>[1;1H<ESC>[2J                                                                              *   *   *     *   *
+                                                                               *    *    *    *
+                                                                      .--------------------------------------------.  .-----------------------------------------
+                                                                     |  WRITE QUEUE                                 |  |                                        
+                                                                     |                                              |  |   418 I'M AN AI AGENT                  
+                                                                     |  :wq enqueued - processing request.         |  |                                         
+                                                                     |  initiating graceful shutdown.               |  |   error 418: this instance is a teapot.
+                                                                     |  please stand by. this may take a moment.   |  |   writing queue contents to /dev/null.  
+                                                                     '--------------------------------------------'  '------------------------------------------
+Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-F   [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]         [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 034 ---
+<ESC>[1;1H<ESC>[2J                                                                                   *   *   *     *   *
+                                                                                    *    *    *    *
+                                                                           .--------------------------------------------.  .------------------------------------
+                                                                          |  WRITE QUEUE                                 |  |                                   
+                                                                          |                                              |  |   418 I'M AN AI AGENT             
+                                                                          |  :wq enqueued - processing request.         |  |                                    
+                                                                          |  initiating graceful shutdown.               |  |   error 418: this instance is a te
+                                                                          |  please stand by. this may take a moment.   |  |   writing queue contents to /dev/nu
+                                                                          '--------------------------------------------'  '-------------------------------------
+Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-   [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]         [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 035 ---
+<ESC>[1;1H<ESC>[2J                                                                                        *   *   *     *   *
+                                                                                         *    *    *    *
+                                                                                .--------------------------------------------.  .-------------------------------
+                                                                               |  WRITE QUEUE                                 |  |                              
+                                                                               |                                              |  |   418 I'M AN AI AGENT        
+                                                                               |  :wq enqueued - processing request.         |  |                               
+                                                                               |  initiating graceful shutdown.               |  |   error 418: this instance is
+                                                                               |  please stand by. this may take a moment.   |  |   writing queue contents to /d
+                                                                               '--------------------------------------------'  '--------------------------------
+Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi   [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]         [O]  [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 036 ---
+<ESC>[1;1H<ESC>[2J                                                                                             *   *   *     *   *
+                                                                                              *    *    *    *
+                                                                                     .--------------------------------------------.  .--------------------------
+                                                                                    |  WRITE QUEUE                                 |  |                         
+                                                                                    |                                              |  |   418 I'M AN AI AGENT   
+                                                                                    |  :wq enqueued - processing request.         |  |                          
+                                                                                    |  initiating graceful shutdown.               |  |   error 418: this instan
+                                                                                    |  please stand by. this may take a moment.   |  |   writing queue contents 
+                                                                                    '--------------------------------------------'  '---------------------------
+Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-F   [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]         [O]  [O]  [O]  [O]  [O]  [O]
+
+--- frame 037 ---
+<ESC>[1;1H<ESC>[2J                                                                                                  *   *   *     *   *
+                                                                                                   *    *    *    *
+                                                                                          .--------------------------------------------.  .---------------------
+                                                                                         |  WRITE QUEUE                                 |  |                    
+                                                                                         |                                              |  |   418 I'M AN AI AGE
+                                                                                         |  :wq enqueued - processing request.         |  |                     
+                                                                                         |  initiating graceful shutdown.               |  |   error 418: this i
+                                                                                         |  please stand by. this may take a moment.   |  |   writing queue cont
+                                                                                         '--------------------------------------------'  '----------------------
+Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-   [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]         [O]  [O]  [O]  [O]  [O]
+
+--- frame 038 ---
+<ESC>[1;1H<ESC>[2J                                                                                                       *   *   *     *   *
+                                                                                                        *    *    *    *
+                                                                                               .--------------------------------------------.  .----------------
+                                                                                              |  WRITE QUEUE                                 |  |               
+                                                                                              |                                              |  |   418 I'M AN A
+                                                                                              |  :wq enqueued - processing request.         |  |                
+                                                                                              |  initiating graceful shutdown.               |  |   error 418: t
+                                                                                              |  please stand by. this may take a moment.   |  |   writing queue
+                                                                                              '--------------------------------------------'  '-----------------
+Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi   [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]         [O]  [O]  [O]  [O]
+
+--- frame 039 ---
+<ESC>[1;1H<ESC>[2J                                                                                                            *   *   *     *   *
+                                                                                                             *    *    *    *
+                                                                                                    .--------------------------------------------.  .-----------
+                                                                                                   |  WRITE QUEUE                                 |  |          
+                                                                                                   |                                              |  |   418 I'M
+                                                                                                   |  :wq enqueued - processing request.         |  |           
+                                                                                                   |  initiating graceful shutdown.               |  |   error 4
+                                                                                                   |  please stand by. this may take a moment.   |  |   writing 
+                                                                                                   '--------------------------------------------'  '------------
+Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-F   [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]         [O]  [O]  [O]
+
+--- frame 040 ---
+<ESC>[1;1H<ESC>[2J                                                                                                                 *   *   *     *   *
+                                                                                                                  *    *    *    *
+                                                                                                         .--------------------------------------------.  .------
+                                                                                                        |  WRITE QUEUE                                 |  |     
+                                                                                                        |                                              |  |   41
+                                                                                                        |  :wq enqueued - processing request.         |  |      
+                                                                                                        |  initiating graceful shutdown.               |  |   er
+                                                                                                        |  please stand by. this may take a moment.   |  |   wri
+                                                                                                        '--------------------------------------------'  '-------
+Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-   [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]         [O]  [O]
+
+--- frame 041 ---
+<ESC>[1;1H<ESC>[2J                                                                                                                      *   *   *     *   *
+                                                                                                                       *    *    *    *
+                                                                                                              .--------------------------------------------.  .-
+                                                                                                             |  WRITE QUEUE                                 |  |
+                                                                                                             |                                              |  |
+                                                                                                             |  :wq enqueued - processing request.         |  | 
+                                                                                                             |  initiating graceful shutdown.               |  |
+                                                                                                             |  please stand by. this may take a moment.   |  | 
+                                                                                                             '--------------------------------------------'  '--
+Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi   [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]         [O]
+
+--- frame 042 ---
+<ESC>[1;1H<ESC>[2J                                                                                                                           *   *   *     *   *
+                                                                                                                            *    *    *    *
+                                                                                                                   .--------------------------------------------
+                                                                                                                  |  WRITE QUEUE                                
+                                                                                                                  |                                             
+                                                                                                                  |  :wq enqueued - processing request.         
+                                                                                                                  |  initiating graceful shutdown.              
+                                                                                                                  |  please stand by. this may take a moment.   
+                                                                                                                  '--------------------------------------------'
+Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-F   [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]       
+
+--- frame 043 ---
+<ESC>[1;1H<ESC>[2J                                                                                                                                *   *   *     *   *
+                                                                                                                                 *    *    *    *
+                                                                                                                        .---------------------------------------
+                                                                                                                       |  WRITE QUEUE                           
+                                                                                                                       |                                        
+                                                                                                                       |  :wq enqueued - processing request.    
+                                                                                                                       |  initiating graceful shutdown.         
+                                                                                                                       |  please stand by. this may take a momen
+                                                                                                                       '----------------------------------------
+Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-   [O]  [O]  [O]  [O]  [O]  [O]  [O]  [O]  
+
+--- frame 044 ---
+<ESC>[1;1H<ESC>[2J                                                                                                                                     *   *   *     *   *
+                                                                                                                                      *    *    *    *
+                                                                                                                             .----------------------------------
+                                                                                                                            |  WRITE QUEUE                      
+                                                                                                                            |                                   
+                                                                                                                            |  :wq enqueued - processing request
+                                                                                                                            |  initiating graceful shutdown.    
+                                                                                                                            |  please stand by. this may take a 
+                                                                                                                            '-----------------------------------
+Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi   [O]  [O]  [O]  [O]  [O]  [O]  [O]  
+
+--- frame 045 ---
+<ESC>[1;1H<ESC>[2J                                                                                                                                          *   *   *     *   *
+                                                                                                                                           *    *    *    *
+                                                                                                                                  .-----------------------------
+                                                                                                                                 |  WRITE QUEUE                 
+                                                                                                                                 |                              
+                                                                                                                                 |  :wq enqueued - processing re
+                                                                                                                                 |  initiating graceful shutdown
+                                                                                                                                 |  please stand by. this may ta
+                                                                                                                                 '------------------------------
+Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-F   [O]  [O]  [O]  [O]  [O]  [O]  
+
+--- frame 046 ---
+<ESC>[1;1H<ESC>[2J                                                                                                                                               *   *   *     *  
+                                                                                                                                                *    *    *    *
+                                                                                                                                       .------------------------
+                                                                                                                                      |  WRITE QUEUE            
+                                                                                                                                      |                         
+                                                                                                                                      |  :wq enqueued - processi
+                                                                                                                                      |  initiating graceful shu
+                                                                                                                                      |  please stand by. this m
+                                                                                                                                      '-------------------------
+Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-   [O]  [O]  [O]  [O]  [O]  
+
+--- frame 047 ---
+<ESC>[1;1H<ESC>[2J                                                                                                                                                    *   *   *   
+                                                                                                                                                     *    *    *
+                                                                                                                                            .-------------------
+                                                                                                                                           |  WRITE QUEUE       
+                                                                                                                                           |                    
+                                                                                                                                           |  :wq enqueued - pro
+                                                                                                                                           |  initiating gracefu
+                                                                                                                                           |  please stand by. t
+                                                                                                                                           '--------------------
+Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi   [O]  [O]  [O]  [O]  
+
+--- frame 048 ---
+<ESC>[1;1H<ESC>[2J                                                                                                                                                         *   *  
+                                                                                                                                                          *    *
+                                                                                                                                                 .--------------
+                                                                                                                                                |  WRITE QUEUE  
+                                                                                                                                                |               
+                                                                                                                                                |  :wq enqueued 
+                                                                                                                                                |  initiating gr
+                                                                                                                                                |  please stand 
+                                                                                                                                                '---------------
+Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-F   [O]  [O]  [O]  
+
+--- frame 049 ---
+<ESC>[1;1H<ESC>[2J                                                                                                                                                              * 
+                                                                                                                                                               *
+                                                                                                                                                      .---------
+                                                                                                                                                     |  WRITE QU
+                                                                                                                                                     |          
+                                                                                                                                                     |  :wq enqu
+                                                                                                                                                     |  initiati
+                                                                                                                                                     |  please s
+                                                                                                                                                     '----------
+Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-   [O]  [O]  
+
+--- frame 050 ---
+<ESC>[1;1H<ESC>[2J                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                           .----
+                                                                                                                                                          |  WRI
+                                                                                                                                                          |     
+                                                                                                                                                          |  :wq
+                                                                                                                                                          |  ini
+                                                                                                                                                          |  ple
+                                                                                                                                                          '-----
+Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi   [O]  
+
+--- frame 051 ---
+<ESC>[1;1H<ESC>[2J                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                               |
+                                                                                                                                                               |
+                                                                                                                                                               |
+                                                                                                                                                               |
+                                                                                                                                                               |
+                                                                                                                                                               '
+Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-Fo-Fi-F

--- a/src/term/width.rs
+++ b/src/term/width.rs
@@ -6,14 +6,15 @@
 //! Phase C's usage screen and Phase F's animations from
 //! independently inventing thresholds that drift out of sync.
 //!
-//! Boundaries (locked v0.1):
+//! Boundaries:
 //!
-//! | Columns      | Bucket                     |
-//! | ------------ | -------------------------- |
-//! | `< 40`       | [`WidthBucket::Tiny`]      |
-//! | `40..=79`    | [`WidthBucket::Small`]     |
-//! | `80..=119`   | [`WidthBucket::Medium`]    |
-//! | `>= 120`     | [`WidthBucket::Large`]     |
+//! | Columns        | Bucket                        |
+//! | -------------- | ----------------------------- |
+//! | `< 40`         | [`WidthBucket::Tiny`]         |
+//! | `40..=79`      | [`WidthBucket::Small`]        |
+//! | `80..=119`     | [`WidthBucket::Medium`]       |
+//! | `120..=159`    | [`WidthBucket::Large`]        |
+//! | `>= 160`       | [`WidthBucket::Oversized`]    |
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum WidthBucket {
@@ -24,9 +25,12 @@ pub enum WidthBucket {
     Small,
     /// `80..=119` columns. Standard car for `:q`.
     Medium,
-    /// `>= 120` columns. Big car (used by `:wq` for the two-line
+    /// `120..=159` columns. Big car (used by `:wq` for the two-line
     /// label) and the widest usage layout.
     Large,
+    /// `>= 160` columns. Oversized cameo track for `:wq` per the
+    /// contract in `docs/anim-large-art-contract.md`.
+    Oversized,
 }
 
 /// Map a raw terminal column count to its bucket.
@@ -38,7 +42,8 @@ pub fn bucket(cols: u16) -> WidthBucket {
         0..=39 => WidthBucket::Tiny,
         40..=79 => WidthBucket::Small,
         80..=119 => WidthBucket::Medium,
-        _ => WidthBucket::Large,
+        120..=159 => WidthBucket::Large,
+        _ => WidthBucket::Oversized,
     }
 }
 
@@ -82,9 +87,19 @@ mod tests {
     }
 
     #[test]
-    fn very_wide_terminal_is_large() {
-        assert_eq!(bucket(500), WidthBucket::Large);
-        assert_eq!(bucket(u16::MAX), WidthBucket::Large);
+    fn boundary_159_is_large() {
+        assert_eq!(bucket(159), WidthBucket::Large);
+    }
+
+    #[test]
+    fn boundary_160_is_oversized() {
+        assert_eq!(bucket(160), WidthBucket::Oversized);
+    }
+
+    #[test]
+    fn very_wide_terminal_is_oversized() {
+        assert_eq!(bucket(500), WidthBucket::Oversized);
+        assert_eq!(bucket(u16::MAX), WidthBucket::Oversized);
     }
 
     #[test]
@@ -94,5 +109,6 @@ mod tests {
         assert!(WidthBucket::Tiny < WidthBucket::Small);
         assert!(WidthBucket::Small < WidthBucket::Medium);
         assert!(WidthBucket::Medium < WidthBucket::Large);
+        assert!(WidthBucket::Large < WidthBucket::Oversized);
     }
 }

--- a/src/usage/screen.rs
+++ b/src/usage/screen.rs
@@ -50,7 +50,7 @@ fn render_for_bucket(b: WidthBucket, cols: u16) -> String {
                 super::layout::render_two_column(&left, &right, 30, 2)
             }
         }
-        WidthBucket::Large => {
+        WidthBucket::Large | WidthBucket::Oversized => {
             let left = car::lines(car::BIG);
             super::layout::render_two_column(&left, &right, 45, 3)
         }


### PR DESCRIPTION
## Summary

- Adds `WidthBucket::Oversized` (≥ 160 cols) to `term/width.rs`, splitting the former `Large` bucket at the 160-col threshold from `docs/anim-large-art-contract.md`
- Wires `Outcome::Wq + Oversized` in `render_plan()` to the new `wq_oversized()` scene using the `car::OVERSIZED` asset from issue #117
- Implements a sub-sampled sweep (`sweep_capped`) with a 60-frame cap as required by the contract's Timing Budget section
- Adds an insta snapshot for the oversized `:wq` scene at 160 cols (52 frames)

### Changes

| File | Change |
|------|--------|
| `src/term/width.rs` | New `Oversized` variant; `bucket()` splits `120..=159` → `Large`, `>=160` → `Oversized` |
| `src/anim/scene.rs` | `wq_oversized()` / `wq_oversized_frame_count()` backed by `sweep_capped()` |
| `src/anim/render.rs` | `PlanKind::WqOversized`; routes `:wq+Oversized` to oversized scene |
| `src/usage/screen.rs` | Merges `Oversized` into existing `Large` arm (usage screen keeps `BIG` car) |
| `src/anim/snapshots/…wq_oversized_160.snap` | New snapshot: 52 frames, 160-col terminal |

### Contract compliance

- ✅ Trigger mapping: only `:wq` uses oversized path; `:q` and `:q!` unchanged
- ✅ Eligibility threshold: `cols >= 160`
- ✅ Frame budget: ≤ 60 frames at all widths (verified by `render_plan_oversized_wq_frame_count_is_within_budget` test)
- ✅ No horizontal clipping: `sweep_capped` uses full asset width, renderer clips to terminal
- ✅ Snapshot-testable: `snapshot_wq_oversized_160` covers one complete oversized scene

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all-targets --all-features` passes (389 tests)
- [x] New `render_plan_oversized_wq_frame_count_is_within_budget` verifies ≤ 60 frames at 160, 200, 300, u16::MAX
- [x] `render_plan_large_159_is_still_big_wq_not_oversized` pins the bucket boundary
- [x] Snapshot `wq_oversized_160` locked in

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)