### PR TITLE
ci(release): add manual crates.io publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,3 +224,32 @@ jobs:
         with:
           files: dist/*
           generate_release_notes: true
+
+  publish-crates-io:
+    name: Publish to crates.io (manual)
+    needs: build
+    runs-on: ubuntu-latest
+    # Runs only on explicit workflow_dispatch to prevent accidental
+    # publishes on every tag push.  The user must manually trigger
+    # this job after verifying the GitHub Release looks correct.
+    if: github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Show version being published
+        shell: bash
+        run: |
+          set -euo pipefail
+          pkgid="$(cargo pkgid -p qorrection)"
+          version="${pkgid##*@}"
+          echo "Publishing qorrection ${version} from ref ${GITHUB_REF_NAME}"
+      - name: cargo publish --dry-run
+        run: cargo publish --dry-run --locked
+      - name: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --locked


### PR DESCRIPTION
## Summary

- Adds a `publish-crates-io` job to `release.yml` that triggers only on `workflow_dispatch` (manual execution)
- Prevents accidental crates.io publishes on every tag push — the maintainer triggers explicitly after verifying the GitHub Release

### Design

```
Tag push → verify-tag → build → publish (GitHub Release)   ← automatic
                                                             
workflow_dispatch → [verify-tag skipped] → build → publish-crates-io   ← manual
```

The new job:
1. Depends on `build` (all platform targets must compile)
2. Runs `cargo publish --dry-run --locked` as a pre-flight check
3. Runs `cargo publish --locked` using `CARGO_REGISTRY_TOKEN` secret

### Usage

After the GitHub Release looks correct, go to **Actions → Release → Run workflow** and dispatch from the tag ref to publish to crates.io.

**Note:** The `CARGO_REGISTRY_TOKEN` secret must be configured in the repository settings before use.

## Test plan

- [x] YAML syntax validated
- [x] `cargo fmt --check` passes (no Rust source changes)
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all-targets --all-features` passes

> **Note:** This PR modifies `.github/workflows/release.yml` and requires a token with the `workflow` scope to merge. Manual merge by the maintainer may be needed.

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)