### PR TITLE
ci(release): add optional crates.io publish job (#78)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,3 +224,24 @@ jobs:
         with:
           files: dist/*
           generate_release_notes: true
+
+  cargo-publish:
+    name: Publish to crates.io (optional)
+    needs: [verify-tag, build]
+    runs-on: ubuntu-latest
+    # Run only on tag push after verify-tag succeeds.
+    # continue-on-error: true so a missing CRATES_IO_TOKEN or a
+    # transient crates.io outage never blocks the GitHub Release.
+    if: |
+      startsWith(github.ref, 'refs/tags/v') &&
+      needs.verify-tag.result == 'success'
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: cargo publish
+        run: cargo publish --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds a `cargo-publish` job to `release.yml` that runs on tag pushes after `verify-tag` succeeds
- `continue-on-error: true` ensures a missing `CRATES_IO_TOKEN` secret or a transient crates.io outage never blocks the GitHub Release publish step
- Uses `CRATES_IO_TOKEN` from repository secrets (`CARGO_REGISTRY_TOKEN` environment variable)

## Setup required (human action)

Before the publish job can succeed, a maintainer must:

1. Generate a crates.io API token at <https://crates.io/settings/tokens> with the `publish-new` and `publish-update` scopes
2. Add the token to repository secrets as `CRATES_IO_TOKEN` (Settings → Secrets and variables → Actions → New repository secret)

Once the secret is set, the job runs automatically on the next `v*` tag push.

## Merge note

This PR modifies `.github/workflows/release.yml`. Due to GitHub OAuth token scope restrictions, it **must be merged via the GitHub web UI** (the automated merge step will be blocked by the `workflow` scope check). Please merge using the "Merge pull request" button on GitHub.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes (workflow-only change, no Rust code changes)
- [ ] Release CI job `cargo-publish` visible and passes (requires `CRATES_IO_TOKEN` secret to be set)

Closes #78

<!-- claimed-by: claude-code-062d62d9 7d09c4e8-fd87-450b-8d8d-defb628ce167 supersedes: none 2026-05-17T10:31:00Z branch: issue/78-9-release-crates-io-publish-cargo-publish -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)