### PR TITLE
chore(idd): re-sync .github/instructions/ from upstream 80e7295

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -51,6 +51,7 @@ words:
   - clauder
   - decckm
   - embark
+  - esync
   - greppable
   - hsomething
   - illumos

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -15,6 +15,25 @@ missing or disagrees.
 **Abort conditions**: A0-T, A1, A3 (default; see decision tree).
 **Early stop condition**: A0-T, A4, or A4.5 (no claim made — see below).
 
+## Authoring label guard
+
+The configured authoring label is `issueAuthoring.authoringLabelName`
+(default: `status:authoring`); the stale threshold is
+`issueAuthoring.authoringStaleAge` (default: `PT4H`).
+
+A0-T, A0-O, and A3 must treat a matching label as not startable. A0-T
+reports `Issue #N is currently being authored` and stops before claim;
+A0-O and A3 filter the issue out. For each skipped issue, fetch the
+latest matching `labeled` timeline event. If the label age exceeds
+`authoringStaleAge`, emit:
+
+```text
+Warning: Issue #N has carried the authoring label for {duration}; the authoring session may be stalled.
+```
+
+If the timestamp is unavailable, still skip the issue and report that the
+stale-authoring age could not be checked.
+
 ## A0-T — Explicit issue target shortcut
 
 Use this shortcut only when the current operator request contains one
@@ -34,7 +53,10 @@ selection. Before A5, run targeted readiness and viability checks against
 that issue only:
 
 1. Re-fetch the target issue.
-2. Apply the same readiness intent as A3 to the target:
+2. If the target issue carries the configured authoring label, report
+   `Issue #N is currently being authored`, run the stale-authoring
+   warning check above, and stop without claiming.
+3. Apply the same readiness intent as A3 to the target:
    - no `status:blocked-by-human` or `status:needs-decision` label;
    - no open dependent issues, except parent epics or aggregate issues
      that are acceptable under A3;
@@ -45,11 +67,11 @@ that issue only:
      markers resolve through the same scoped body-content lookup used by
      A3, and the matching roadmap work is closed or otherwise complete;
    - no external human coordination is required to start.
-3. Run the normal A4 viability gate against the target only.
-4. If `.github/idd/config.json` exists and is valid and
+4. Run the normal A4 viability gate against the target only.
+5. If `.github/idd/config.json` exists and is valid and
    `skipIssueAuthorApprovalGate` is `true`, skip the issue-author
    approval gate and keep the target selected.
-5. Otherwise, apply the same issue-author approval evaluation used in
+6. Otherwise, apply the same issue-author approval evaluation used in
    **A3.5**:
    - use `maintainerApprovalActorPolicy` from `.github/idd/config.json`
      when present; if absent, default to
@@ -111,6 +133,7 @@ body satisfies **all** of the following:
   `<!-- qorrection-blocked-by: … -->` marker.
 - Does NOT have a `status:blocked-by-human` or `status:needs-decision`
   label.
+- Does NOT have the configured authoring label.
 - Does NOT contain visible `Blocked by #NNN` lines where the referenced
   issue is open (apply the same fail-safe as A3: if a reference cannot
   be resolved, treat as blocked).
@@ -217,8 +240,26 @@ referenced issues. Collect only **open** issues.
 - Incidental narrative mentions (e.g., "Similar to #NNN") without an
   explicit task, sub-issue, or dependency relationship
 
-Traverse referenced issues regardless of their open/closed state;
-include only **open** issues in the A2 candidate set.
+Traverse referenced issues regardless of their open/closed state.
+
+**Roadmap node classification**: any issue carrying the `roadmap` label
+or containing an
+`<!-- qorrection-roadmap-id: ... -->` marker is a
+**roadmap node**, not an execution leaf. Roadmap nodes are
+traversal-only coordination nodes:
+
+- Continue walking their outbound references to reach execution leaf
+  issues below them.
+- Do **not** add roadmap nodes to the A2 candidate set, even when open.
+- Closed intermediate roadmap nodes must still be traversed so open
+  descendants cannot be hidden behind a closed parent.
+- Only non-roadmap open issues (execution leaves) advance to
+  A3/A4/A4.5/A5.
+- Track open roadmap nodes separately and report them alongside the A2
+  execution candidates.
+- The root roadmap selected by A1 is the traversal starting point and
+  is not added to the roadmap-node set; only issues discovered through
+  its outbound references are classified and reported.
 
 **Permitted repo-wide queries** — only the following scoped lookups may
 touch issues outside the roadmap traversal graph:
