### PR TITLE
docs(changelog): record oversized cameo track in Unreleased section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Oversized cameo track** for `:wq` on wide terminals (≥ 160 columns).
+  Inspired by `sl`/`nyancat` in scale while keeping repo-owned, pure-ASCII,
+  embedded art.
+  - Scene contract in `docs/anim-large-art-contract.md` defines eligibility
+    (≥ 160 cols), trigger mapping (`:wq` only), frame budget (≤ 60 frames), and
+    clipping policy (no horizontal or vertical clipping allowed).
+  - Original oversized ASCII locomotive asset: `src/anim/assets/oversized.txt`
+    (10 rows × 99 cols, exposed as `car::OVERSIZED`).
+  - `WidthBucket::Oversized` width bucket for ≥ 160-column terminals.
+  - `:wq` at ≥ 160 cols renders the oversized locomotive sweep (≤ 60 frames at
+    50 ms each); `:q` and `:q!` keep their existing large-bucket scenes.
+
 ## [0.1.0] - 2026-05-17
 
 ### Added


### PR DESCRIPTION
## Summary

Records the completed oversized ASCII cameo feature track in `CHANGELOG.md` under `[Unreleased]`, closing the meta/epic issue #115.

### What was completed

All three child issues have been merged:

| Issue | PR | What |
|-------|-----|------|
| #116 | #123 | Scene contract (`docs/anim-large-art-contract.md`) |
| #117 | #154 | Original oversized ASCII locomotive asset (`car::OVERSIZED`) |
| #118 | #156 | Renderer integration (`WidthBucket::Oversized`, `:wq` at ≥ 160 cols) |

### CHANGELOG entry added

Documents the oversized cameo track under `[Unreleased]`:
- Feature overview and eligibility (≥ 160 cols, `:wq` only)
- Frame budget (≤ 60 frames at 50 ms each)
- Components: contract doc, asset, width bucket, renderer change

## Test plan

- [x] `cargo fmt --check` passes (no Rust changes)
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all-targets --all-features` passes (389 tests)

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)