### PR TITLE
test(pty_smoke): guard ClosePseudoConsole with bounded timeout on Windows (#162)

### DIFF
--- a/tests/pty_smoke.rs
+++ b/tests/pty_smoke.rs
@@ -22,8 +22,12 @@
 //! master handle is open — the ConPTY session object keeps the process
 //! wait from completing. The fix is to close the full `PtyMaster` (which
 //! calls `ClosePseudoConsole`) *before* polling `try_wait`. A brief sleep
-//! before closing gives `cmd.exe` time to flush "hi" into the ConPTY
-//! buffer so the output is captured before the session tears down.
+//! before closing gives `cmd.exe` time to flush its output into the ConPTY
+//! buffer before the session tears down.
+//!
+//! `ClosePseudoConsole` is called from a short-lived teardown thread so
+//! that a stuck close (possible on some ConPTY builds or CI environments)
+//! triggers a bounded panic instead of hanging the test runner indefinitely.
 //!
 //! Closing just the writer half of the master would instead signal
 //! `STATUS_CONTROL_C_EXIT`; we drop the full master as a unit to stay
@@ -118,12 +122,28 @@ fn portable_pty_echoes_hi() {
     // cmd.exe with ConPTY performs extensive terminal initialisation
     // (escape sequences, window-title, cursor management) before running
     // the user command. 3 s is a conservative budget that covers even
-    // slow CI runners; the captured output includes both init sequences
-    // and the actual "hi" from `echo hi`.
+    // slow CI runners.
+    //
+    // ClosePseudoConsole is called from a dedicated thread so a stuck
+    // close fails fast via a channel timeout rather than hanging forever.
     #[cfg(windows)]
     {
         thread::sleep(Duration::from_millis(3000));
-        drop(master.take());
+
+        let teardown_master = master.take();
+        let (teardown_tx, teardown_rx) = mpsc::channel::<()>();
+        thread::spawn(move || {
+            drop(teardown_master); // calls ClosePseudoConsole
+            let _ = teardown_tx.send(());
+        });
+        const CLOSE_BUDGET: Duration = Duration::from_secs(5);
+        if teardown_rx.recv_timeout(CLOSE_BUDGET).is_err() {
+            let _ = killer.kill();
+            panic!(
+                "ClosePseudoConsole did not complete within {CLOSE_BUDGET:?}; \
+                 ConPTY teardown hung"
+            );
+        }
     }
 
     // Bounded wait for the child. On Unix the reader thread is still


### PR DESCRIPTION
## Summary

- Wraps the `drop(master.take())` call (which calls `ClosePseudoConsole`) in a short-lived thread
- A `mpsc` channel with `recv_timeout(5 s)` replaces the previous unbounded drop
- If `ClosePseudoConsole` blocks beyond 5 s, the test panics with a clear diagnostic and the child is killed, rather than hanging CI indefinitely

## Problem

The previous code called `ClosePseudoConsole` directly in the main thread before the `WAIT_BUDGET` loop:

```rust
#[cfg(windows)]
{
    thread::sleep(Duration::from_millis(3000));
    drop(master.take()); // ← unbounded; could hang
}
```

If `ClosePseudoConsole` blocks (e.g., on some ConPTY builds or CI environments waiting for attached processes to drain), neither the 5 s `WAIT_BUDGET` guard nor the `killer.kill()` path can fire — execution is stuck in the `drop`.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --test pty_smoke` passes (Linux)
- [ ] `Test (windows-latest)` CI passes — happy path: fast `ClosePseudoConsole` in teardown thread, channel fires, execution continues normally

Closes #162

<!-- claimed-by: claude-code-062d62d9 77684c51-5905-4ff6-a697-8df33ba18920 supersedes: none 2026-05-17T11:10:00Z branch: issue/162-0-test-pty-smoke-windows-close-timeout -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)