@@ -250,7 +291,7 @@ touch issues outside the roadmap traversal graph:
   selected candidate and is not added to any candidate set.
 
 **Prohibited in all other contexts** — the following must not be used in
-any phase except as listed above, or when A3 step 4 explicit opt-in
+any phase except as listed above, or when A3 step 5 explicit opt-in
 authorizes an alternate scope for the current run:
 
 - `gh issue list` or any variant
@@ -268,15 +309,16 @@ authorizes an alternate scope for the current run:
   unresolvable with the reason, skip that branch, and continue with the
   rest of the traversal. This is not an enumeration failure.
 
-Report every A2 candidate with its provenance path from the roadmap
-(e.g., `#222 → #228 → #257`) before passing to A3. Also report any
-unresolvable references encountered during traversal.
+Report every A2 execution candidate with its provenance path (e.g.,
+`#222 → #228 → #257`), open roadmap nodes encountered, and any
+unresolvable references before passing to A3.
 
 ## A3 — Filter to ready-to-start
 
 From A2, keep only issues that satisfy **all** of the following:
 
 - No `status:blocked-by-human` or `status:needs-decision` label
+- No configured authoring label
 - No open dependent issues (parent epics / aggregate issues that are
   still open are acceptable)
 - All dependency issues are closed or otherwise completed. Check both
@@ -292,7 +334,8 @@ From A2, keep only issues that satisfy **all** of the following:
   migration integrity problem such as a typo, deleted issue, or
   incomplete migration). If multiple issues match, treat as blocked if
   any is open.
-- No external human coordination required to start
+- No external human coordination required to start; otherwise keep
+  scanning
 
 **When A2 finds zero candidates, or when zero issues survive A3
 filtering**, apply the following decision tree — do not silently expand
@@ -303,27 +346,28 @@ scope:
    (Unresolvable individual references are already pruned in A2 and do
    not trigger this step.)
 
-2. **A2 empty** (roadmap has no outbound references, all referenced
-   issues are closed, or all branches were skipped due to unresolvable
-   references): report that A2 found zero open candidates — include any
-   skipped unresolvable references — then proceed to step 4.
+2. **A2 empty — only open roadmap nodes remain** (all reachable open
+   issues are roadmap nodes, not execution leaves): report the node
+   list with provenance paths. These nested roadmaps need A1.5 audit
+   or further leaf-issue population. Do not treat them as candidates.
+   Proceed to step 5.
 
-3. **A3 filtered to zero** (A2 found candidates but all were filtered
-   out): report each candidate and the filter criterion it failed, then
-   proceed to step 4.
+3. **A2 empty** (no open candidates, no roadmap nodes): report zero
+   open candidates and skipped references; proceed to step 5.
+
+4. **A3 filtered to zero** (A2 found execution candidates but all were
+   filtered out): report each candidate and the filter criterion it
+   failed, then proceed to step 5.
 
    **Diagnostic — all candidates blocked by an open roadmap**: if every
-   candidate is blocked because its
-   `<!-- qorrection-blocked-by: X -->` marker points to a
-   roadmap issue that is still open, the markers are likely misused as
-   grouping tags rather than as true sequential dependencies. Sub-tasks
-   that should be worked on while the roadmap is open belong in the
-   roadmap's task list as `- [ ] #NNN` entries; the `blocked-by` marker
-   is reserved for issues that must wait for a separate, prior roadmap to
-   close. Report this pattern explicitly so the operator can correct the
-   issue setup.
+   candidate is blocked by a
+   `<!-- qorrection-blocked-by: X -->` marker that points
+   to an open roadmap, the markers may be misused as grouping tags.
+   Sub-tasks that run while the roadmap is open belong in the task list
+   (`- [ ] #NNN`); the `blocked-by` marker is for issues that must wait
+   for a separate roadmap to close first.
 
-4. **Request explicit opt-in** — ask the operator: "No roadmap-scoped
+5. **Request explicit opt-in** — ask the operator: "No roadmap-scoped
    issues are available. Do you want to expand the search scope for this
    run? If so, specify the alternate scope." An agent is **unattended**
    if it cannot wait for and receive a same-run operator reply. Then:
@@ -375,7 +419,8 @@ Candidates that fail the gate are **not** ready-to-start. Keep them in
 an **approval-needed fallback bucket** ordered by ascending issue number.
 Continue to A4 with only the startable candidates. Preserve any earlier
 A0-O filtering from `orphan-first-policy`; this gate never widens
-previously excluded orphan candidates back into scope.
+previously excluded orphan candidates back into scope. Keep fallback
+issues visible; do not drop them.
 
 If no startable candidates remain but the approval-needed fallback
 bucket is non-empty:
@@ -504,30 +549,10 @@ for a separate, prior roadmap to close before they can start (cross-
 phase sequential dependency). Using it for grouping causes A3 to block
 every sub-task for the entire lifetime of the roadmap.
 
-## Scope invariant (detailed query allowlist)
+## Scope invariant (summary)
 
-Agents must not widen issue-selection scope beyond what the roadmap
-explicitly references (directly or transitively) without explicit
-operator instruction. Specifically:
-
-- A single explicit issue target provided by the operator in the current
-  run is explicit operator instruction for that one issue only. Use the
-  A0-T path; do not use the target as permission to search for alternate
-  issues.
-- Repo-wide searches (`gh issue list`, `gh search`, label-based queries)
-  are permitted only in **A1** (to locate the roadmap itself), in
-  **A0-T** for the scoped body-content lookup needed to resolve the
-  explicit target's `qorrection-blocked-by` markers, in
-  **A0-O** when `issue-scope` is `orphan-first` (body-content filter to
-  find issues lacking `qorrection-roadmap-id` and
-  `qorrection-blocked-by` markers), and for the scoped
-  `qorrection-roadmap-id` body-content lookup required by
-  A3's dependency-marker check. A1.5 may also run a narrow repo-wide
-  duplicate/reuse check for a specific autonomous gap before creating a
-  follow-up issue; the result may only prevent a duplicate or link an
-  existing issue back to the selected roadmap, not expand the candidate
-  set.
-- After a zero-result report at A3, an operator may grant a one-time
-  opt-in for the current run, specifying an alternate scope.
-- Opt-in must be granted interactively during the current run. Prior or
-  standing instructions do not count as opt-in.
+Do not widen issue-selection scope beyond the roadmap traversal except
+for the explicit query allowlist already defined in A0-T, A0-O, A1,
+A1.5, A3, and A4.5, or for a same-run operator opt-in after a
+zero-result report. A single explicit target authorizes only that issue;
+prior or standing instructions do not count as opt-in.

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -1,18 +1,31 @@
 # IDD — PR Submit Phase (D)
 
-Read this file after the self-review loop passes. It covers syncing
-main, verifying the claim, running tests, pushing, creating the PR, and
-waiting for CI.
+Read this file after the self-review loop passes. It covers
+pre-publication main sync, claim verification, tests, pushing, PR
+creation, and waiting for CI.
 
 Before the D1 rebase and D2 push, apply the shared claim revalidation
 gate. The active claim must still use your current `{claim-id}`.
 
-## D1 — Sync main
+## D1 — Sync main before first push
 
-Rebase the feature branch onto `main`. Resolve any conflicts and
-continue the rebase. After completing the rebase, if any files were
-manually edited during conflict resolution, run **fix-validate** before
-proceeding.
+If the branch has not been pushed yet, rebase it onto `main`. This is
+the routine pre-publication history cleanup step.
+
+After the first D-phase push, do not reuse D1 as the normal
+synchronization path. Later branch updates should return through the
+E-phase review loop and, by default, merge `main` into the published PR
+branch so the synchronization diff is reviewable.
+
+This D-phase file records the publication boundary and target
+post-push synchronization contract. Follow-up work may still be needed
+to align later-phase conflict-handling and resume-routing helpers before
+that runtime route is fully active everywhere.
+
+If D1 itself reveals content conflicts before the first push, resolve
+them and continue the rebase. After completing the rebase, if any files
+were manually edited during conflict resolution, run **fix-validate**
+before proceeding.
 
 ## D2 — Verify claim, lint, test, push
 
@@ -23,8 +36,17 @@ proceeding.
 2. Run **pre-push-validate**.
 
    (E2E tests are verified by CI; do not run them locally.)
-3. Push the branch to the remote. If D1 used rebase (history was
-   rewritten), use `--force-with-lease`.
+3. Push the branch to the remote. On the first publication push, use a
+   normal push. If you are recovering an already-published branch under
+   an explicit force-push exception, use `--force-with-lease` only when
+   repository policy permits it and the exceptional route already
+   required a rebase; otherwise stop and return to the merge-based sync
+   path.
+
+Once the branch is pushed, treat it as published review history. A PR
+that is merely `BEHIND` does not force a branch update by itself unless
+branch protection or explicit repository policy requires an up-to-date
+head before merge.
 
 ## D3 — Create PR
 

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -1,8 +1,8 @@
 # IDD — Pre-Merge Conditions Phase (F1–F2)
 
-Read this file after ReviewItems_snapshot is empty (E3 or E8), or when
-returning to merge gate checks after a fix cycle. It covers final
-conflict resolution
+Read this file after the E-phase branch-sync check confirms no
+synchronization is required, or when returning to merge gate checks
+after a sync cycle. It covers a final read-only branch-state check
 (F1) and the full pre-merge condition checklist (F2).
 
 This phase includes a repository-specific GitHub Copilot advisory review
@@ -25,30 +25,32 @@ claim ownership, advisory wait, or CI gates.
 When all F2 conditions are satisfied, proceed to
 `idd-merge-handoff.instructions.md`.
 
-## F1 — Final conflict resolution
+## F1 — Final branch-state check
 
-Check whether the PR branch is out of date with `main` by running:
+Read the current branch state. When helper runtime is enabled, call:
+`idd-branch-conflict-state --pr {pr-number}`
+
+Otherwise read the state directly:
 
 ```sh
 gh pr view {pr-number} --json mergeable,mergeStateStatus
 ```
 
-If `mergeable` is `CONFLICTING` or `mergeStateStatus` is `BEHIND` or
-`DIRTY`, resolve conflicts:
+This check is read-only — F1 does not rebase, merge, or push.
 
-1. **Active review gate**: if the PR has unresolved review threads,
-   unreplied comments, or any reviewer's latest state is
-   `CHANGES_REQUESTED`, get explicit operator confirmation before
-   rebasing, as the history rewrite can disrupt ongoing review.
-2. Rebase onto `main`. Resolve any conflicts and continue the rebase.
-3. Run **post-fix-validate**.
-
-4. Push (use `--force-with-lease` if you rebased).
-5. If the HEAD changed (new commits were added): return to
-   `idd-review-snapshot.instructions.md` (E1) to re-evaluate reviews.
-   Before returning, update the PR live status digest with
-   `Phase: F1 rebased`, the new HEAD in `Authoritative by`, and
-   `Next action: E1 review snapshot`.
+- **`clean`** (`mergeable` is `MERGEABLE` and `mergeStateStatus` is
+  `CLEAN`) or **`behind-no-conflict`** when no up-to-date-head policy
+  applies: proceed to F2.
+- **`behind-no-conflict`** when branch protection or recorded repository
+  policy requires an up-to-date head, or **`content-conflict`**
+  (`mergeable` is `CONFLICTING`): return to the E-phase branch-sync check
+  in `idd-review-triage.instructions.md`. Before returning, update the PR
+  live status digest with `Phase: F1 sync-required`, the branch state in
+  `Open blockers`, and `Next action: E-phase branch-sync`.
+- **`dirty`** (`mergeStateStatus` is `DIRTY`) or **`unknown`**: hold; post
+  a PR comment documenting the branch state and stop. Do not proceed to F2
+  without confirmed clean branch-state evidence. A maintainer must clear
+  the hold.
 
 ## F2 — Pre-merge condition check
 
@@ -169,14 +171,38 @@ must align with every F2 condition below.
 - **CI**: Current PR head SHA has all required CI checks generated and
   all passing (→ run CI wait per `idd-ci.instructions.md` using the
   same resolved `ciWait.runningTimeout`, `ciWait.generationTimeout`, and
-  `ciWait.rerunPolicy` values; on-success → re-evaluate F2)
+  `ciWait.rerunPolicy` values; on-success → re-evaluate F2).
+
+  **External-check waivers**: When `pre-merge-readiness` reports a check
+  as `coveredByWaiver: true` in its output, a trusted maintainer has
+  authorized skipping that specific check under the current head SHA and
+  active claim. Treat it as passing for F2/F3 routing **only when**:
+  - `waiverEvidence.valid` is non-empty for that check's selector
+  - The waiver actor is a trusted marker login
+  - The waiver `headSha` matches the current PR HEAD
+  - The waiver `claimId` matches the active claim
+  - The waiver `expiresAt` is in the future
+
+  Waivers never bypass review currency, advisory wait, unresolved
+  threads, unreplied comments, required reviews, disposition evidence,
+  or claim ownership. If `waiverEvidence.wrongHead`, `wrongClaim`,
+  `unauthorized`, `expired`, or `malformed` are non-empty, report them
+  as suspicious context and do not treat them as valid permissions.
 - **Required reviews**: Required approvals count is satisfied and all
-  CODEOWNER approvals are obtained. If approvals are absent but there
-  are no open actionable review items (ReviewItems_snapshot is empty), do **not**
-  route to E1 — instead, request CODEOWNER/required reviewers directly
-  (if not already requested), post a hold comment, and stop. Return to
-  E1 only when there are actual review threads or comments to address (→
-  go to `idd-review-snapshot.instructions.md` only in that case).
+  CODEOWNER approvals are obtained. If helper evidence includes
+  `reviewerStates.codeownerSelfApproval`, include that diagnostic in the
+  F2 evidence and any hold comment when its `status` is `deadlock` or
+  `possible_deadlock`. `deadlock` means the current PR/ruleset/CODEOWNER
+  topology cannot be satisfied by ordinary self-approval; `possible_deadlock`
+  means the helper could not prove an eligible non-author CODEOWNER or
+  applicable pull-request bypass, so fail closed. This diagnostic is
+  evidence only and never permission to bypass the Required reviews
+  gate. If approvals are absent but there are no open actionable review
+  items (ReviewItems_snapshot is empty), do **not** route to E1 —
+  instead, request CODEOWNER/required reviewers directly (if not already
+  requested), post a hold comment, and stop. Return to E1 only when
+  there are actual review threads or comments to address (→ go to
+  `idd-review-snapshot.instructions.md` only in that case).
 - **No `CHANGES_REQUESTED`** (human/required/CODEOWNER reviewers only):
   No human, required, or CODEOWNER reviewer's latest state is
   `CHANGES_REQUESTED` (→ if not yet addressed, return to review triage;

--- a/.github/instructions/idd-resume.instructions.md
+++ b/.github/instructions/idd-resume.instructions.md
@@ -128,7 +128,7 @@ Section numbers §W1–§W8 are detail entries in `docs/idd-resume-detail.md`.
 
 After routing, refresh the digest only when the route materially changes what
 a human should expect next (e.g., `Phase: resume → B3`, `Phase: resume → D1`,
-`Phase: resume → F1`). Set `Authoritative by` to the claim, PR/branch, CI,
+`Phase: resume → F2`). Set `Authoritative by` to the claim, PR/branch, CI,
 and review evidence used for the routing decision.
 
 ## Step 3 — Determine PR and CI/review state
@@ -142,7 +142,7 @@ node scripts/resume-route-selection.mjs --issue {issue-number}
 
 Map helper `route` to the Step 3 table outcomes:
 
-- `D1`, `D4`, `E1`, `E15`, `F1`, `F2` → matching row outcome.
+- `D1`, `D4`, `E1`, `E15`, `Esync`, `F1`, `F2` → matching row outcome.
 - `stop` → stop and report the helper reason; do not mutate state.
 
 Before any mutation after helper-assisted routing, still re-check live
@@ -159,7 +159,10 @@ output is invalid, use the written table below directly.
 | `failure` / `cancelled` / `timed_out` | no reviews                                                           | D4 failure/cancelled branch                        |
 | `failure` / `cancelled` / `timed_out` | reviews exist                                                        | E15 failure/cancelled branch                       |
 | `success`                             | unresolved threads / unreplied comments / active `CHANGES_REQUESTED` | → E1                                               |
-| `success`                             | none of the above                                                    | → F1                                               |
+| `success`                             | none of the above; branch clean                                      | → F2                                               |
+| `success`                             | none of the above; branch behind (no content conflict)               | → F1 (policy check, then F2 or Esync)              |
+| `success`                             | none of the above; branch has content conflict                       | → Esync (E-phase branch-sync check)                |
+| `success`                             | none of the above; branch dirty or unknown state                     | → hold/stop                                        |
 
 For forced-handoff recovery on an open PR: treat the final `success` row as
 → E1 until the successor has posted its own same-claim review watermark and

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -54,19 +54,22 @@ Convergence guardrails:
 ## E11 — Resolve conflicts with main
 
 Check for conflicts between the feature branch and `main`. If conflicts
-exist, rebase the feature branch onto `main`, resolve any conflicts, and
-continue the rebase.
+exist, merge `main` into the feature branch
+(`git fetch origin main && git merge origin/main`), resolve any
+conflicts, and complete the merge.
 
 **Active review gate**: if the PR has unresolved review threads,
 unreplied comments, or any reviewer's latest state is
-`CHANGES_REQUESTED`, get explicit operator confirmation before rebasing,
-as the history rewrite can disrupt ongoing review.
+`CHANGES_REQUESTED`, get explicit operator confirmation before merging
+`main` into the feature branch, as the merge commit will appear in the
+PR history.
 
 ## E12 — Lint, test, push
 
 Run **post-fix-validate**.
 
-Then push with `--force-with-lease` (E11 uses rebase).
+Then push the feature branch normally (E11 uses merge commits, not
+rebase, so no force push is required).
 
 ## E13 — Reply to feedback
 

--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -8,7 +8,8 @@ Before posting any E-phase operational comment or GitHub reply, apply
 the shared claim revalidation gate. The active claim must still use your
 current `{claim-id}`.
 
-**If ReviewItems_snapshot is empty after E3**: proceed to `idd-pre-merge.instructions.md`.
+**If ReviewItems_snapshot is empty after E3**: proceed to the
+E-phase branch-sync check in `idd-review-triage.instructions.md`.
 **If ReviewItems_snapshot is non-empty after E3**: proceed to
 `idd-review-triage.instructions.md` (E4).
 
@@ -186,6 +187,7 @@ comment token; use the HTTP `POST` path for reliability).
 
 ## E3 — Empty list check
 
-If ReviewItems_snapshot is empty → proceed to `idd-pre-merge.instructions.md`.
+If ReviewItems_snapshot is empty → proceed to the E-phase branch-sync
+check in `idd-review-triage.instructions.md`.
 
 Otherwise → proceed to `idd-review-triage.instructions.md` (E4).

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -9,7 +9,7 @@ the shared claim revalidation gate. The active claim must still use your
 current `{claim-id}`.
 
 **Skip condition E8**: if the Accepted PATH A count after verification
-is zero, proceed to `idd-pre-merge.instructions.md`.
+is zero, proceed to the **E-phase branch-sync check** below.
 
 ## E4 — Classify and score ReviewItems_snapshot
 
@@ -232,10 +232,55 @@ return to E1 afterward.
 
 ## E8 — Accepted PATH A count check
 
-If the Accepted PATH A count is zero → proceed to
-`idd-pre-merge.instructions.md`.
+If the Accepted PATH A count is zero → proceed to the
+**E-phase branch-sync check** below.
 
 Otherwise continue to `idd-review-fix.instructions.md`.
+
+## E-phase branch-sync check
+
+After the review loop confirms no PATH A items remain (from E3 or E8),
+check the current branch state before routing to F-phase. This gate uses
+merge-from-`main` (never rebase) when synchronization is required,
+preserving review history on the already-published PR branch.
+
+When helper runtime is enabled, call:
+`idd-branch-conflict-state --pr {pr-number}`
+
+Otherwise read branch state directly:
+
+```sh
+gh pr view {pr-number} --json mergeable,mergeStateStatus
+```
+
+Route based on `branchState` from the helper (or `mergeable` /
+`mergeStateStatus` from `gh pr view`):
+
+- **`clean`** or **`behind-no-conflict`** when branch protection does not
+  require an up-to-date head: proceed to
+  `idd-pre-merge.instructions.md` (F1).
+- **`behind-no-conflict`** when branch protection or recorded repository
+  policy requires an up-to-date head: → **sync path** below.
+- **`content-conflict`** (`mergeable` is `CONFLICTING`): → **sync path**
+  below.
+- **`dirty`** (`mergeStateStatus` is `DIRTY`) or **`unknown`**: hold; post
+  a PR comment documenting the state and stop. Do not proceed to F-phase
+  without confirmed branch-state evidence.
+
+**Sync path** (merge-from-`main`):
+
+1. **Active review gate**: if the PR has unresolved review threads,
+   unreplied comments, or any reviewer's latest state is
+   `CHANGES_REQUESTED`, get explicit operator confirmation before merging
+   `main` into the feature branch, as the merge commit will appear in the
+   PR history.
+2. Merge `main` into the feature branch:
+   `git fetch origin main && git merge origin/main`
+3. If conflicts arise, resolve them and complete the merge.
+4. Run **post-fix-validate**.
+5. Push the feature branch normally (no force push required for merge
+   commits).
+6. Return to `idd-review-snapshot.instructions.md` (E1).
 
 ## Review item classes
 

--- a/.github/instructions/idd-roadmap-audit.instructions.md
+++ b/.github/instructions/idd-roadmap-audit.instructions.md
@@ -30,12 +30,25 @@ a specific autonomous gap before creating a follow-up issue; use those
 results only to link existing gap work or avoid creating a duplicate,
 not to widen A2 candidates.
 
+When the selected roadmap graph includes descendant issues that are
+themselves roadmap nodes, such as descendants carrying the `roadmap`
+label or a `qorrection-roadmap-id` marker, treat those
+descendants as **nested roadmaps** rather than as normal execution
+leaves. A nested roadmap is a coordination/audit node in the recursive
+hierarchy: it may remain open while its own leaf descendants are still
+executing, and its presence does not by itself widen A2 candidates
+outside the selected roadmap graph.
+
 - If the roadmap itself has `status:blocked-by-human` or
   `status:needs-decision`, report the blocker and stop before A2. Do
   not continue selecting child issues under a blocked roadmap.
 - If any referenced child or descendant issue is open, inaccessible, or
   unresolved, report the provenance path and reason, then continue to
-  A2.
+  A2, unless the open descendant is a nested roadmap with at least one
+  reachable leaf descendant and all of those reachable leaf descendants
+  are closed or otherwise complete. In that special case, treat the
+  nested roadmap as the next completion target and continue applying
+  the bottom-up rules below before routing to A2.
 - If any referenced child or descendant has an open linked or closing
   PR that is not merged or otherwise obsolete, treat that child work as
   unresolved, report the PR, and continue to A2.
@@ -45,6 +58,28 @@ not to widen A2 candidates.
   ready-to-start rules. Do not treat stale blocker labels on closed
   children as audit blockers when their referenced descendants are
   resolved.
+- If an open leaf issue sits under an open nested roadmap, treat the
+  nested roadmap and every ancestor roadmap on that provenance path as
+  unresolved. Report the deepest blocking path and continue to A2.
+- If a nested roadmap has no reachable leaf descendants after
+  traversal, treat it as childless or malformed and continue to A2. Do
+  not treat an empty reachable-leaf set as proof of completion.
+- If a nested roadmap remains open after at least one reachable leaf
+  descendant exists and all reachable leaf descendants are closed or
+  otherwise complete, treat that nested roadmap as the **next
+  completion target**. Do not close its parent first. Re-evaluate the
+  graph bottom-up so the deepest completed nested roadmap is audited and
+  closed before its parent roadmap is considered complete.
+- If a nested roadmap appears closed but still has an open, inaccessible,
+  or otherwise unresolved descendant, treat that descendant as the
+  controlling unresolved state. Report the contradictory provenance path
+  and continue to A2; do not infer parent completion from the nested
+  roadmap's closed state alone.
+- If traversal or helper output reports a cycle or duplicate reference
+  inside the recursive roadmap graph, preserve that evidence and treat
+  the affected path as unresolved until the graph can be interpreted
+  safely. Do not guess at a closure order when the traversal graph is
+  ambiguous.
 - If all referenced child and descendant work is closed or otherwise
   complete, compare the roadmap success criteria against the closed
   child issues, linked merged PRs, task-list state, follow-up comments,
@@ -52,8 +87,10 @@ not to widen A2 candidates.
   completion from checkbox state alone.
 
 A1.5 can publish roadmap-level GitHub side effects before a child task
-issue is selected. Before any such side effect, coordinate on the
-roadmap issue itself:
+issue is selected. In recursive hierarchies, the immediate audit target
+may be the selected roadmap or the deepest completed nested roadmap
+discovered beneath it. Before any such side effect, coordinate on the
+**exact roadmap issue being mutated**:
 
 Treat `stale` and `non-stale` in this section using the
 `claim-stale-age` policy default from `docs/policy-constants.md`
@@ -79,6 +116,10 @@ Treat `stale` and `non-stale` in this section using the
   coordination name, not a work branch, and it does not require
   creating a branch or worktree unless the audit also needs git
   changes.
+- In recursive hierarchies, do not reuse one roadmap-audit claim across
+  parent, child, or sibling roadmap mutations. Each roadmap comment,
+  follow-up issue link, body edit, label change, or close action must
+  be scoped to the roadmap issue being mutated at that moment.
 - If the active roadmap claim already uses this current session's
   previously recorded and verified `{claim-id}`, continue with that same
   claim and do not post a new claim.
@@ -99,9 +140,13 @@ input still matches the evidence.
 Apply one outcome:
 
 - **Audit passes**: post an `IDD roadmap completion audit` comment with
-  a concise evidence summary, then close the roadmap. No child task
-  issue is claimed. Return to `idd-discover.instructions.md` (A1) and
-  select the next open roadmap, if any.
+  a concise evidence summary, then close the roadmap. In recursive
+  hierarchies, this outcome applies only when the selected roadmap is
+  the deepest remaining open roadmap on its path whose descendants are
+  all complete. After closing a nested roadmap, release that
+  roadmap-audit claim, re-fetch the ancestor graph, and return to
+  `idd-discover.instructions.md` (A1) so the parent roadmap can be
+  re-evaluated from fresh state. No child task issue is claimed.
 - **Autonomous gaps found**: create or link follow-up issues using the
   repository's issue-authoring rules, update the roadmap task list with
   those links, and continue to A2 so the new work can be discovered.


### PR DESCRIPTION
## Summary

Re-sync the 8 IDD instruction files that upstream `kurone-kito/idd-skill@80e7295` touched since qorrection's previous re-import (2026-05-14, #108). The remaining 11 instruction files were already in sync. Also add `esync` to the cspell allowlist for the new `Esync` (E-phase branch-sync check) routing state.

## What landed upstream (folded in here)

- **`idd-discover.instructions.md`** (+139/-87): new `Authoring label guard` section gating A0-T / A0-O / A3 against the `status:authoring` label; stale-authoring warning path.
- **`idd-pr-submit.instructions.md`** (+30/-12): refinements to D-phase claim revalidation and rebase ordering.
- **`idd-pre-merge.instructions.md`** (+60/-20): F-phase external-check waiver consumption; new F2 evidence rows.
- **`idd-resume.instructions.md`** (+5/-4): branch-state routing alignment, references the new `Esync` state.
- **`idd-review-fix.instructions.md`** (+8/-5): tightened claim/advisory revalidation.
- **`idd-review-snapshot.instructions.md`** (+3/-3): minor wording.
- **`idd-review-triage.instructions.md`** (+45/-6): expanded PATH B / disposition rules.
- **`idd-roadmap-audit.instructions.md`** (+50/-7): roadmap-audit refinements.

## Substitutions applied

Per `.github/idd/config.json`:

| Placeholder | Value |
|---|---|
| `{{PROJECT_MARKER_PREFIX}}`, `{{REPO_NAME}}` | `qorrection` |
| `{{INSTALL_DEPS_COMMAND}}` | `true` |
| `{{FIX_VALIDATE_COMMANDS}}` | `cargo fmt && cargo clippy --all-targets -- -D warnings` |
| `{{PRE_PUSH_VALIDATE_COMMANDS}}`, `{{POST_FIX_VALIDATE_COMMANDS}}` | the pre-push triple (fmt --check + clippy + test) |

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all-targets --all-features`
- [x] `markdownlint-cli2 .github/instructions/idd-*.instructions.md` — 0 errors
- [x] `cspell` — 0 issues after `esync` allowlist update
- [x] No unsubstituted `{{...}}` placeholders remain
- [x] Frontmatter (`applyTo: "**"`, `excludeAgent: "code-review"`) preserved on `idd-overview.instructions.md` and `idd-overview-core.instructions.md`
- [x] Helper-script references remain conditional ("When helper runtime is enabled" / "In the idd-skill source repository, …"), not mandates
- [ ] CI matrix runs on push — Rust untouched, expected pass

## C-phase observations (per ops C-phase rigor guidance)

- 8 files updated, 11 unchanged — verified by per-file `cmp` against substituted upstream.
- No `node scripts/...` references promoted from optional to mandatory; the `helperRuntime: instructions-only` profile remains the default path.
- Cross-references to `docs/idd-*.md` and `.claude/skills/issue-authoring/` files still resolve (those docs/skills land in #170 and #171; if upstream's wording references content that only appears after those merge, the reference still resolves at the file-path level).
- **Discovery bundle byte total now 75951** (+751 over upstream's `bundle-discovery: 75200` limit). qorrection does not import `audit/sync-manifest.json`, so this isn't CI-enforced locally; flagged for the next re-import that brings in the manifest.

Closes #169. Part of roadmap #168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined issue discovery and authoring protection procedures
  * Enhanced PR submission and synchronization workflow steps
  * Updated pre-merge validation and branch-state handling
  * Improved roadmap auditing for nested roadmap scenarios
  * Refined review routing and sync decision logic

* **Chores**
  * Added spell-check dictionary entry

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/qorrection/pull/174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->